### PR TITLE
add alert manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ src/WebUI/dotnet/WebPortal/hosting.json
 cluster-autoscaler
 src/ClusterBootstrap/services/monitor/grafana-config.yaml
 src/ClusterBootstrap/services/monitor/prometheus-alerting.yaml
+src/ClusterBootstrap/services/monitor/alert-templates.yaml

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -88,6 +88,7 @@ default_config_parameters = {
         ".swf": True,
         ".gzip": True,
         ".rules": True,
+        ".tmpl": True,
     },
     "render-by-copy": {
         # The following file will be copied (not rendered for configuration)
@@ -102,6 +103,7 @@ default_config_parameters = {
         "collectd.influxdb.conf.tpl": True,
         "collectd.riemann.conf.tpl": True,
         "prometheus-alerting.yaml": True,
+        "alert-templates.yaml": True,
         # "nginx": True,
         "RecogServer": True,
         

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -24,6 +24,13 @@ default_config_parameters = {
     "node-exporter": { "port": 9100 },
     "watchdog": { "port": 9101 },
     "grafana": { "port": 3000 },
+    "alert-manager": {
+        "port": 9093,
+        "configured": False
+        # If want to deploy with alert-manager, should config
+        # configured with True, and fill appropriate value to:
+        # smtp_url, smtp_from, smtp_auth_username, smtp_auth_password and receiver
+    },
 
     "mysql_port": "3306",
     "mysql_username": "root",
@@ -207,6 +214,7 @@ default_config_parameters = {
         "FragmentGPUJob": "all",
         "grafana": "etcd_node_1",
         "prometheus": "etcd_node_1",
+        "alert-manager": "etcd_node_1",
         "watchdog": "etcd_node_1",
         "elasticsearch": "etcd_node_1",
         "kibana": "etcd_node_1",

--- a/src/ClusterBootstrap/services/monitor/alert-manager.yaml
+++ b/src/ClusterBootstrap/services/monitor/alert-manager.yaml
@@ -1,0 +1,82 @@
+{% if cnf["alert-manager"]["configured"] %}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alert-manager
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alert-manager
+  template:
+    metadata:
+      name: alert-manager
+      labels:
+        app: alert-manager
+      annotations:
+        prometheus.io/alert: "true"
+        prometheus.io/port: "{{ cnf['alert-manager']['port'] }}"
+    spec:
+      nodeSelector:
+        alert-manager: active
+      hostNetwork: true
+      containers:
+      - name: alert-manager
+        image: prom/alertmanager:v0.15.1
+        args:
+          - '--config.file=/etc/alertmanager/config.yml'
+          - '--storage.path=/alertmanager'
+          - '--web.external-url={{ cnf["api-server-ip"] }}/alert-manager/'
+          - '--web.route-prefix=alert-manager'
+        ports:
+        - name: alert-manager
+          containerPort: {{ cnf["alert-manager"]["port"] }}
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/alertmanager
+        - name: storage
+          mountPath: /alertmanager
+      volumes:
+      - name: config-volume
+        configMap:
+          name: alert-manager
+      - name: storage
+        emptyDir: {}
+      tolerations:
+      - key: node.kubernetes.io/memory-pressure
+        operator: "Exists"
+      - key: node.kubernetes.io/disk-pressure
+        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+---
+{% endif %}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: alert-manager
+  namespace: kube-system
+data:
+  config.yml: |-
+{% if cnf["alert-manager"]["configured"] %}
+{% set alert_info = cnf["alert-manager"] %}
+    global:
+      resolve_timeout: 5m
+      smtp_smarthost: {{ alert_info["smtp_url"] }}
+      smtp_from: {{ alert_info["smtp_from"] }}
+      smtp_auth_username: {{ alert_info["smtp_auth_username"] }}
+      smtp_auth_password: {{ alert_info["smtp_auth_password"] }}
+    route:
+      receiver: alert-email
+      group_wait: 30s
+      group_interval: 5m
+      group_by: [alertname]
+    receivers:
+    - name: "alert-email"
+      email_configs:
+        - to: {{ alert_info["receiver"] }}
+          headers:
+            subject: '{{ cnf["cluster_name"] }}: {{ "{{" }} template "__subject" . {{ "}}" }}'
+{% endif %}

--- a/src/ClusterBootstrap/services/monitor/alert-manager.yaml
+++ b/src/ClusterBootstrap/services/monitor/alert-manager.yaml
@@ -28,7 +28,7 @@ spec:
         args:
           - '--config.file=/etc/alertmanager/config.yml'
           - '--storage.path=/alertmanager'
-          - '--web.external-url={{ cnf["api-server-ip"] }}/alert-manager/'
+          - '--web.external-url=http://localhost/alert-manager/'
           - '--web.route-prefix=alert-manager'
         ports:
         - name: alert-manager
@@ -38,10 +38,15 @@ spec:
           mountPath: /etc/alertmanager
         - name: storage
           mountPath: /alertmanager
+        - name: templates-volume
+          mountPath: /etc/alertmanager/template
       volumes:
       - name: config-volume
         configMap:
           name: alert-manager
+      - name: templates-volume
+        configMap:
+          name: alert-templates
       - name: storage
         emptyDir: {}
       tolerations:
@@ -68,6 +73,8 @@ data:
       smtp_from: {{ alert_info["smtp_from"] }}
       smtp_auth_username: {{ alert_info["smtp_auth_username"] }}
       smtp_auth_password: {{ alert_info["smtp_auth_password"] }}
+    templates:
+    - "/etc/alertmanager/template/*.tmpl"
     route:
       receiver: alert-email
       group_wait: 30s
@@ -77,6 +84,7 @@ data:
     - name: "alert-email"
       email_configs:
         - to: {{ alert_info["receiver"] }}
+          html: '{{ "{{" }} template "email.html" . {{ "}}" }}'
           headers:
             subject: '{{ cnf["cluster_name"] }}: {{ "{{" }} template "__subject" . {{ "}}" }}'
 {% endif %}

--- a/src/ClusterBootstrap/services/monitor/alert-templates/email.tmpl
+++ b/src/ClusterBootstrap/services/monitor/alert-templates/email.tmpl
@@ -1,0 +1,128 @@
+{{ define "email.html" }}
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+Style and HTML derived from https://github.com/mailgun/transactional-email-templates
+
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Mailgun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<head>
+<meta name="viewport" content="width=device-width"/>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+<title>{{ template "__subject" . }}</title>
+
+</head>
+
+<body itemscope="" itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; height: 100%; line-height: 1.6em; width: 100% !important; background-color: #f6f6f6; margin: 0; padding: 0;" bgcolor="#f6f6f6">
+
+<table style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+  <tr>
+    <td valign="top"></td>
+    <td width="600" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; display: block !important; max-width: 600px !important; clear: both !important; width: 100% !important; margin: 0 auto; padding: 0;" valign="top">
+      <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; max-width: 600px; display: block; margin: 0 auto; padding: 0;">
+        <table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; border-radius: 3px; background-color: #fff; margin: 0; border: 1px solid #e9e9e9;" bgcolor="#fff">
+          <tr>
+            {{ if gt (len .Alerts.Firing) 0 }}
+            <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; vertical-align: top; color: #fff; font-weight: 500; text-align: center; border-radius: 3px 3px 0 0; background-color: #E6522C; margin: 0; padding: 20px;" align="center" bgcolor="#E6522C" valign="top">
+            {{ else }}
+            <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; vertical-align: top; color: #fff; font-weight: 500; text-align: center; border-radius: 3px 3px 0 0; background-color: #2CBE4E; margin: 0; padding: 20px;" align="center" bgcolor="#2CBE4E" valign="top"> <!--changed color-->
+            {{ end }}
+              {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}s{{ end }} for {{ range .GroupLabels.SortedPairs }}
+                {{ .Name }}={{ .Value }}
+              {{ end }}
+            </td>
+          </tr>
+          <tr>
+            <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 10px;" valign="top">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <a href="{{ template "__alertmanagerURL" . }}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">View in {{ template "__alertmanager" . }}</a>
+                  </td>
+                </tr>
+                {{ if gt (len .Alerts.Firing) 0 }}
+                <tr>
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong>[{{ .Alerts.Firing | len }}] Firing</strong>
+                  </td>
+                </tr>
+                {{ end }}
+                {{ range .Alerts.Firing }}
+                <tr>
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    {{ if .Annotations.summary }}
+                        {{ .Annotations.summary }}
+                    {{ else }}
+                        <strong>Labels</strong><br/>
+                        {{ range .Labels.SortedPairs }}{{ .Name }} = {{ .Value }}<br/>{{ end }}
+                        {{ if gt (len .Annotations) 0 }}<strong>Annotations</strong><br/>{{ end }}
+                        {{ range .Annotations.SortedPairs }}{{ .Name }} = {{ .Value }}<br/>{{ end }}
+                    {{ end }}
+                    <a href="{{ .GeneratorURL }}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; color: #348eda; text-decoration: underline; margin: 0;">Source</a><br/>
+                  </td>
+                </tr>
+                {{ end }}
+
+                {{ if gt (len .Alerts.Resolved) 0 }}
+                <tr>
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong>[{{ .Alerts.Resolved | len }}] Resolved</strong>
+                  </td>
+                </tr>
+                {{ end }}
+                {{ range .Alerts.Resolved }}
+                <tr>
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    {{ if .Annotations.summary }}
+                        {{ .Annotations.summary }}
+                    {{ else }}
+                        <strong>Labels</strong><br/>
+                        {{ range .Labels.SortedPairs }}{{ .Name }} = {{ .Value }}<br/>{{ end }}
+                        {{ if gt (len .Annotations) 0 }}<strong>Annotations</strong><br/>{{ end }}
+                        {{ range .Annotations.SortedPairs }}{{ .Name }} = {{ .Value }}<br/>{{ end }}
+                    {{ end }}
+                    <a href="{{ .GeneratorURL }}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; color: #348eda; text-decoration: underline; margin: 0;">Source</a><br/>
+                  </td>
+                </tr>
+                {{ end }}
+              </table>
+            </td>
+          </tr>
+        </table>
+
+        <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; clear: both; color: #999; margin: 0; padding: 20px;">
+          <table width="100%">
+            <tr>
+              <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 12px; vertical-align: top; text-align: center; color: #999; margin: 0; padding: 0 0 20px;" align="center" valign="top"><a href="{{ .ExternalURL }}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">Sent by {{ template "__alertmanager" . }}</a></td>
+            </tr>
+          </table>
+        </div></div>
+    </td>
+    <td valign="top"></td>
+  </tr>
+</table>
+
+</body>
+</html>
+{{ end }}

--- a/src/ClusterBootstrap/services/monitor/launch_order
+++ b/src/ClusterBootstrap/services/monitor/launch_order
@@ -5,4 +5,5 @@ prometheus-alerting.yaml
 prometheus.yaml
 grafana-config.yaml
 grafana.yaml
+alert-templates.yaml
 alert-manager.yaml

--- a/src/ClusterBootstrap/services/monitor/launch_order
+++ b/src/ClusterBootstrap/services/monitor/launch_order
@@ -5,3 +5,4 @@ prometheus-alerting.yaml
 prometheus.yaml
 grafana-config.yaml
 grafana.yaml
+alert-manager.yaml

--- a/src/ClusterBootstrap/services/monitor/pre-render.sh
+++ b/src/ClusterBootstrap/services/monitor/pre-render.sh
@@ -3,11 +3,14 @@
 dir=`dirname $0`
 
 grafana_file_name=${dir}/grafana-config.yaml
+alert_tmpl_file_name=${dir}/alert-templates.yaml
 prometheus_file_name=${dir}/prometheus-alerting.yaml
 
 # create configmap
 for i in `find ${dir}/grafana-config/ -type f -regex ".*json" ` ; do
     echo --from-file=$i
 done | xargs ${dir}/../../deploy/bin/kubectl --namespace=kube-system create configmap grafana-configuration --dry-run -o yaml >> $grafana_file_name
+
+${dir}/../../deploy/bin/kubectl --namespace=kube-system create configmap alert-templates --from-file=${dir}/alert-templates --dry-run -o yaml > $alert_tmpl_file_name
 
 ${dir}/../../deploy/bin/kubectl --namespace=kube-system create configmap prometheus-alert --from-file=${dir}/alerting --dry-run -o yaml >> $prometheus_file_name

--- a/src/ClusterBootstrap/services/monitor/prometheus.yaml
+++ b/src/ClusterBootstrap/services/monitor/prometheus.yaml
@@ -34,6 +34,25 @@ data:
         - source_labels: [__meta_kubernetes_pod_label_app]
           action: replace
           target_label: exporter_name
+    alerting:
+      alertmanagers:
+        - path_prefix: alert-manager
+          tls_config:
+            ca_file: '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+          bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token'
+          kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: ["kube-system"]
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_alert]
+              regex: true
+              action: keep
+            - source_labels: [__meta_kubernetes_pod_host_ip, __meta_kubernetes_pod_annotation_prometheus_io_port]
+              regex: '([^;]+);(\d+)'
+              replacement: ${1}:${2}
+              action: replace
+              target_label: __address__
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
we can deploy with following config to enable alert-manager:

``` yaml
alert-manager:
  configured: True
  smtp_url: smtp.office365.com:587
  smtp_from: xxx@microsoft.com
  smtp_auth_username: xxx@microsoft.com
  smtp_auth_password: xxx
  receiver: yyy@example.com
```

auto-healing can be enabled via [this method](https://static.sched.com/hosted_files/kccncna17/f1/slides.pdf), i.e. leverage webhook of alert-manager to trigger some external process to do something on alerts.