### PR TITLE
add vc_url in watchdog deployment

### DIFF
--- a/src/ClusterBootstrap/services/monitor/watchdog.yaml
+++ b/src/ClusterBootstrap/services/monitor/watchdog.yaml
@@ -34,6 +34,10 @@ spec:
         - --bearer
         - /var/run/secrets/kubernetes.io/serviceaccount/token
         - https://{{ cnf["api-server-ip"] }}:443
+        {% if "vc_url" in cnf["watchdog"] %}
+        - --vc_url
+        - {{cnf["watchdog"]["vc_url"]}}
+        {% endif %}
         env:
         - name: LOGGING_LEVEL
           value: INFO


### PR DESCRIPTION
Related to https://github.com/microsoft/pai/pull/2876 .

When deploying, user should add config:

``` yaml
watchdog:
    vc_url: http://$IP:5000/ListVCs?userName=xxx
```

With this setup, other could query: `$MASTER_IP:9091/prometheus/api/v1/query?query=$QUERY_STRING`.

prometheus API doc can be viewed [here](https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries).

`MASTER_IP` should be master node of k8s, and `QUERY_STRING` could be url encoded string of:
* `k8s_vc_gpu_available{vc_name="multimedia", gpu_type="P40"}`: will return number of gpu available to vc multimedia and gpu type P40.
* `k8s_vc_gpu_preemptive_available{vc_name="multimedia", gpu_type="P40"}`: will return number of gpu available to vc multimedia and gpu type P40. This will assume we can preempt all preemptible jobs.
* `k8s_vc_gpu_preemptive_available`: will return all gpu available to all VCs and all gpu types, will list them separately.
* `k8s_vc_gpu_total`: will return total quota assigned to all VCs and all gpu types, will list them separately.