### PR TITLE
add support for notify user about job state change

### DIFF
--- a/src/ClusterBootstrap/services/monitor/alert-manager.yaml
+++ b/src/ClusterBootstrap/services/monitor/alert-manager.yaml
@@ -82,12 +82,17 @@ data:
       group_interval: 5m
       group_by: [alertname]
       routes:
-      - receiver: task_user
+      - receiver: idle_gpu_receiver
         repeat_interval: 4h
         group_by: [alertname, user_email, cluster]
         match_re:
           type: user_alert
           alertname: "zero-gpu-usage"
+      - receiver: job_state_change_receiver
+        group_by: [alertname, user_email, cluster, subject]
+        match_re:
+          type: user_alert
+          alertname: "job-state-changed"
     receivers:
     - name: "alert-email"
       email_configs:
@@ -95,7 +100,7 @@ data:
           html: '{{ "{{" }} template "email.html" . {{ "}}" }}'
           headers:
             subject: '{{ "{{" }} .GroupLabels.cluster {{ "}}" }}: {{ "{{" }} template "__subject" . {{ "}}" }}'
-    - name: "task_user"
+    - name: "idle_gpu_receiver"
       email_configs:
         {% if cnf["alert-manager"]["alert_users"] %}
         - to: '{{ "{{" }} .GroupLabels.user_email {{ "}}" }},{{ alert_info["receiver"] }}'
@@ -103,6 +108,20 @@ data:
         - to: '{{ alert_info["receiver"] }}'
         {% endif %}
           html: '{{ "{{" }} template "idle_gpu.html" . {{ "}}" }}'
+          headers:
+            {% if cnf["alert-manager"]["alert_users"] %}
+            To: '{{ "{{" }} .GroupLabels.user_email {{ "}}" }}'
+            CC: '{{ alert_info["receiver"] }}'
+            {% endif %}
+            subject: '{{ "{{" }} .GroupLabels.cluster {{ "}}" }}: {{ "{{" }} template "__subject" . {{ "}}" }}'
+    - name: "job_state_change_receiver"
+      email_configs:
+        {% if cnf["alert-manager"]["alert_users"] %}
+        - to: '{{ "{{" }} .GroupLabels.user_email {{ "}}" }},{{ alert_info["receiver"] }}'
+        {% else %}
+        - to: '{{ alert_info["receiver"] }}'
+        {% endif %}
+          html: '{{ "{{" }} template "job_state.html" . {{ "}}" }}'
           headers:
             {% if cnf["alert-manager"]["alert_users"] %}
             To: '{{ "{{" }} .GroupLabels.user_email {{ "}}" }}'

--- a/src/ClusterBootstrap/services/monitor/alert-templates/job_state.tmpl
+++ b/src/ClusterBootstrap/services/monitor/alert-templates/job_state.tmpl
@@ -1,0 +1,71 @@
+{{ define "job_state.html" }}
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+Style and HTML derived from https://github.com/mailgun/transactional-email-templates
+
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Mailgun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<head>
+<meta name="viewport" content="width=device-width"/>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+<title>{{ template "__subject" . }}</title>
+
+</head>
+
+<body itemscope="" itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; height: 100%; line-height: 1.6em; width: 100% !important; background-color: #f6f6f6; margin: 0; padding: 0;" bgcolor="#f6f6f6">
+
+<table style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+  <tr>
+    <td valign="top"></td>
+    <td width="600" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; display: block !important; max-width: 600px !important; clear: both !important; width: 100% !important; margin: 0 auto; padding: 0;" valign="top">
+      <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; max-width: 600px; display: block; margin: 0 auto; padding: 0;">
+        <table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; border-radius: 3px; background-color: #fff; margin: 0; border: 1px solid #e9e9e9;" bgcolor="#fff">
+          <tr>
+            <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 10px;" valign="top">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                {{ range .Alerts.Firing }}
+                <tr>
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+Your job
+<a href="http://dltshub.redmond.corp.microsoft.com/Home/JobDetail/?cluster={{.Labels.cluster}}&jobId={{.Labels.job_name}}">
+<strong>{{.Labels.job_name}}</strong>
+</a> from cluster '{{.Labels.cluster}}' has changed to state of {{.Labels.job_state}}.
+                  </td>
+                </tr>
+                {{ end }}
+              </table>
+            </td>
+          </tr>
+        </table>
+
+        </div>
+    </td>
+    <td valign="top"></td>
+  </tr>
+</table>
+
+</body>
+</html>
+{{ end }}

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -180,7 +180,7 @@ def AutoApproveJob(job):
 
 UnusualJobs = {}
 
-def UpdateJobStatus(job, notifier):
+def UpdateJobStatus(job, notifier=None):
     dataHandler = DataHandler()
     jobParams = json.loads(base64.b64decode(job["jobParams"]))
 
@@ -227,8 +227,9 @@ def UpdateJobStatus(job, notifier):
     elif result.strip() == "Failed":
         logging.warning("Job %s fails, cleaning...", job["jobId"])
 
-        notifier.notify(notify.new_job_state_change_message(
-            job["userName"], job["jobId"], result.strip()))
+        if notifier is not None:
+            notifier.notify(notify.new_job_state_change_message(
+                job["userName"], job["jobId"], result.strip()))
 
         joblog_manager.extract_job_log(job["jobId"],logPath,jobParams["userId"])
         dataHandler.UpdateJobTextField(job["jobId"],"jobStatus","failed")

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -220,6 +220,9 @@ def UpdateJobStatus(job, notifier=None):
         if jobDescriptionPath is not None and os.path.isfile(jobDescriptionPath):
             k8sUtils.kubectl_delete(jobDescriptionPath)
 
+        if notifier is not None:
+            notifier.notify(notify.new_job_state_change_message(
+                job["userName"], job["jobId"], result.strip()))
     elif result.strip() == "Running":
         if job["jobStatus"] != "running":
             dataHandler.UpdateJobTextField(job["jobId"],"jobStatus","running")

--- a/src/utils/notify.py
+++ b/src/utils/notify.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+
+import threading
+import time
+import logging
+import urlparse
+import json
+import smtplib
+
+from Queue import Queue
+from Queue import Empty
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+class NotifyMsg(object):
+    def __init__(self, email, alert_name):
+        self.email = email
+        self.alert_name = alert_name
+
+    def labels(self):
+        raise NotImplementedError()
+
+    def subject(self):
+        raise NotImplementedError()
+
+    def body(self):
+        return self.subject()
+
+
+class JobStateChangedMsg(NotifyMsg):
+    def __init__(self, email, alert_name, job_name, job_state):
+        super(JobStateChangedMsg, self).__init__(email, alert_name)
+        self.job_name = job_name
+        self.job_state = job_state
+
+    def labels(self):
+        return {"job_name": self.job_name, "job_state": self.job_state}
+
+    def subject(self):
+        return "Your job %s has changed to state of %s" % (self.job_name, self.job_state)
+
+
+def new_job_state_change_message(email, job_name, state):
+    return JobStateChangedMsg(email, "job-state-changed", job_name, state)
+
+
+class Notifier(object):
+    def __init__(self, config):
+        self.queue = Queue()
+        self.running = False
+        self.thread = None
+
+        self.cluster = None
+        self.alert_manager_url = None
+        self.smtp_url = self.smtp_from = self.smtp_auth_name = self.smtp_auth_pass = None
+
+        if "notifier" in config:
+            notifier_config = config["notifier"]
+
+            self.cluster = notifier_config.get("cluster")
+            self.smtp_url = notifier_config.get("smtp-url")
+            self.smtp_from = notifier_config.get("smtp-from")
+            self.smtp_auth_name = notifier_config.get("smtp-auth-username")
+            self.smtp_auth_pass = notifier_config.get("smtp-auth-password")
+
+            alert_manager_url = notifier_config.get("alert-manager-url")
+            if alert_manager_url is not None and len(alert_manager_url) > 0:
+                if alert_manager_url[-1] == "/":
+                    self.alert_manager_url = alert_manager_url + "api/v1/alerts"
+                else:
+                    self.alert_manager_url = alert_manager_url + "/api/v1/alerts"
+
+        if self.cluster is None or \
+                self.alert_manager_url is None and (
+                        self.smtp_url is None or \
+                        self.smtp_from is None or \
+                        self.smtp_auth_name is None or \
+                        self.smtp_auth_pass is None):
+            logger.warning("Notifier not configured")
+
+    def start(self):
+        if not self.running:
+            self.running = True
+            self.thread = threading.Thread(target=self.process, name="notifier")
+            self.thread.start()
+
+    def stop(self):
+        if self.running:
+            self.running = False
+            self.thread.join()
+            self.thread = None
+
+    def notify(self, msg):
+        self.queue.put(msg)
+
+    def process(self):
+        while self.running:
+            try:
+                msg = self.queue.get(block=True, timeout=1) # 1s timeout
+            except Empty:
+                continue
+
+            retry_count = 0
+            sent = False
+
+            while retry_count < 3:
+                if self.send(msg):
+                    sent = True
+                    break
+                time.sleep(0.2)
+                retry_count += 1
+
+            if not sent:
+                logger.error("failed to send out, discard msg: %s", msg)
+
+    def send(self, msg):
+        subject = msg.subject()
+
+        try:
+            if self.alert_manager_url is not None:
+                labels = msg.labels()
+                labels.update({
+                    "alertname": msg.alert_name,
+                    "type": "user_alert",
+                    "cluster": self.cluster,
+                    "user_email": msg.email,
+                    "subject": subject,
+                    })
+
+                resp = requests.post(self.alert_manager_url, timeout=5,
+                        data=json.dumps([{"labels": labels}]))
+                resp.raise_for_status()
+                return True
+            elif self.smtp_url is not None and \
+                    self.smtp_from is not None and \
+                    self.smtp_auth_name is not None and \
+                    self.smtp_auth_pass is not None:
+                smtp_send_email(self.smtp_url, self.smtp_from,
+                        self.smtp_auth_name, self.smtp_auth_pass,
+                        msg.email, subject, msg.body())
+                return True
+            else:
+                # not configured, discard message
+                return True
+        except Exception as e:
+            logger.exception("sending email failed")
+            return False
+
+
+def smtp_send_email(smtp_url, smtp_from, smtp_auth_name, smtp_auth_pass, to, subject, body):
+    msg = "From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n%s" % (smtp_from, to, subject, body)
+    conn = smtplib.SMTP(smtp_url)
+    conn.starttls()
+    conn.login(smtp_auth_name, smtp_auth_pass)
+    conn.sendmail(smtp_from, to, msg)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)
+    notifier = Notifier({"notifier": {"cluster": "local", "alert-manager-url": "http://localhost:9093/alert-manager"}})
+    notifier.start()
+
+    notifier.notify(new_job_state_change_message("dixu@microsoft.com", "job-id", "stopped"))
+    notifier.stop()

--- a/src/utils/notify.py
+++ b/src/utils/notify.py
@@ -56,7 +56,7 @@ class Notifier(object):
         self.alert_manager_url = None
         self.smtp_url = self.smtp_from = self.smtp_auth_name = self.smtp_auth_pass = None
 
-        if "notifier" in config:
+        if config is not None and "notifier" in config:
             notifier_config = config["notifier"]
 
             self.cluster = notifier_config.get("cluster")


### PR DESCRIPTION
Current only notify users when their jobs failed.

Will need to add following config to jobmanager:
```yaml
job-manager:
  notifier:
    cluster: $user_friendly_cluster_name # e.g. Azure-EastUS-V100
    alert-manager-url: $alert_manager_url # e.g. http://localhost:9093/alert-manager
```

This will use alert-manager to send email.

Or add following config to jobmanager to use smtp to send out email directly, if alert-manager was not deployed:
```yaml
job-manager:
  notifier:
    smtp-url: smtp.office365.com:587
    smtp-from: xxx@example.com
    smtp-auth-username: xxx@example.com
    smtp-auth-password: xxxx
```