### PR TITLE
Feature: interactive port and tensorboard

### DIFF
--- a/src/ClusterManager/endpoint_manager.py
+++ b/src/ClusterManager/endpoint_manager.py
@@ -81,7 +81,7 @@ spec:
 
 
 def create_node_port(endpoint):
-    endpoint_description = generate_node_port_service(endpoint["jobId"], endpoint["podName"], endpoint["id"], endpoint["name"], endpoint["port"])
+    endpoint_description = generate_node_port_service(endpoint["jobId"], endpoint["podName"], endpoint["id"], endpoint["name"], endpoint["podPort"])
     endpoint_description_path = os.path.join(config["storage-mount-path"], endpoint["endpointDescriptionPath"])
     print("endpointDescriptionPath: %s" % endpoint_description_path)
     with open(endpoint_description_path, 'w') as f:
@@ -127,11 +127,12 @@ def start_endpoint(endpoint):
 
     port_name = endpoint["name"]
     if port_name == "ssh":
-        port = setup_ssh_server(user_name, pod_name, host_network)
-    else:
-        port = setup_jupyter_server(user_name, pod_name)
-
-    endpoint["port"] = port
+        endpoint["podPort"] = setup_ssh_server(user_name, pod_name, host_network)
+    elif port_name == "ipython":
+        endpoint["podPort"] = setup_jupyter_server(user_name, pod_name)
+    elif port_name == "tensorboard":
+        # TODO tensorboard
+        endpoint["podPort"] = 49999
 
     # create NodePort
     create_node_port(endpoint)

--- a/src/ClusterManager/endpoint_manager.py
+++ b/src/ClusterManager/endpoint_manager.py
@@ -148,8 +148,8 @@ def is_user_ready(pod_name):
 
 def start_endpoints():
     try:
-        data_handler = DataHandler()
         try:
+            data_handler = DataHandler()
             pending_endpoints = data_handler.GetPendingEndpoints()
 
             for endpoint_id, endpoint in pending_endpoints.items():
@@ -166,13 +166,10 @@ def start_endpoints():
 
                 print("\n\n\n\n\n\n----------------Begin to start endpoint %s" % endpoint["id"])
                 output = get_k8s_endpoint(endpoint["endpointDescriptionPath"])
-                if (output != ""):
+                if(output != ""):
                     endpoint_description = json.loads(output)
                     endpoint["endpointDescription"] = endpoint_description
                     endpoint["status"] = "running"
-                    if endpoint["hostNetwork"]:
-                        endpoint["port"] = endpoint_description["spec"]["ports"][0]["port"]
-
                     pod = k8sUtils.GetPod("podName=" + endpoint["podName"])
                     if "items" in pod and len(pod["items"]) > 0:
                         endpoint["nodeName"] = pod["items"][0]["spec"]["nodeName"]
@@ -183,8 +180,6 @@ def start_endpoints():
                 data_handler.UpdateEndpoint(endpoint)
         except Exception as e:
             traceback.print_exc()
-        finally:
-            data_handler.Close()
     except Exception as e:
         traceback.print_exc()
 

--- a/src/ClusterManager/endpoint_manager.py
+++ b/src/ClusterManager/endpoint_manager.py
@@ -133,6 +133,8 @@ def start_endpoint(endpoint):
     elif port_name == "tensorboard":
         # TODO tensorboard
         endpoint["podPort"] = 49999
+    else:
+        endpoint["podPort"] = int(endpoint["podPort"])
 
     # create NodePort
     create_node_port(endpoint)

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -1007,6 +1007,7 @@ class Endpoint(Resource):
 
         for [_, endpoint] in endpoints.items():
             ret = {
+                "id": endpoint["id"],
                 "name": endpoint["name"],
                 "username": endpoint["username"],
                 "status": endpoint["status"],
@@ -1014,6 +1015,8 @@ class Endpoint(Resource):
                 "podName": endpoint["podName"],
                 "domain": config["domain"],
             }
+            if "podPort" in endpoint:
+                ret["podPort"] = endpoint["podPort"]
             if endpoint["status"] == "running":
                 if endpoint["hostNetwork"]:
                     port = int(endpoint["port"])
@@ -1050,9 +1053,15 @@ class Endpoint(Resource):
                 for i in range(nums[role]):
                     pod_names.append(job_id + "-" + role + str(i))
 
-        # endpoints should be in ["ssh", "ipython"]
-        if any(elem not in ["ssh", "ipython"] for elem in requested_endpoints):
-            return ("Bad request, endpoints only allowed in [\"ssh\", \"ipython\"]: %s" % requested_endpoints), 400
+        interactive_ports = []
+        # endpoints should be ["ssh", "ipython", "tensorboard", {"name": "port name", "podPort": "port on pod in 50000-59999"}]
+        for interactive_port in [ elem for elem in requested_endpoints if elem not in ["ssh", "ipython", "tensorboard"] ]:
+            if any(required_field not in interactive_port for required_field in ["name", "podPort"]):
+               # if ["name", "port"] not in interactive_port:
+               return ("Bad request, interactive port should have \"name\" and \"podPort\"]: %s" % requested_endpoints), 400
+            if int(interactive_port["podPort"]) < 50000 or int(interactive_port["podPort"]) > 59999:
+               return ("Bad request, interactive podPort should in range 50000-59999: %s" % requested_endpoints), 400
+            interactive_ports.append(interactive_port)
 
         # HostNetwork
         if "hostNetwork" in job_params and job_params["hostNetwork"] == True:
@@ -1116,6 +1125,60 @@ class Endpoint(Resource):
                     "podName": pod_name,
                     "username": username,
                     "name": "ipython",
+                    "status": "pending",
+                    "hostNetwork": host_network
+                }
+                endpoints[endpoint_id] = endpoint
+            else:
+                print("Endpoint {} exists. Skip.".format(endpoint_id))
+
+        # Only open tensorboard on the master
+        if 'tensorboard' in requested_endpoints:
+            if job_type == "RegularJob":
+                pod_name = pod_names[0]
+            else:
+                # For a distributed job, we set up jupyter on first worker node.
+                # PS node does not have GPU access.
+                # TODO: Simplify code logic after removing PS
+                pod_name = pod_names[1]
+
+            endpoint_id = "endpoint-" + pod_name + "-tensorboard"
+
+            if not endpoint_exist(endpoint_id=endpoint_id):
+                print("Endpoint {} does not exist. Add.".format(endpoint_id))
+                endpoint = {
+                    "id": endpoint_id,
+                    "jobId": job_id,
+                    "podName": pod_name,
+                    "username": username,
+                    "name": "tensorboard",
+                    "status": "pending",
+                    "hostNetwork": host_network
+                }
+                endpoints[endpoint_id] = endpoint
+            else:
+                print("Endpoint {} exists. Skip.".format(endpoint_id))
+
+        # interactive port
+        for interactive_port in interactive_ports:
+            if job_type == "RegularJob":
+                pod_name = pod_names[0]
+            else:
+                # For a distributed job, we set up jupyter on first worker node.
+                # PS node does not have GPU access.
+                # TODO: Simplify code logic after removing PS
+                pod_name = pod_names[1]
+
+            endpoint_id = "endpoint-" + pod_name + "-" + interactive_port["name"]
+            if not endpoint_exist(endpoint_id=endpoint_id):
+                print("Endpoint {} does not exist. Add.".format(endpoint_id))
+                endpoint = {
+                    "id": endpoint_id,
+                    "jobId": job_id,
+                    "podName": pod_name,
+                    "username": username,
+                    "name": interactive_port["name"],
+                    "podPort": interactive_port["podPort"],
                     "status": "pending",
                     "hostNetwork": host_network
                 }

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -1057,10 +1057,12 @@ class Endpoint(Resource):
         # endpoints should be ["ssh", "ipython", "tensorboard", {"name": "port name", "podPort": "port on pod in 50000-59999"}]
         for interactive_port in [ elem for elem in requested_endpoints if elem not in ["ssh", "ipython", "tensorboard"] ]:
             if any(required_field not in interactive_port for required_field in ["name", "podPort"]):
-               # if ["name", "port"] not in interactive_port:
-               return ("Bad request, interactive port should have \"name\" and \"podPort\"]: %s" % requested_endpoints), 400
+                # if ["name", "port"] not in interactive_port:
+                return ("Bad request, interactive port should have \"name\" and \"podPort\"]: %s" % requested_endpoints), 400
             if int(interactive_port["podPort"]) < 50000 or int(interactive_port["podPort"]) > 59999:
-               return ("Bad request, interactive podPort should in range 50000-59999: %s" % requested_endpoints), 400
+                return ("Bad request, interactive podPort should in range 50000-59999: %s" % requested_endpoints), 400
+            if len(interactive_port["name"]) > 16:
+                return ("Bad request, interactive port name length shoule be less than 16: %s" % requested_endpoints), 400
             interactive_ports.append(interactive_port)
 
         # HostNetwork
@@ -1087,7 +1089,7 @@ class Endpoint(Resource):
         if "ssh" in requested_endpoints:
             # setup ssh for each pod
             for pod_name in pod_names:
-                endpoint_id = "endpoint-" + pod_name + "-ssh"
+                endpoint_id = "e-" + pod_name + "-ssh"
 
                 if endpoint_exist(endpoint_id=endpoint_id):
                     print("Endpoint {} exists. Skip.".format(endpoint_id))
@@ -1115,7 +1117,7 @@ class Endpoint(Resource):
                 # TODO: Simplify code logic after removing PS
                 pod_name = pod_names[1]
 
-            endpoint_id = "endpoint-" + pod_name + "-ipython"
+            endpoint_id = "e-" + job_id + "-ipython"
 
             if not endpoint_exist(endpoint_id=endpoint_id):
                 print("Endpoint {} does not exist. Add.".format(endpoint_id))
@@ -1142,7 +1144,7 @@ class Endpoint(Resource):
                 # TODO: Simplify code logic after removing PS
                 pod_name = pod_names[1]
 
-            endpoint_id = "endpoint-" + pod_name + "-tensorboard"
+            endpoint_id = "e-" + job_id + "-tensorboard"
 
             if not endpoint_exist(endpoint_id=endpoint_id):
                 print("Endpoint {} does not exist. Add.".format(endpoint_id))
@@ -1169,7 +1171,7 @@ class Endpoint(Resource):
                 # TODO: Simplify code logic after removing PS
                 pod_name = pod_names[1]
 
-            endpoint_id = "endpoint-" + pod_name + "-" + interactive_port["name"]
+            endpoint_id = "e-" + job_id + "-" + interactive_port["name"]
             if not endpoint_exist(endpoint_id=endpoint_id):
                 print("Endpoint {} does not exist. Add.".format(endpoint_id))
                 endpoint = {

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -1054,13 +1054,13 @@ class Endpoint(Resource):
                     pod_names.append(job_id + "-" + role + str(i))
 
         interactive_ports = []
-        # endpoints should be ["ssh", "ipython", "tensorboard", {"name": "port name", "podPort": "port on pod in 50000-59999"}]
+        # endpoints should be ["ssh", "ipython", "tensorboard", {"name": "port name", "podPort": "port on pod in 40000-49999"}]
         for interactive_port in [ elem for elem in requested_endpoints if elem not in ["ssh", "ipython", "tensorboard"] ]:
             if any(required_field not in interactive_port for required_field in ["name", "podPort"]):
                 # if ["name", "port"] not in interactive_port:
                 return ("Bad request, interactive port should have \"name\" and \"podPort\"]: %s" % requested_endpoints), 400
-            if int(interactive_port["podPort"]) < 50000 or int(interactive_port["podPort"]) > 59999:
-                return ("Bad request, interactive podPort should in range 50000-59999: %s" % requested_endpoints), 400
+            if int(interactive_port["podPort"]) < 40000 or int(interactive_port["podPort"]) > 49999:
+                return ("Bad request, interactive podPort should in range 40000-49999: %s" % requested_endpoints), 400
             if len(interactive_port["name"]) > 16:
                 return ("Bad request, interactive port name length shoule be less than 16: %s" % requested_endpoints), 400
             interactive_ports.append(interactive_port)

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -1013,12 +1013,13 @@ class Endpoint(Resource):
                 "status": endpoint["status"],
                 "hostNetwork": endpoint["hostNetwork"],
                 "podName": endpoint["podName"],
-                "podPort": endpoint["podPort"],
                 "domain": config["domain"],
             }
+            if "podPort" in endpoint:
+                ret["podPort"] = endpoint["podPort"]
             if endpoint["status"] == "running":
                 if endpoint["hostNetwork"]:
-                    port = int(endpoint["podPort"])
+                    port = int(endpoint["endpointDescription"]["spec"]["ports"][0]["port"])
                 else:
                     port = int(endpoint["endpointDescription"]["spec"]["ports"][0]["nodePort"])
                 ret["port"] = port

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -1013,13 +1013,12 @@ class Endpoint(Resource):
                 "status": endpoint["status"],
                 "hostNetwork": endpoint["hostNetwork"],
                 "podName": endpoint["podName"],
+                "podPort": endpoint["podPort"],
                 "domain": config["domain"],
             }
-            if "podPort" in endpoint:
-                ret["podPort"] = endpoint["podPort"]
             if endpoint["status"] == "running":
                 if endpoint["hostNetwork"]:
-                    port = int(endpoint["port"])
+                    port = int(endpoint["podPort"])
                 else:
                     port = int(endpoint["endpointDescription"]["spec"]["ports"][0]["nodePort"])
                 ret["port"] = port


### PR DESCRIPTION
Features:
1. Interactive ports [DONE]
1. Tensorboard [DONE]

Design restriction:
1. Tensorboard would working with `--logdir=/job/logs`
1. All interactive  (and tensorboard) ports serve on ‘master’ role.
1. Listen on the port in range 40000-49999. (Try to avoid port overlay with NodePort.)
1. Interactive port name should less than 16 characters. (We use port name as part of the k8s service name, k8s have length limitation on the service name.)

API payload example for `create` endpoints:
`{ "jobId": "bd3d090a-53b6-4616-9b6c-fe4a86fd68ea", "endpoints": ["ssh", "ipython", "tensorboard", {"name": "port1", "podPort": "49999"}]}
`
