### PR TITLE
add missing cluster prefix in alert manager

### DIFF
--- a/src/ClusterBootstrap/services/monitor/alert-manager.yaml
+++ b/src/ClusterBootstrap/services/monitor/alert-manager.yaml
@@ -80,7 +80,7 @@ data:
       receiver: alert-email
       group_wait: 30s
       group_interval: 5m
-      group_by: [alertname]
+      group_by: [alertname, cluster]
       routes:
       - receiver: task_user
         repeat_interval: 4h


### PR DESCRIPTION
Current alert email to dltsdri missing cluster name because we did not group cluster. This fix the issue.