### PR TITLE
Use session.isAuthorized instead of User.Identity.IsAuthenticated.

### DIFF
--- a/src/WebUI/dotnet/WebPortal/Controllers/AccountController.cs
+++ b/src/WebUI/dotnet/WebPortal/Controllers/AccountController.cs
@@ -37,7 +37,7 @@ namespace WindowsAuth.Controllers
         [HttpGet("{scheme}")]
         public async Task Login(string scheme )
         {
-            if (HttpContext.User == null || !HttpContext.User.Identity.IsAuthenticated)
+            if (HttpContext.Session.GetString("isAuthorized") != "true")
             {
                 await HttpContext.Authentication.ChallengeAsync(scheme, new AuthenticationProperties { RedirectUri = "/" });
             }

--- a/src/WebUI/dotnet/WebPortal/Controllers/HomeController.cs
+++ b/src/WebUI/dotnet/WebPortal/Controllers/HomeController.cs
@@ -836,11 +836,6 @@ namespace WindowsAuth.Controllers
 
         public IActionResult JobSubmission()
         {
-            if (!User.Identity.IsAuthenticated)
-            {
-                return RedirectToAction("Index", "Home");
-            }
-
             if (!HttpContext.Session.Keys.Contains("isAuthorized") || HttpContext.Session.GetString("isAuthorized") != "true")
             {
                 return RedirectToAction("Index", "Home");
@@ -867,11 +862,6 @@ namespace WindowsAuth.Controllers
 
         public IActionResult DataJob()
         {
-            if (!User.Identity.IsAuthenticated)
-            {
-                return RedirectToAction("Index", "Home");
-            }
-
             if (!HttpContext.Session.Keys.Contains("isAuthorized") || HttpContext.Session.GetString("isAuthorized") != "true")
             {
                 return RedirectToAction("Index", "Home");
@@ -898,11 +888,6 @@ namespace WindowsAuth.Controllers
 
         public IActionResult ViewJobs()
         {
-            if (!User.Identity.IsAuthenticated)
-            {
-                return RedirectToAction("Index", "Home");
-            }
-
             if (!HttpContext.Session.Keys.Contains("isAuthorized") || HttpContext.Session.GetString("isAuthorized") != "true")
             {
                 return RedirectToAction("Index", "Home");
@@ -917,10 +902,6 @@ namespace WindowsAuth.Controllers
 
         public IActionResult JobDetail()
         {
-            if (!User.Identity.IsAuthenticated)
-            {
-                return RedirectToAction("Index", "Home");
-            }
             if (!HttpContext.Session.Keys.Contains("isAuthorized") || HttpContext.Session.GetString("isAuthorized") != "true")
             {
                 return RedirectToAction("Index", "Home");
@@ -940,11 +921,6 @@ namespace WindowsAuth.Controllers
 
         public IActionResult ViewCluster()
         {
-            if (!User.Identity.IsAuthenticated)
-            {
-                // return RedirectToAction("Login", "Account", new { controller = "Account", action = "Login" });
-                return RedirectToAction("Index", "Home");
-            }
             if (!HttpContext.Session.Keys.Contains("isAuthorized") || HttpContext.Session.GetString("isAuthorized") != "true")
             {
                 return RedirectToAction("Index", "Home");
@@ -988,7 +964,7 @@ namespace WindowsAuth.Controllers
             var currentCluster = HttpContext.Session.GetString("CurrentClusters");
             if (Startup.Database.ContainsKey(currentCluster))
             {
-                if (!User.Identity.IsAuthenticated || HttpContext.Session.GetString("isAdmin").Equals("false") )
+                if (HttpContext.Session.GetString("isAuthorized") != "true")
                 {
                     return RedirectToAction("Index", "Home");
                 }
@@ -1030,7 +1006,7 @@ namespace WindowsAuth.Controllers
 
         public async Task<IActionResult> AccountSettings()
         {
-            if (!User.Identity.IsAuthenticated)
+            if (HttpContext.Session.GetString("isAuthorized") != "true")
             {
                 return RedirectToAction("Index", "Home");
             }

--- a/src/WebUI/dotnet/WebPortal/Controllers/dlwsController.cs
+++ b/src/WebUI/dotnet/WebPortal/Controllers/dlwsController.cs
@@ -191,7 +191,7 @@ namespace WindowsAuth.Controllers
                 return tuple.Item2;
 
 
-            if (!User.Identity.IsAuthenticated && !passwdLogin)
+            if (HttpContext.Session.GetString("isAuthorized") != "true" && !passwdLogin)
             {
                 ret = "Unauthorized User, Please login!";
                 return ret;
@@ -447,7 +447,7 @@ namespace WindowsAuth.Controllers
                 return tuple.Item2;
 
 
-            if (!User.Identity.IsAuthenticated && !passwdLogin)
+            if (HttpContext.Session.GetString("isAuthorized") != "true" && !passwdLogin)
             {
                 ret = "Unauthorized User, Please login!";
                 return ret;

--- a/src/WebUI/dotnet/WebPortal/Views/Shared/_LoginPartial.cshtml
+++ b/src/WebUI/dotnet/WebPortal/Views/Shared/_LoginPartial.cshtml
@@ -4,7 +4,7 @@
 @using WindowsAuth
 @using Newtonsoft.Json;
 
-@if (User.Identity.IsAuthenticated)
+@if (Context.Session.GetString("isAuthorized") == "true")
 {
     <ul class="nav navbar-nav navbar-right">
         <li class="dropdown" id="teams-dropdown">


### PR DESCRIPTION
This PR will remove the dependency of OpenID connect token after user is successfully signed in.