### PR TITLE
Update kubeconfig template to latest version

### DIFF
--- a/src/ClusterBootstrap/template/kubeconfig/kubeconfig.yaml.template
+++ b/src/ClusterBootstrap/template/kubeconfig/kubeconfig.yaml.template
@@ -3,13 +3,13 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    certificate-authority: ./ssl/ca/ca.pem
+    certificate-authority: ../ssl/ca/ca.pem
     server: {{cnf["api_servers"]}}
 users:
 - name: kubelet
   user:
-    client-certificate: ./ssl/kubelet/apiserver.pem
-    client-key: ./ssl/kubelet/apiserver-key.pem
+    client-certificate: ../ssl/kubelet/apiserver.pem
+    client-key: ../ssl/kubelet/apiserver-key.pem
 contexts:
 - context:
     cluster: local


### PR DESCRIPTION
Update kubeconfig template to latest version, the path has been changed to `deploy/kubeconfig/kubeconfig.yaml` instead of `deploy/kubeconfig.yaml`