### PR TITLE
mitigate nfs hang problem

### DIFF
--- a/src/Jobs_Templete/init_user.sh
+++ b/src/Jobs_Templete/init_user.sh
@@ -11,7 +11,7 @@ export ENV_FILE=/dlws/pod.env
 addgroup --force-badname --gid  ${DLWS_GID} domainusers
 adduser --force-badname --home /home/${DLWS_USER_NAME} --shell /bin/bash --uid ${DLWS_UID}  -gecos '' --gid ${DLWS_GID} --disabled-password ${DLWS_USER_NAME}
 usermod -p $(echo tryme2017 | openssl passwd -1 -stdin) ${DLWS_USER_NAME}
-chown -R ${DLWS_USER_NAME} /home/${DLWS_USER_NAME}/ || /bin/true
+chown ${DLWS_USER_NAME} /home/${DLWS_USER_NAME}/ /home/${DLWS_USER_NAME}/.profile || /bin/true
 chmod -R 600 /home/${DLWS_USER_NAME}/.ssh || /bin/true
 chmod 700 /home/${DLWS_USER_NAME}/.ssh || /bin/true
 


### PR DESCRIPTION
Problem:
1. Operations on nfs may hang (ls, chown, chmod and etc), it's a nfs known issue.
1. If there are huge amount of files, the operation `chown -R` may hang with a obviously high possibility.

The mitigation:
1. Now we would only touch minimal necessary files within the `init_user.sh`.
1. User would be respond to fix the owner/permissions of other files by themselves.

Attention: **Need more test to figure out exactly `minimal necessary` files.**