### PR TITLE
Bug fix for auto-mount on glusterfs.

### DIFF
--- a/docs/deployment/Storage/GlusterFS.md
+++ b/docs/deployment/Storage/GlusterFS.md
@@ -52,9 +52,12 @@ The document describes the procedure to setup glusterFS across a cluster. Gluste
   deploy.py kubernetes labels
   ```
   
-6. Start glusterFS daemon set and mount volumes 
+6. Start glusterFS daemon set and mount volumes.
+  First time, you should use the follows to bootstrap the cluster. 
   ```
   deploy.py --glusterfs start kubernetes start glusterfs
+  [Wait about 30 seconds]
+  deploy.py kubernetes stop glusterfs
   ```
   The second time around, glusterFS daemon set can be started with 
   ```
@@ -64,6 +67,8 @@ The document describes the procedure to setup glusterFS across a cluster. Gluste
   You may use:
   ```
   deploy.py --glusterfs format kubernetes start glusterfs
+  [Wait about 30 seconds]
+  deploy.py kubernetes stop glusterfs
   ```
   to remove any wrongly created volume in glusterfs, and recreate the volume. Please caution that this command will erasure all data on the glusterfs volume. Please use with care. 
   
@@ -80,3 +85,4 @@ The document describes the procedure to setup glusterFS across a cluster. Gluste
 9. Trouble shooting:
    You may log onto a node deployed with glusterfs, and check its operating log at: /var/log/glusterfs.
    The launch log is available at /var/log/glusterfs/launch/launch.log
+   Check on commonly observed issue of glusterfs [here](GlusterFS_FAQ.md).

--- a/docs/deployment/Storage/GlusterFS_FAQ.md
+++ b/docs/deployment/Storage/GlusterFS_FAQ.md
@@ -1,0 +1,33 @@
+# Frequently asked questions (FAQ) on GlustserFS deployment. 
+
+* Glusterd fail to start. 
+
+    * Checking log of tail -n 100 /var/log/glusterfs/etc-glusterfs-glusterd.vol.log
+        with failure: "0-socket.management: binding to  failed: Address already in use"
+      
+      You may have start a glusterfs pod before the prior glusterfs pod is shutdown. The port used by glusterd is still occupied, so that it can't be used for the new pod. Please make sure that you shutdown the glusterfs service via:
+      ```
+      ./deploy.py kubernetes stop glusterfs
+      ```
+      check and make sure all glusterfs pods have been shotdown:
+      ```
+      ./deploy.py kubectl get pods
+      ```
+      before launch a new glusterfs service. 
+
+* Volume fail to start
+    Check log of tail -n 100 /var/log/glusterfs/launch/launch.log, we have failure "Commit failed on localhost. Please check log file for details."
+
+    Sometime, when you are formatting the volume, it is put in a bad state. Please do follows:
+    
+    1. go to one of the glusterfs node, and do a force volume start. 
+      ```
+      gluster volume start [VOLUME_NAME] force
+      ```
+    2. Shutdown glusterfs pod 
+    3. Restart the pod to resume operation. 
+    
+
+      
+
+  

--- a/src/ClusterBootstrap/deploy.py
+++ b/src/ClusterBootstrap/deploy.py
@@ -2298,6 +2298,7 @@ def mount_fileshares_by_service(perform_mount=True):
 			utils.sudo_scp( config["ssh_cert"], "./deploy/storage/auto_share/auto_share.service","/etc/systemd/system/auto_share.service", config["admin_username"], node )
 			utils.sudo_scp( config["ssh_cert"], "./deploy/storage/auto_share/logging.yaml",os.path.join(config["folder_auto_share"], "logging.yaml"), config["admin_username"], node )
 			utils.sudo_scp( config["ssh_cert"], "./deploy/storage/auto_share/auto_share.py",os.path.join(config["folder_auto_share"], "auto_share.py"), config["admin_username"], node )
+			utils.sudo_scp( config["ssh_cert"], "./template/storage/auto_share/glusterfs.mount",os.path.join(config["folder_auto_share"], "glusterfs.mount"), config["admin_username"], node )
 			utils.sudo_scp( config["ssh_cert"], "./deploy/storage/auto_share/mounting.yaml",os.path.join(config["folder_auto_share"], "mounting.yaml"), config["admin_username"], node )
 			remotecmd += "sudo chmod +x %s; " % os.path.join(config["folder_auto_share"], "auto_share.py")
 			remotecmd += "sudo " + os.path.join(config["folder_auto_share"], "auto_share.py") + "; " # run it once now

--- a/src/ClusterBootstrap/template/storage/auto_share/glusterfs.mount
+++ b/src/ClusterBootstrap/template/storage/auto_share/glusterfs.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=Mount GlusterFS volume automatically  
+After=docker.service
+
+
+[Mount]
+What={{cnf["node"]}}:{{cnf["filesharename"]}}
+Where={{cnf["physicalmountpoint"]}}
+Type=glusterfs
+Options={{cnf["options"]}}
+


### PR DESCRIPTION
Add option to use systemd mount service for glusterfs. The path hasn't been enabled. However, the presence of the additional configuration may insert a little time between umount and mount -t glusterfs. Otherwise, mount -t glusterfs fails in auto_share (but will succeed if the command is typed in CLI).