### PR TITLE
Multiple fixes for ssh/ipython endpoints

### DIFF
--- a/src/ARM/azuredeploy.json
+++ b/src/ARM/azuredeploy.json
@@ -20,7 +20,7 @@
             "type": "string",
             "metadata": {
                 "description": "Username on machines."
-            }            
+            }
         },
         "adminPassword": {
             "type": "securestring",
@@ -52,7 +52,7 @@
             "type": "string",
             "defaultValue": "Standard_DS2_v2",
             "metadata": {
-                "description": "Size of the infra-VM. Use a CPU VM for infra-VM." 
+                "description": "Size of the infra-VM. Use a CPU VM for infra-VM."
             }
         },
         "numberOfWorkerVM": {
@@ -101,7 +101,7 @@
             "metadata": {
                 "description": "Client Secret of the web application registered with the authentication provider."
             }
-        },        
+        },
         "_artifactsLocation": {
             "type": "string",
             "metadata": {
@@ -467,9 +467,10 @@
                             "destinationPortRanges": [
                                 "80",
                                 "443",
-                                "30000-32767",
+                                "30000-39999",
                                 "25826",
-                                "3080"
+                                "3080",
+                                "40000-49999"
                             ]
                         }
                     },

--- a/src/ClusterBootstrap/acs_tools.py
+++ b/src/ClusterBootstrap/acs_tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/python
 # Tools to build ACS cluster
 
 import sys
@@ -140,7 +140,7 @@ def acs_wait_for_kube():
     while numNodes < expectedNodes:
         binary = os.path.abspath('./deploy/bin/kubectl')
         kubeconfig = os.path.abspath('./deploy/'+config["acskubeconfig"])
-        cmd = binary + ' -o=json --kubeconfig='+kubeconfig+' get nodes'    
+        cmd = binary + ' -o=json --kubeconfig='+kubeconfig+' get nodes'
         nodeInfo = utils.subproc_runonce(cmd)
         nodes = yaml.load(nodeInfo)
         numNodes = len(nodes["items"])
@@ -148,7 +148,7 @@ def acs_wait_for_kube():
             print "Waiting for {0} kubernetes nodes to start up, currently have only {1} nodes".format(expectedNodes, numNodes)
             time.sleep(5)
 
-# divide nodes into master / agent 
+# divide nodes into master / agent
 def acs_set_nodes_info():
     if "acs_master_nodes" not in config or "acs_agent_nodes" not in config:
         allnodes = acs_get_kube_nodes()
@@ -362,7 +362,7 @@ def acs_get_storage_key():
     cmd += " --account-name=%s" % config["mountpoints"]["rootshare"]["accountname"]
     cmd += " --resource-group=%s" % config["resource_group"]
     keys = az_cmd(cmd)
-    return keys[0]["value"] 
+    return keys[0]["value"]
 
 def acs_create_storage():
     # Create storage account
@@ -497,7 +497,7 @@ def acs_deploy():
     az_create_sql()
 
     # Add rules for NSG
-    acs_add_nsg_rules({"HTTPAllow" : 80, "RestfulAPIAllow" : 5000, "AllowKubernetesServicePorts" : "30000-32767"})
+    acs_add_nsg_rules({"HTTPAllow" : 80, "RestfulAPIAllow" : 5000, "AllowKubernetesServicePorts" : "30000-49999"})
 
     # Get kubectl binary / acs config
     acs_get_config()

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -106,7 +106,7 @@ default_config_parameters = {
         "alert-templates.yaml": True,
         # "nginx": True,
         "RecogServer": True,
-        
+
         # This template will be rendered inside container, but not at build stage
         # "hdfs-site.xml.template": True,
     },
@@ -566,8 +566,8 @@ default_config_parameters = {
             "tutorial-nlp": {},
             "tutorial-fastai": {},
             "tutorial-imagenet18": {},
-            "gobld": {}, 
-            "kubernetes": {}, 
+            "gobld": {},
+            "kubernetes": {},
         },
         "external": {
             # These dockers are to be built by additional add ons.
@@ -581,11 +581,11 @@ default_config_parameters = {
             "kube-dns":{"fullname":"dlws/k8s-dns-kube-dns-amd64:1.14.8"},
             "kube-dnsmasq":{"fullname":"dlws/k8s-dns-dnsmasq-nanny-amd64:1.14.8"},
             "kube-dns-sidecar":{"fullname":"dlws/k8s-dns-sidecar-amd64:1.14.8"},
-            "heapster":{"fullname":"dlws/heapster-amd64:v1.4.0"},            
-            "etcd":{"fullname":"dlws/etcd:3.1.10"},            
-            "mysql":{"fullname":"dlws/mysql:5.6"},            
+            "heapster":{"fullname":"dlws/heapster-amd64:v1.4.0"},
+            "etcd":{"fullname":"dlws/etcd:3.1.10"},
+            "mysql":{"fullname":"dlws/mysql:5.6"},
             "phpmyadmin":{"fullname":"dlws/phpmyadmin:4.7.6"},
-            "fluentd-elasticsearch":{"fullname":"dlws/fluentd-elasticsearch:v2.0.2"},            
+            "fluentd-elasticsearch":{"fullname":"dlws/fluentd-elasticsearch:v2.0.2"},
 
         },
         "infrastructure": {
@@ -600,8 +600,8 @@ default_config_parameters = {
     "cloud_config": {
         "vnet_range": "192.168.0.0/16",
         "default_admin_username": "dlwsadmin",
-        "tcp_port_for_pods": "30000-32767",
-        "tcp_port_ranges": "80 443 30000-32767 25826",
+        "tcp_port_for_pods": "30000-49999",
+        "tcp_port_ranges": "80 443 30000-49999 25826",
         "udp_port_ranges": "25826",
         "dev_network": {
             "tcp_port_ranges": "22 1443 2379 3306 5000 8086",

--- a/src/ClusterManager/endpoint_manager.py
+++ b/src/ClusterManager/endpoint_manager.py
@@ -38,7 +38,7 @@ def start_ssh_server(pod_name, user_name, host_network=False, ssh_port=22):
     if host_network:
         # if the ssh_port is default value 22, randomly choose one
         if ssh_port == 22:
-            ssh_port = random.randint(30001, 32767)
+            ssh_port = random.randint(40000, 49999)
         # bash_script = "sed -i '/^Port 22/c Port "+str(ssh_port)+"' /etc/ssh/sshd_config && "+bash_script
         # TODO refine the script later
         bash_script = "sudo bash -c 'apt-get update && apt-get install -y openssh-server && sed -i \"s/^Port 22/Port " + str(ssh_port) + "/\" /etc/ssh/sshd_config && cd /home/" + user_name + " && (chown " + user_name + " -R .ssh; chmod 600 -R .ssh/*; chmod 700 .ssh; true) && service ssh restart'"
@@ -107,7 +107,7 @@ def setup_ssh_server(user_name, pod_name, host_network=False):
 
 def setup_jupyter_server(user_name, pod_name):
 
-    jupyter_port = random.randint(30001, 32767)
+    jupyter_port = random.randint(40000, 49999)
     bash_script = "sudo bash -c 'apt-get update && apt-get install python-pip -y && python -m pip install --upgrade pip && python -m pip install jupyter && cd /home/" + user_name + " && runuser -l " + user_name + " -c \"jupyter notebook --no-browser --ip=0.0.0.0 --NotebookApp.token= --port=" + str(jupyter_port) + " &>/dev/null &\"'"
     output = k8sUtils.kubectl_exec("exec %s %s" % (pod_name, " -- " + bash_script))
     if output == "":

--- a/src/ClusterManager/endpoint_manager.py
+++ b/src/ClusterManager/endpoint_manager.py
@@ -137,6 +137,14 @@ def start_endpoint(endpoint):
     create_node_port(endpoint)
 
 
+def is_user_ready(pod_name):
+    bash_script = "bash -c 'ls /dlws/USER_READY'"
+    output = k8sUtils.kubectl_exec("exec %s %s" % (pod_name, " -- " + bash_script))
+    if output == "":
+        return False
+    return True
+
+
 def start_endpoints():
     try:
         data_handler = DataHandler()
@@ -145,6 +153,8 @@ def start_endpoints():
         for endpoint_id, endpoint in pending_endpoints.items():
             job = data_handler.GetJob(jobId=endpoint["jobId"])[0]
             if job["jobStatus"] != "running":
+                continue
+            if not is_user_ready(endpoint["podName"]):
                 continue
 
             # get endpointDescriptionPath

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -402,7 +402,7 @@ def SubmitPSDistJob(job):
 
                     random.seed(datetime.datetime.now())
                     if "hostNetwork" in jobParams and jobParams["hostNetwork"]:
-                        distJobParam["containerPort"] = random.randint(3000, 32767)
+                        distJobParam["containerPort"] = random.randint(40000, 49999)
                     else:
                         distJobParam["containerPort"] = int(random.random()*1000+3000)
 
@@ -656,7 +656,7 @@ def start_ssh_server(pod_name, user_name, host_network=False, ssh_port=22):
     if host_network:
         # if the ssh_port is default value 22, randomly choose one
         if ssh_port == 22:
-            ssh_port = random.randint(30001, 32767)
+            ssh_port = random.randint(40000, 49999)
         # bash_script = "sed -i '/^Port 22/c Port "+str(ssh_port)+"' /etc/ssh/sshd_config && "+bash_script
         # TODO refine the script later
         bash_script = "sudo bash -c 'apt-get update && apt-get install -y openssh-server && sed -i \"s/^Port 22/Port " + str(ssh_port) + "/\" /etc/ssh/sshd_config && cd /home/" + user_name + " && (chown " + user_name + " -R .ssh; chmod 600 -R .ssh/*; chmod 700 .ssh; true) && service ssh restart'"

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -957,6 +957,7 @@ class Endpoint(Resource):
                 "status": endpoint["status"],
                 "hostNetwork": endpoint["hostNetwork"],
                 "podName": endpoint["podName"],
+                "domain": config["domain"],
             }
             if endpoint["status"] == "running":
                 if endpoint["hostNetwork"]:

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -20,6 +20,7 @@ from authorization import ResourceType, Permission, AuthorizationManager
 from config import config
 from config import global_vars
 import authorization
+from DataHandler import DataHandler
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(dir_path, 'logging.yaml'), 'r') as f:
@@ -1037,7 +1038,9 @@ class Endpoint(Resource):
             }
             endpoints[endpoint_id] = endpoint
 
-        JobRestAPIUtils.update_job(job_id, "endpoints", json.dumps(endpoints))
+        data_handler = DataHandler()
+        for [_, endpoint] in endpoints.items():
+            data_handler.UpdateEndpoint(endpoint)
 
         resp = jsonify(endpoints)
         resp.headers["Access-Control-Allow-Origin"] = "*"

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -7,7 +7,6 @@ from flask_restful import reqparse, abort, Api, Resource
 from flask import request, jsonify
 import base64
 import yaml
-import re
 import uuid
 
 import logging
@@ -982,14 +981,17 @@ class Endpoint(Resource):
 
         # get the job
         job = JobRestAPIUtils.get_job(job_id)
-
-        # get endpointDescriptionPath
-        # job["jobDescriptionPath"] = "jobfiles/" + time.strftime("%y%m%d") + "/" + jobParams["jobId"] + "/" + jobParams["jobId"] + ".yaml"
-        endpoint_description_dir = re.search("(.*/)[^/\.]+.yaml", job["jobDescriptionPath"]).group(1)
+        job_params = json.loads(base64.b64decode(job["jobParams"]))
 
         # get pods
-        job_description = base64.b64decode(job["jobDescription"])
-        pod_names = [resource["metadata"]["name"] for resource in yaml.load_all(job_description) if resource['kind'] == 'Pod']
+        pod_names = []
+        if(job_params["jobtrainingtype"] == "RegularJob"):
+            pod_names.append(job_id)
+        else:
+            nums = {"ps": int(job_params["numps"]), "worker": int(job_params["numpsworker"])}
+            for role in ["ps", "worker"]:
+                for i in range(nums[role]):
+                    pod_names.append(job_id + "-" + role + str(i))
 
         # endpoints should be in ["ssh", "ipython"]
         if any(elem not in ["ssh", "ipython"] for elem in requested_endpoints):
@@ -1017,7 +1019,6 @@ class Endpoint(Resource):
                     "podName": pod_name,
                     "username": username,
                     "name": "ssh",
-                    "endpointDescriptionPath": os.path.join(endpoint_description_dir, endpoint_id + ".yaml"),
                     "status": "pending",
                     "hostNetwork": host_network
                 }
@@ -1033,7 +1034,6 @@ class Endpoint(Resource):
                 "podName": pod_name,
                 "username": username,
                 "name": "ipython",
-                "endpointDescriptionPath": os.path.join(endpoint_description_dir, endpoint_id + ".yaml"),
                 "status": "pending",
                 "hostNetwork": host_network
             }


### PR DESCRIPTION
1. Fix the issue: can't enable ssh/ipython in the same time.
1. Change port range: '30000-39999' for NodePort, 40000-49999 for HostNetwork.
1. Start endpoint only after user is properly setup, avoids the race condition.