### PR TITLE
add job status and gpu usage dashboard

### DIFF
--- a/src/ClusterBootstrap/services/monitor/grafana-config/gpu-usage-history-dashboard.json
+++ b/src/ClusterBootstrap/services/monitor/grafana-config/gpu-usage-history-dashboard.json
@@ -1,0 +1,164 @@
+{"dashboard": {
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "refresh": "30s",
+  "rows": [
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 0,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(k8s_node_gpu_available)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Available",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(k8s_node_gpu_total)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Total",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(k8s_node_gpu_reserved)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Reserved",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "GPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "GPU Usage",
+  "version": 0
+}}

--- a/src/ClusterBootstrap/services/monitor/grafana-config/job-status-dashboard.json
+++ b/src/ClusterBootstrap/services/monitor/grafana-config/job-status-dashboard.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Dashboard to view service metrics",
+  "description": "Dashboard to view job metrics",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
@@ -58,7 +58,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "service_cpu_percent{name=\"$service_name\"}",
+              "expr": "task_cpu_percent{job_name=\"$job_name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{'{{'}}instance{{'}}'}}",
@@ -134,7 +134,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "service_mem_usage_byte{name=\"$service_name\"}",
+              "expr": "task_mem_usage_byte{job_name=\"$job_name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{'{{'}}instance{{'}}'}}",
@@ -222,7 +222,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "service_net_in_byte{name=\"$service_name\"}",
+              "expr": "task_net_in_byte{job_name=\"$job_name\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -230,7 +230,7 @@
               "refId": "A"
             },
             {
-              "expr": "service_net_out_byte{name=\"$service_name\"}",
+              "expr": "task_net_out_byte{job_name=\"$job_name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{'{{'}}instance{{'}}'}} Outbound",
@@ -306,7 +306,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(service_block_in_byte{name=\"$service_name\"}[300s])",
+              "expr": "irate(task_block_in_byte{job_name=\"$job_name\"}[300s])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -314,7 +314,7 @@
               "refId": "A"
             },
             {
-              "expr": "irate(service_block_out_byte{name=\"$service_name\"}[300s])",
+              "expr": "irate(task_block_out_byte{job_name=\"$job_name\"}[300s])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{'{{'}}instance{{'}}'}} Write",
@@ -364,6 +364,169 @@
       "showTitle": false,
       "title": "Dashboard Row",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "task_gpu_percent{job_name=\"$job_name\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "GPU {{'{{'}}minor_number{{'}}'}} on {{'{{'}}instance{{'}}'}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "GPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "task_gpu_mem_percent{job_name=\"$job_name\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "GPU {{'{{'}}minor_number{{'}}'}} on {{'{{'}}instance{{'}}'}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "GPU Memory Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,
@@ -379,9 +542,9 @@
         "includeAll": false,
         "label": null,
         "multi": false,
-        "name": "service_name",
+        "name": "job_name",
         "options": [],
-        "query": "label_values(service_cpu_percent, name)",
+        "query": "label_values(task_cpu_percent, job_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -424,6 +587,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "Service Status",
+  "title": "Job Status",
   "version": 1
 }}

--- a/src/ClusterBootstrap/services/monitor/grafana-config/job-status-dashboard.json
+++ b/src/ClusterBootstrap/services/monitor/grafana-config/job-status-dashboard.json
@@ -88,7 +88,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": 0,
               "show": true
             },
             {

--- a/src/ClusterBootstrap/services/monitor/grafana-config/service-status-dashboard.json
+++ b/src/ClusterBootstrap/services/monitor/grafana-config/service-status-dashboard.json
@@ -88,7 +88,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": 0,
               "show": true
             },
             {


### PR DESCRIPTION
Add job status and gpu usage dashboard.

Job status dashboard looks like:

![image](https://user-images.githubusercontent.com/665253/58538625-1be7f580-8228-11e9-833d-11933c747d4c.png)

Job uses little resource because it's `sleep infinity` job.

Gpu usage dashboard looks like:

![image](https://user-images.githubusercontent.com/665253/58538708-476ae000-8228-11e9-9510-2c634f8ef61a.png)