### PR TITLE
Dixu/use prometheus as usage

### DIFF
--- a/src/ClusterManager/node_manager.py
+++ b/src/ClusterManager/node_manager.py
@@ -67,7 +67,7 @@ def get_job_gpu_usage(jobId):
     try:
         hostaddress = config.get("prometheus_node", "127.0.0.1")
 
-        url = """http://"""+hostaddress+""":9091/prometheus/api/v1/query?query=avg%28avg_over_time%28task_gpu_percent%7Bjob_name%3D%22""" + jobId + """%22%7D%5B4h%5D%29%29+by+%28job_name%2C+instance%2C+username%29"""
+        url = """http://"""+hostaddress+""":9091/prometheus/api/v1/query?query=avg%28avg_over_time%28task_gpu_percent%7Bpod_name%3D%22""" + jobId + """%22%7D%5B4h%5D%29%29+by+%28pod_name%2C+instance%2C+username%29"""
 
         curl = pycurl.Curl()
         curl.setopt(pycurl.URL, url)


### PR DESCRIPTION
Change resource usage source from influx db to prometheus.

Using prometheus query avg(avg_over_time(task_gpu_percent{pod_name="$pod_name"}[4h])) by (pod_name, instance, username) which will return float number no more than 100.

This also support distributed jobs.