### PR TITLE
Chanage default rootshare directory to '/data/share'.

### DIFF
--- a/src/ClusterBootstrap/az_tools.py
+++ b/src/ClusterBootstrap/az_tools.py
@@ -426,10 +426,10 @@ def create_cluster(arm_vm_password=None):
         create_vm_param(0, False, True, config["azure_cluster"]["infra_vm_size"],
                         True, arm_vm_password)
     for i in range(int(config["azure_cluster"]["infra_node_num"])):
-        create_vm_param(i, False, False, config["azure_cluster"]["infra_vm_size"], 
+        create_vm_param(i, False, False, config["azure_cluster"]["infra_vm_size"],
                         arm_vm_password is not None, arm_vm_password)
     for i in range(int(config["azure_cluster"]["worker_node_num"])):
-        create_vm_param(i, True, False, config["azure_cluster"]["worker_vm_size"], 
+        create_vm_param(i, True, False, config["azure_cluster"]["worker_vm_size"],
                         arm_vm_password is not None, arm_vm_password)
 
 
@@ -697,7 +697,7 @@ def gen_cluster_config(output_file_name, output_file=True, no_az=False):
         else:
             cc["mountpoints"]["rootshare"]["type"] = "nfs"
             cc["mountpoints"]["rootshare"]["server"] = get_vm_ip(0, False, False)
-            cc["mountpoints"]["rootshare"]["filesharename"] = "/mnt/share"
+            cc["mountpoints"]["rootshare"]["filesharename"] = "/data/share"
             cc["mountpoints"]["rootshare"][
                 "curphysicalmountpoint"] = "/mntdlws/nfs"
             cc["mountpoints"]["rootshare"]["mountpoints"] = ""
@@ -817,13 +817,13 @@ Prerequest:
 * Create config.yaml according to instruction in docs/deployment/azure/configure.md.
 
 Command:
-  create Create an Azure VM cluster based on the parameters in config file. 
-  delete Delete the Azure VM cluster. 
-  scaleup Scale up operation. 
-  scaledown shutdown a particular VM. 
+  create Create an Azure VM cluster based on the parameters in config file.
+  delete Delete the Azure VM cluster.
+  scaleup Scale up operation.
+  scaledown shutdown a particular VM.
   list list VMs.
   interconnect create network links among VMs
-  genconfig Generate configuration files for Azure VM cluster. 
+  genconfig Generate configuration files for Azure VM cluster.
   ''') )
     parser.add_argument("--cluster_name",
                         help="Specify a cluster name",


### PR DESCRIPTION
On Azure, we mount managed disk under /data, change the default rootshare directory so the share directory will go to managed disk in default.