### PR TITLE
Use in cluster client

### DIFF
--- a/src/ClusterBootstrap/template/kube-addons/dns-addon.yml
+++ b/src/ClusterBootstrap/template/kube-addons/dns-addon.yml
@@ -75,7 +75,6 @@ spec:
         args:
         - --domain=cluster.local.
         - --dns-port=10053
-        - --kubecfg-file=/etc/kubernetes/worker-kubeconfig.yaml
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: ssl-certs-kubernetes


### PR DESCRIPTION
There's no need to use `kubecfg-file=/etc/kubernetes/worker-kubeconfig.yaml` if your kube-dns is running with a Pod inside Kubernetes cluster.

It can automatically use a in cluster client with token automatically mounted inside the Pod to query kube-apiserver.

It can fix a lot of kube-dns problem like can't access kube-apiserver etc.