### PR TITLE
Fix password authentication.

### DIFF
--- a/src/WebUI/dotnet/WebPortal/Startup.cs
+++ b/src/WebUI/dotnet/WebPortal/Startup.cs
@@ -489,9 +489,9 @@ namespace WindowsAuth
 
             app.Use(async (context, next) =>
             {
-                if (context.Request.Query.ContainsKey("team") && context.Session.GetString("Teams") != null)
+                if (context.Request.Query.ContainsKey("current-team") && context.Session.GetString("Teams") != null)
                 {
-                    var team = context.Request.Query["Team"];
+                    var team = context.Request.Query["current-team"];
                     var teams = JsonConvert.DeserializeObject<string[]>(context.Session.GetString("Teams"));
                     if (Array.Exists(teams, t => t.Equals(team)))
                     {

--- a/src/WebUI/dotnet/WebPortal/Views/Shared/_LoginPartial.cshtml
+++ b/src/WebUI/dotnet/WebPortal/Views/Shared/_LoginPartial.cshtml
@@ -8,18 +8,22 @@
 {
     <ul class="nav navbar-nav navbar-right">
 
-        @if (ViewData["isAuthorized"] != null && (bool)ViewData["isAuthorized"])
+        @if (Context.Session.GetString("Team") != null)
         {
-        <li class="dropdown" id="teams-dropdown">
-            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">@Context.Session.GetString("Team") <span class="caret"></span></a>
-            <ul class="dropdown-menu">
-                @{ var teams = JsonConvert.DeserializeObject<string[]>(Context.Session.GetString("Teams")); }
-                @foreach (var team in teams)
-                {
-                    <li><a href="#">@team</a></li>
-                }
-            </ul>
-        </li>
+            try
+            {
+                <li class="dropdown" id="teams-dropdown">
+                    <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">@Context.Session.GetString("Team") <span class="caret"></span></a>
+                    <ul class="dropdown-menu">
+                        @{ var teams = JsonConvert.DeserializeObject<string[]>(Context.Session.GetString("Teams")); }
+                        @foreach (var team in teams)
+                        {
+                            <li><a href="#">@team</a></li>
+                        }
+                    </ul>
+                </li>
+            }
+            catch { /* ignored */ }
         }
 
         <li><a asp-area="" asp-controller="Home" asp-action="AccountSettings">Hello, @ViewData["Username"]</a></li>
@@ -30,12 +34,12 @@
             var querystring = location.search.replace(/^\?/, '');
             var queries = querystring.split('&');
             queries = queries.filter(function (query) {
-                return !/^\s*$/.test(query) && !/^team=/i.test(query);
+                return !/^\s*$/.test(query) && !/^current-team=/i.test(query);
             });
             if (queries.length > 0) {
-                querystring = '?' + queries.join('&') + '&team=';
+                querystring = '?' + queries.join('&') + '&current-team=';
             } else {
-                querystring = '?team='
+                querystring = '?current-team=';
             }
 
             $('#teams-dropdown .dropdown-menu a').each(function () {


### PR DESCRIPTION
Cherry-picked from WIP hyper drive integration to be checked in firstly.

There are 2 extra query fields must be provided in password authentication of dlws controller: `cluster` and `team`.

To avoid the ambiguity of `team` query, rename the `team` query using in home controller for changing current team to `current-team`.

- [x] should use the password of the main database, which displays in the profile page.