### PR TITLE
Refactoring and fix job status

### DIFF
--- a/src/ClusterBootstrap/deploy.py
+++ b/src/ClusterBootstrap/deploy.py
@@ -2831,8 +2831,8 @@ def start_one_kube_service(fname):
             pass
 
     if fname == "./deploy/services/jobmanager/jobmanager.yaml":
-        # recreate the configmap init-user-script
-        run_kubectl( ["create configmap init-user-script --from-file=../Jobs_Templete/init_user.sh -o yaml --dry-run | ./deploy/bin/kubectl apply -f -"] )
+        # recreate the configmap dlws-scripts
+        run_kubectl( ["create configmap dlws-scripts --from-file=../Jobs_Templete/ -o yaml --dry-run | ./deploy/bin/kubectl apply -f -"] )
 
     run_kubectl( ["create", "-f", fname ] )
 

--- a/src/ClusterManager/cluster_manager.py
+++ b/src/ClusterManager/cluster_manager.py
@@ -8,12 +8,13 @@ import time
 
 logger = logging.getLogger(__name__)
 
+
 def create_log(logdir="/var/log/dlworkspace"):
     if not os.path.exists(logdir):
         os.system("mkdir -p " + logdir)
     with open("logging.yaml") as f:
         logging_config = yaml.load(f)
-    logging_config["handlers"]["file"]["filename"] = logdir+"/clustermanager.log"
+    logging_config["handlers"]["file"]["filename"] = logdir + "/clustermanager.log"
     logging.config.dictConfig(logging_config)
 
 
@@ -22,13 +23,13 @@ def Run():
 
     cwd = os.path.dirname(__file__)
     cmds = [
-            ["python", os.path.join(cwd, "job_manager.py")],
-            ["python", os.path.join(cwd, "user_manager.py")],
-            ["python", os.path.join(cwd, "node_manager.py")],
-            ["python", os.path.join(cwd, "joblog_manager.py")],
-            ["python", os.path.join(cwd, "command_manager.py")],
-            ["python", os.path.join(cwd, "endpoint_manager.py")],
-            ]
+        ["python", os.path.join(cwd, "job_manager.py")],
+        ["python", os.path.join(cwd, "user_manager.py")],
+        ["python", os.path.join(cwd, "node_manager.py")],
+        ["python", os.path.join(cwd, "joblog_manager.py")],
+        ["python", os.path.join(cwd, "command_manager.py")],
+        ["python", os.path.join(cwd, "endpoint_manager.py")],
+    ]
 
     FNULL = open(os.devnull, "w")
 
@@ -41,12 +42,11 @@ def Run():
                 if child is not None:
                     logger.info("%s is dead restart it", cmd)
                 try:
-                    childs[i] = subprocess32.Popen(cmd,
-                            stdin=FNULL, close_fds=True)
+                    childs[i] = subprocess32.Popen(cmd, stdin=FNULL, close_fds=True)
                 except Exception as e:
-                    logger.exception("caught exception when trying to start %s, ignore",
-                            cmd)
+                    logger.exception("caught exception when trying to start %s, ignore", cmd)
         time.sleep(60)
+
 
 if __name__ == "__main__":
     sys.exit(Run())

--- a/src/ClusterManager/cluster_manager.py
+++ b/src/ClusterManager/cluster_manager.py
@@ -4,6 +4,7 @@ import os
 import logging
 import logging.config
 import sys
+import time
 
 logger = logging.getLogger(__name__)
 

--- a/src/ClusterManager/command_manager.py
+++ b/src/ClusterManager/command_manager.py
@@ -20,7 +20,6 @@ import yaml
 from jinja2 import Environment, FileSystemLoader, Template
 from config import config, GetStoragePath
 from DataHandler import DataHandler
-from node_manager import create_log
 from node_manager import get_cluster_status
 import base64
 
@@ -41,8 +40,17 @@ def RunCommand(command):
     dataHandler.Close()
     return True
 
+def create_log(logdir = '/var/log/dlworkspace'):
+    if not os.path.exists(logdir):
+        os.system("mkdir -p " + logdir)
+    with open('logging.yaml') as f:
+        logging_config = yaml.full_load(f)
+        f.close()
+        logging_config["handlers"]["file"]["filename"] = logdir+"/command_manager.log"
+        logging.config.dictConfig(logging_config)
 
 def Run():
+    create_log()
     while True:
         try:
             dataHandler = DataHandler()
@@ -58,6 +66,4 @@ def Run():
         time.sleep(1)
 
 if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',
-            level=logging.INFO)
     Run()

--- a/src/ClusterManager/endpoint_manager.py
+++ b/src/ClusterManager/endpoint_manager.py
@@ -151,14 +151,6 @@ def start_endpoint(endpoint):
     create_node_port(endpoint)
 
 
-def is_user_ready(pod_name):
-    bash_script = "bash -c 'ls /dlws/USER_READY'"
-    output = k8sUtils.kubectl_exec("exec %s %s" % (pod_name, " -- " + bash_script))
-    if output == "":
-        return False
-    return True
-
-
 def start_endpoints():
     try:
         data_handler = DataHandler()
@@ -168,8 +160,6 @@ def start_endpoints():
             for endpoint_id, endpoint in pending_endpoints.items():
                 job = data_handler.GetJob(jobId=endpoint["jobId"])[0]
                 if job["jobStatus"] != "running":
-                    continue
-                if not is_user_ready(endpoint["podName"]):
                     continue
 
                 # get endpointDescriptionPath

--- a/src/ClusterManager/endpoint_manager.py
+++ b/src/ClusterManager/endpoint_manager.py
@@ -223,8 +223,19 @@ def cleanup_endpoints():
     except Exception as e:
         logger.exception("close data handler failed")
 
+def create_log(logdir = '/var/log/dlworkspace'):
+    if not os.path.exists(logdir):
+        os.system("mkdir -p " + logdir)
+    with open('logging.yaml') as f:
+        logging_config = yaml.full_load(f)
+        f.close()
+        logging_config["handlers"]["file"]["filename"] = logdir+"/endpoint_manager.log"
+        logging.config.dictConfig(logging_config)
+
 
 def Run():
+    create_log()
+
     while True:
         # start endpoints
         start_endpoints()
@@ -234,8 +245,5 @@ def Run():
         cleanup_endpoints()
         time.sleep(1)
 
-
 if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',
-            level=logging.INFO)
     Run()

--- a/src/ClusterManager/job_deployer.py
+++ b/src/ClusterManager/job_deployer.py
@@ -148,6 +148,6 @@ class JobDeployer:
         else:
             logging.warning("Exec on pod {} failed. cmd: {}, err: {}.".format(pod_name, exec_command, err))
             status_code = int(err["details"]["causes"][0]["message"])
-        output = client.read_channel(STDOUT_CHANNEL) + client.read_channel(STDERR_CHANNEL)
+        output = client.read_all()
         logging.info("Exec on pod {}, status: {}, cmd: {}, output: {}".format(pod_name, status_code, exec_command, output))
         return [status_code, output]

--- a/src/ClusterManager/job_deployer.py
+++ b/src/ClusterManager/job_deployer.py
@@ -60,6 +60,8 @@ class JobDeployer:
             try:
                 self.delete_pod(pod_name)
             except Exception as e:
+                if isinstance(e, ApiException) and 404 == e.status:
+                    return []
                 message = "Delete pod failed: {}".format(pod_name)
                 logging.warning(message, exc_info=True)
                 errors.append({"message": message, "exception": e})

--- a/src/ClusterManager/job_deployer.py
+++ b/src/ClusterManager/job_deployer.py
@@ -58,7 +58,7 @@ class JobDeployer:
         errors = []
         for pod in pods:
             try:
-                pod_name = pod["metadata"]["name"]
+                pod_name = pod.metadata.name
                 self.delete_pod(pod_name)
             except Exception as e:
                 message = "Delete pod failed: {}".format(pod_name)
@@ -70,7 +70,7 @@ class JobDeployer:
         errors = []
         for service in services:
             try:
-                service_name = service["metadata"]["name"]
+                service_name = service.metadata.name
                 self.delete_service(service_name)
             except ApiException as e:
                 message = "Delete service failed: {}".format(service_name)
@@ -108,11 +108,11 @@ class JobDeployer:
         label_selector = "run={}".format(job_id)
 
         # query pods then delete
-        pods = self.get_pod_by_label(label_selector)
+        pods = self.get_pods_by_label(label_selector)
         pod_errors = self.cleanup_pods(pods)
 
         # query services then delete
-        services = self.get_service_by_label(label_selector)
+        services = self.get_services_by_label(label_selector)
         service_errors = self.cleanup_services(services)
 
         errors = pod_errors + service_errors

--- a/src/ClusterManager/job_deployer.py
+++ b/src/ClusterManager/job_deployer.py
@@ -3,6 +3,8 @@ import os
 import logging
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
+from kubernetes.stream import stream
+from kubernetes.stream.ws_client import ERROR_CHANNEL, STDERR_CHANNEL, STDOUT_CHANNEL
 
 
 class JobDeployer:
@@ -115,3 +117,30 @@ class JobDeployer:
 
         errors = pod_errors + service_errors
         return errors
+
+    def pod_exec(self, pod_name, exec_command):
+        logging.info("Exec on pod {}: {}".format(pod_name, exec_command))
+        client = stream(
+            self.v1.connect_get_namespaced_pod_exec,
+            name=pod_name,
+            namespace=self.namespace,
+            command=exec_command,
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+            _preload_content=False,
+        )
+
+        client.run_forever(timeout=60)
+        err = yaml.full_load(client.read_channel(ERROR_CHANNEL))
+        if err["status"] == "Success":
+            status_code = 0
+        else:
+            logging.warning("Exec on pod {} failed: {}".format(pod_name, err))
+            status_code = int(err["details"]["causes"][0]["message"])
+
+        output = client.read_channel(STDOUT_CHANNEL) + client.read_channel(STDERR_CHANNEL)
+
+        logging.info("Exec on pod {}, status: {}, output: {}".format(pod_name, status_code, output))
+        return [status_code, output]

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -242,6 +242,15 @@ def check_job_status(job_id):
 
     return "Running"
 
+def create_log(logdir = '/var/log/dlworkspace'):
+    if not os.path.exists(logdir):
+        os.system("mkdir -p " + logdir)
+    with open('logging.yaml') as f:
+        logging_config = yaml.full_load(f)
+        f.close()
+        logging_config["handlers"]["file"]["filename"] = logdir+"/jobmanager.log"
+        logging.config.dictConfig(logging_config)
+
 
 def JobInfoSorter(elem):
     return elem["sortKey"]
@@ -329,6 +338,7 @@ def TakeJobActions(jobs):
 
 
 def Run():
+    create_log()
 
     while True:
 
@@ -370,7 +380,4 @@ def Run():
 
 
 if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',
-            level=logging.INFO)
     Run()
-    #print k8sUtils.get_pod_events("d493d41c-45ea-4e85-8ca4-01c3533cd727")

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -87,7 +87,7 @@ def SubmitJob(job):
         job_deployer = JobDeployer()
         try:
             pods = job_deployer.create_pods(pods)
-            ret["output"] = "Created pods: {}".format([pod.metedata.name for pod in pods])
+            ret["output"] = "Created pods: {}".format([pod.metadata.name for pod in pods])
         except Exception as e:
             ret["output"] = "Error: %s" % e.message
             logging.error(e, exc_info=True)
@@ -104,7 +104,7 @@ def SubmitJob(job):
         jobMeta["jobPath"] = job_object.job_path
         jobMeta["workPath"] = job_object.work_path
         # the command of the first container
-        jobMeta["LaunchCMD"] = pods[0]["spec"]["containers"][0]["command"]
+        jobMeta["LaunchCMD"] = pods[0].spec.containers[0].command
 
         jobMetaStr = base64.b64encode(json.dumps(jobMeta))
         dataHandler.UpdateJobTextField(job_object.job_id, "jobMeta", jobMetaStr)

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -23,7 +23,6 @@ import yaml
 from jinja2 import Environment, FileSystemLoader, Template
 from config import config, GetStoragePath, GetWorkPath
 from DataHandler import DataHandler
-from node_manager import create_log
 from node_manager import get_cluster_status
 import base64
 from ResourceInfo import ResourceInfo
@@ -148,26 +147,6 @@ def ApproveJob(job):
     return True
 
 
-def AutoApproveJob(job):
-    # TODO: All jobs are currently auto-approved. We need to allow
-    # configuring different policies for different VC.
-    ApproveJob(job)
-
-    # This block is kept here for reference of the original code.
-    # cluster_status = get_cluster_status()
-    # jobUser = getAlias(job["userName"])
-    # jobParams = json.loads(base64.b64decode(job["jobParams"]))
-    # jobGPU = GetJobTotalGpu(jobParams)
-    #
-    # currentGPU = 0
-    # for user in cluster_status["user_status"]:
-    #     if user["userName"] == jobUser:
-    #         currentGPU = int(user["userGPU"])
-    #
-    # if True or currentGPU == 0 or currentGPU + jobGPU <= 4:
-    #     ApproveJob(job)
-
-
 UnusualJobs = {}
 
 
@@ -262,16 +241,6 @@ def check_job_status(job_id):
         return "Pending"
 
     return "Running"
-
-
-def create_log( logdir = '/var/log/dlworkspace' ):
-    if not os.path.exists( logdir ):
-        os.system("mkdir -p " + logdir )
-    with open('logging.yaml') as f:
-        logging_config = yaml.full_load(f)
-        f.close()
-        logging_config["handlers"]["file"]["filename"] = logdir+"/jobmanager.log"
-        logging.config.dictConfig(logging_config)
 
 
 def JobInfoSorter(elem):
@@ -387,7 +356,7 @@ def Run():
                         elif job["jobStatus"] == "scheduling" or job["jobStatus"] == "running":
                             UpdateJobStatus(job)
                         elif job["jobStatus"] == "unapproved":
-                            AutoApproveJob(job)
+                            ApproveJob(job)
                     except Exception as e:
                         logging.info(e)
             except Exception as e:

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -137,7 +137,7 @@ def KillJob(job, desiredState="killed"):
         dataHandler.UpdateJobTextField(job["jobId"], "jobStatus", "error")
         dataHandler.UpdateJobTextField(job["jobId"], "lastUpdated", datetime.datetime.now().isoformat())
         dataHandler.Close()
-        logger.error("Kill job failed with errors: {}".format(errors))
+        logging.error("Kill job failed with errors: {}".format(errors))
         return False
 
 

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -130,10 +130,12 @@ def KillJob(job, desiredState="killed"):
 
     if len(errors) == 0:
         dataHandler.UpdateJobTextField(job["jobId"], "jobStatus", desiredState)
+        dataHandler.UpdateJobTextField(job["jobId"], "lastUpdated", datetime.datetime.now().isoformat())
         dataHandler.Close()
         return True
     else:
         dataHandler.UpdateJobTextField(job["jobId"], "jobStatus", "error")
+        dataHandler.UpdateJobTextField(job["jobId"], "lastUpdated", datetime.datetime.now().isoformat())
         dataHandler.Close()
         logger.error("Kill job failed with errors: {}".format(errors))
         return False

--- a/src/ClusterManager/job_role.py
+++ b/src/ClusterManager/job_role.py
@@ -2,9 +2,7 @@ from job_deployer import JobDeployer
 
 
 class JobRole:
-    # MARK_CONTAINER_READY_FILE = "/dlws/CONTAINER_READY"
-    # MARK_WORKER_READY_FILE = "/dlws/WORKER_READY"
-    MARK_JOB_READY_FILE = "/dlws/JOB_READY"
+    MARK_ROLE_READY_FILE = "/pod/running/ROLE_READY"
 
     @staticmethod
     def get_job_roles(job_id):
@@ -28,7 +26,7 @@ class JobRole:
 
     def status(self):
         """
-        Return role status.
+        Return role status in ["NotFound", "Pending", "Running", "Succeeded", "Failed", "Unknown"]
         It's slightly different from pod phase, when pod is running:
             CONTAINER_READY -> WORKER_READY -> JOB_READY (then the job finally in "Running" status.)
         """
@@ -44,7 +42,7 @@ class JobRole:
 
         # !!! Pod is runing, doesn't mean "Role" is ready and running.
         if(phase == "Running"):
-            if not self.isJobReady():
+            if not self.isRoleReady():
                 return "Pending"
 
         # TODO handle exit status
@@ -56,14 +54,5 @@ class JobRole:
         status_code, _ = deployer.pod_exec(self.pod_name, ["/bin/sh", "-c", "ls -lrt {}".format(file)])
         return status_code == 0
 
-    # def isUserReady(self):
-    #     return self.isFileExisting(JobRole.MARK_USER_READY_FILE)
-
-    # def isWorkerReady(self):
-    #     return self.isFileExisting(JobRole.MARK_WORKER_READY_FILE)
-
-    def isJobReady(self):
-        # only mark job ready on the "ps" or "master" pod
-        if(self.role_name not in ["ps", "master"]):
-            return False
-        return self.isFileExisting(JobRole.MARK_JOB_READY_FILE)
+    def isRoleReady(self):
+        return self.isFileExisting(JobRole.MARK_ROLE_READY_FILE)

--- a/src/ClusterManager/job_role.py
+++ b/src/ClusterManager/job_role.py
@@ -45,8 +45,6 @@ class JobRole:
             if not self.isRoleReady():
                 return "Pending"
 
-        # TODO handle exit status
-
         return phase
 
     def isFileExisting(self, file):

--- a/src/ClusterManager/job_role.py
+++ b/src/ClusterManager/job_role.py
@@ -1,0 +1,69 @@
+from job_deployer import JobDeployer
+
+
+class JobRole:
+    # MARK_CONTAINER_READY_FILE = "/dlws/CONTAINER_READY"
+    # MARK_WORKER_READY_FILE = "/dlws/WORKER_READY"
+    MARK_JOB_READY_FILE = "/dlws/JOB_READY"
+
+    @staticmethod
+    def get_job_roles(job_id):
+        deployer = JobDeployer()
+        pods = deployer.get_pods(label_selector="run={}".format(job_id))
+
+        job_roles = []
+        for pod in pods:
+            pod_name = pod.metadata.name
+            if "distRole" in pod.metadata.labels:
+                role = pod.metadata.labels["distRole"]
+            else:
+                role = "master"
+            job_role = JobRole(role, pod_name)
+            job_roles.append(job_role)
+        return job_roles
+
+    def __init__(self, role_name, pod_name):
+        self.role_name = role_name
+        self.pod_name = pod_name
+
+    def status(self):
+        """
+        Return role status.
+        It's slightly different from pod phase, when pod is running:
+            CONTAINER_READY -> WORKER_READY -> JOB_READY (then the job finally in "Running" status.)
+        """
+        # pod-phase: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+        deployer = JobDeployer()
+        pods = deployer.get_pods(field_selector="metadata.name={}".format(self.pod_name))
+        if(len(pods) < 1):
+            return "NotFound"
+
+        assert(len(pods) == 1)
+        pod = pods[0]
+        phase = pod.status.phase
+
+        # !!! Pod is runing, doesn't mean "Role" is ready and running.
+        if(phase == "Running"):
+            if not self.isJobReady():
+                return "Pending"
+
+        # TODO handle exit status
+
+        return phase
+
+    def isFileExisting(self, file):
+        deployer = JobDeployer()
+        status_code, _ = deployer.pod_exec(self.pod_name, ["/bin/sh", "-c", "ls -lrt {}".format(file)])
+        return status_code == 0
+
+    # def isUserReady(self):
+    #     return self.isFileExisting(JobRole.MARK_USER_READY_FILE)
+
+    # def isWorkerReady(self):
+    #     return self.isFileExisting(JobRole.MARK_WORKER_READY_FILE)
+
+    def isJobReady(self):
+        # only mark job ready on the "ps" or "master" pod
+        if(self.role_name not in ["ps", "master"]):
+            return False
+        return self.isFileExisting(JobRole.MARK_JOB_READY_FILE)

--- a/src/ClusterManager/joblog_manager.py
+++ b/src/ClusterManager/joblog_manager.py
@@ -34,9 +34,9 @@ from DataHandler import DataHandler
 
 logger = logging.getLogger(__name__)
 
-def create_log( logdir = '/var/log/dlworkspace' ):
+def create_log(logdir = '/var/log/dlworkspace'):
     if not os.path.exists( logdir ):
-        os.system("mkdir -p " + logdir )
+        os.system("mkdir -p " + logdir)
     with open('logging.yaml') as f:
         logging_config = yaml.load(f)
         f.close()
@@ -159,6 +159,4 @@ def Run():
         time.sleep(1)
 
 if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',
-            level=logging.INFO)
     Run()

--- a/src/ClusterManager/node_manager.py
+++ b/src/ClusterManager/node_manager.py
@@ -41,9 +41,9 @@ from DataHandler import DataHandler
 
 
 
-def create_log( logdir = '/var/log/dlworkspace' ):
-    if not os.path.exists( logdir ):
-        os.system("mkdir -p " + logdir )
+def create_log(logdir = '/var/log/dlworkspace'):
+    if not os.path.exists(logdir):
+        os.system("mkdir -p " + logdir)
     with open('logging.yaml') as f:
         logging_config = yaml.load(f)
         f.close()
@@ -252,6 +252,4 @@ def Run():
         time.sleep(30)
 
 if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',
-            level=logging.INFO)
     Run()

--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -106,6 +106,10 @@ class PodTemplate():
         local_pod_path = job.get_hostpath(job.job_path, "master")
         params["LaunchCMD"] = PodTemplate.generate_launch_script(params["jobId"], local_pod_path, params["userId"], params["resourcegpu"], params["cmd"])
 
+        if "envs" not in params:
+            params["envs"] =[]
+        params["envs"].append({"name": "DLWS_ROLE_NAME", "value": "master"})
+
         pods = []
         if all(hyper_parameter in params for hyper_parameter in ["hyperparametername", "hyperparameterstartvalue", "hyperparameterendvalue", "hyperparameterstep"]):
             env_name = params["hyperparametername"]
@@ -116,13 +120,12 @@ class PodTemplate():
             for idx, val in enumerate(range(start, end, step)):
                 pod = params.copy()
                 pod["podName"] = "{0}-pod-{1}".format(job.job_id, idx)
-                pod["envs"] = [{"name": env_name, "value": val}]
+                pod["envs"].append({"name": env_name, "value": val})
                 pods.append(pod)
         else:
-                pod = params.copy()
-                pod["podName"] = job.job_id
-                pod["envs"] = []
-                pods.append(pod)
+            pod = params.copy()
+            pod["podName"] = job.job_id
+            pods.append(pod)
 
         k8s_pods = []
         for pod in pods:

--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -19,15 +19,12 @@ class PodTemplate():
         if not os.path.exists(path_to_save):
             mkdirsAsUser(path_to_save, user_id)
 
-        file_name = "launch-%s.sh" % job_id
+        file_name = "job_command.sh"
         launch_script_file = os.path.join(path_to_save, file_name)
         with open(launch_script_file, 'w') as f:
-            f.write("#!/bin/bash -x\n")
-            f.write("mkdir /opt; \n")
-            f.write("echo 'localhost slots=%s' | tee -a /opt/hostfile; \n" % gpu_num)
-            f.write("bash /dlws/init_user.sh &>> /pod/init_user_script.log && runuser -l ${DLWS_USER_NAME} -c '%s'\n" % user_script)
+            f.write(user_script)
         os.system("sudo chown %s %s" % (user_id, launch_script_file))
-        luanch_cmd = "[\"bash\", \"/pod/%s\"]" % file_name
+        luanch_cmd = ["bash", "/pod/scripts/bootstrap.sh"]
         return luanch_cmd
 
     def generate_pod(self, pod):

--- a/src/ClusterManager/test_job_deployer.py
+++ b/src/ClusterManager/test_job_deployer.py
@@ -1,6 +1,9 @@
 import unittest
 import kubernetes
 import yaml
+import string
+import random
+import time
 from kubernetes.client.rest import ApiException
 
 from job_deployer import JobDeployer
@@ -22,13 +25,13 @@ class TestJobDeployer(unittest.TestCase):
         self.assertIsNotNone(job_deployer)
         return job_deployer
 
-    def test_create_pod(self):
+    def create_pod(self, pod_name):
         job_deployer = self.create_job_deployer()
         raw_yaml = """
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-pod
+  name: {}
 spec:
   containers:
   - name: busybox
@@ -36,32 +39,31 @@ spec:
     args:
     - sleep
     - "1000000"
-    """
+    """.format(pod_name)
         body = yaml.full_load(raw_yaml)
 
         # with self.assertRaises(ApiException):
         job_deployer.create_pod(body)
 
     def test_delete_pod(self):
+        pod_name = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(16))
+        self.create_pod(pod_name)
+
         job_deployer = self.create_job_deployer()
 
-        job_deployer.delete_pod("test-pod")
+        job_deployer.delete_pod(pod_name)
 
     def test_cleanup_pods(self):
         job_deployer = self.create_job_deployer()
+        pod_names = ["pod-1", "pod-2"]
 
-        pods = [
-            {"metadata": {"name": "pod-1"}},
-            {"metadata": {"name": "pod-2"}},
-        ]
-
-        job_deployer.cleanup_pods(pods)
+        job_deployer.cleanup_pods(pod_names)
 
     def test_get_pod_by_label(self):
         job_deployer = self.create_job_deployer()
         label_selector = "run=some_job_id"
 
-        pods = job_deployer.get_pods_by_label(label_selector)
+        pods = job_deployer.get_pods(label_selector=label_selector)
 
         self.assertEqual(0, len(pods))
 
@@ -100,13 +102,18 @@ spec:
 
     def test_pod_exec(self):
         job_deployer = self.create_job_deployer()
+
+        pod_name = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(16))
+        self.create_pod(pod_name)
+        time.sleep(3)
+
         exec_command = [
             '/bin/sh',
             '-c',
             'echo This message goes to stderr >&2 && echo This message goes to stdout'
         ]
 
-        status_code, ouput = job_deployer.pod_exec("test-pod", exec_command)
+        status_code, ouput = job_deployer.pod_exec(pod_name, exec_command)
         self.assertEqual(0, status_code)
 
         bad_command = [
@@ -114,7 +121,7 @@ spec:
             '-c',
             'echo This message goes to stderr >&2 && xecho This message goes to stdout; sleep 3; exit 8'
         ]
-        status_code, ouput = job_deployer.pod_exec("test-pod", bad_command)
+        status_code, ouput = job_deployer.pod_exec(pod_name, bad_command)
         self.assertEqual(8, status_code)
 
         bad_command = [
@@ -122,5 +129,7 @@ spec:
             '-c',
             'echo This message goes to stderr >&2 && xecho This message goes to stdout; sleep 3; exit 8'
         ]
-        status_code, ouput = job_deployer.pod_exec("test-pod", bad_command, 1)
+        status_code, ouput = job_deployer.pod_exec(pod_name, bad_command, 1)
         self.assertEqual(-1, status_code)
+
+        job_deployer.delete_pod(pod_name)

--- a/src/ClusterManager/test_job_deployer.py
+++ b/src/ClusterManager/test_job_deployer.py
@@ -47,3 +47,44 @@ spec:
         ]
 
         job_deployer.cleanup_pods(pods)
+
+    def test_get_pod_by_label(self):
+        job_deployer = self.create_job_deployer()
+        label_selector = "run=some_job_id"
+
+        pods = job_deployer.get_pods_by_label(label_selector)
+
+        self.assertEqual(0, len(pods))
+
+    def test_get_services_by_label(self):
+        job_deployer = self.create_job_deployer()
+        label_selector = "run=some_job_id"
+
+        services = job_deployer.get_services_by_label(label_selector)
+
+        self.assertEqual(0, len(services))
+
+    def test_create_endpoint(self):
+        job_deployer = self.create_job_deployer()
+        raw_yaml = """
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+    """
+        body = yaml.full_load(raw_yaml)
+
+        # with self.assertRaises(ApiException):
+        job_deployer.create_service(body)
+
+    def test_delete_service(self):
+        job_deployer = self.create_job_deployer()
+
+        job_deployer.delete_service("test-service")

--- a/src/ClusterManager/test_job_deployer.py
+++ b/src/ClusterManager/test_job_deployer.py
@@ -112,7 +112,15 @@ spec:
         bad_command = [
             '/bin/sh',
             '-c',
-            'echo This message goes to stderr >&2 && xecho This message goes to stdout; exit 8'
+            'echo This message goes to stderr >&2 && xecho This message goes to stdout; sleep 3; exit 8'
         ]
         status_code, ouput = job_deployer.pod_exec("test-pod", bad_command)
         self.assertEqual(8, status_code)
+
+        bad_command = [
+            '/bin/sh',
+            '-c',
+            'echo This message goes to stderr >&2 && xecho This message goes to stdout; sleep 3; exit 8'
+        ]
+        status_code, ouput = job_deployer.pod_exec("test-pod", bad_command, 1)
+        self.assertEqual(-1, status_code)

--- a/src/ClusterManager/test_job_role.py
+++ b/src/ClusterManager/test_job_role.py
@@ -1,0 +1,34 @@
+import unittest
+from job_role import JobRole
+
+
+class TestJobRole(unittest.TestCase):
+
+    def test_status_Running(self):
+        job_role = JobRole("master", "bd3d090a-53b6-4616-9b6c-fe4a86fd68ea-ps0")
+
+        role_status = job_role.status()
+        self.assertEqual("Running", role_status)
+
+    def test_status_NotFound(self):
+        job_role = JobRole("master", "bd3d090a-53b6-4616-9b6c-fe4a86fd68ea-ps0-not-found")
+
+        role_status = job_role.status()
+        self.assertEqual("NotFound", role_status)
+
+    def test_status_Pending(self):
+        # Pod is running, but mark file not existing: JobRole.MARK_POD_READY_FILE
+        job_role = JobRole("master", "nginx-cm7kf")
+
+        role_status = job_role.status()
+        self.assertEqual("Pending", role_status)
+
+    def test_get_job_roles_dist_job(self):
+        job_roles = JobRole.get_job_roles("bd3d090a-53b6-4616-9b6c-fe4a86fd68ea")
+
+        self.assertEqual(3, len(job_roles))
+
+    def test_get_job_roles_regular_job(self):
+        job_roles = JobRole.get_job_roles("8ca7fcdf-c4e7-4687-a3fa-1eeea97415c4")
+
+        self.assertEqual(1, len(job_roles))

--- a/src/ClusterManager/test_pod_template.py
+++ b/src/ClusterManager/test_pod_template.py
@@ -32,7 +32,7 @@ class TestPodTemplate(unittest.TestCase):
         script_file = PodTemplate.generate_launch_script(job_id, path_to_save, user_id, gpu_num, user_script)
 
         # return the container command
-        self.assertEqual('["bash", "/pod/launch-ce7dca49-28df-450a-a03b-51b9c2ecc69c.sh"]', script_file)
+        self.assertListEqual(["bash", "/pod/scripts/bootstrap.sh"], script_file)
 
     def test_pod_template_without_custer_scheduler(self):
         enable_custom_scheduler = False

--- a/src/ClusterManager/user_manager.py
+++ b/src/ClusterManager/user_manager.py
@@ -36,9 +36,9 @@ from DataHandler import DataHandler
 
 
 
-def create_log( logdir = '/var/log/dlworkspace' ):
-    if not os.path.exists( logdir ):
-        os.system("mkdir -p " + logdir )
+def create_log(logdir = '/var/log/dlworkspace'):
+    if not os.path.exists(logdir):
+        os.system("mkdir -p " + logdir)
     with open('logging.yaml') as f:
         logging_config = yaml.load(f)
         f.close()

--- a/src/Jobs_Templete/bootstrap.sh
+++ b/src/Jobs_Templete/bootstrap.sh
@@ -42,4 +42,7 @@ chmod +x /pod/job_command.sh
 runuser -l ${DLWS_USER_NAME} -c /pod/job_command.sh
 # Save exit code
 EXIT_CODE=$?
-echo  `date` ": $EXIT_CODE"  > ${PROC_DIR}/EXIT_CODE
+echo  `date` ": ${EXIT_CODE}"  > ${PROC_DIR}/EXIT_CODE
+
+# exit
+exit ${EXIT_CODE}

--- a/src/Jobs_Templete/bootstrap.sh
+++ b/src/Jobs_Templete/bootstrap.sh
@@ -4,12 +4,12 @@ set -ex
 SCRIPT_DIR=/pod/scripts
 
 # Dir for saving running status
-PROC_DIR=/pod/running
+export PROC_DIR=/pod/running
 rm -rf ${PROC_DIR}
 mkdir -p ${PROC_DIR}
 
 # Dir for logs
-LOG_DIR=/pod/logs
+export LOG_DIR=/pod/logs
 rm -rf ${LOG_DIR}
 mkdir -p ${LOG_DIR}
 
@@ -18,15 +18,22 @@ PID_FILE=${PROC_DIR}/pid
 echo $$ > $PID_FILE
 
 # Setup container
-bash ${SCRIPT_DIR}/init_user.sh &>> ${LOG_DIR}/init_user.log
+bash ${SCRIPT_DIR}/init_user.sh &>> ${LOG_DIR}/bootstrap.log
 touch ${PROC_DIR}/CONTAINER_READY
 
 # Setup roles
-# TODO
+if [ "$DLWS_ROLE_NAME" = "worker" ] || [ "$DLWS_ROLE_NAME" = "ps" ];
+then
+    bash ${SCRIPT_DIR}/setup_sshd.sh &>> ${LOG_DIR}/bootstrap.log
+fi
 touch ${PROC_DIR}/ROLE_READY
 
 # Setup job
-# TODO
+# now only need to setup on "ps"
+if [ "$DLWS_ROLE_NAME" = "ps" ];
+then
+    bash ${SCRIPT_DIR}/setup_ssh_config.sh &>> ${LOG_DIR}/bootstrap.log
+fi
 touch ${PROC_DIR}/JOB_READY
 
 set +e

--- a/src/Jobs_Templete/bootstrap.sh
+++ b/src/Jobs_Templete/bootstrap.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+set -ex
+
+SCRIPT_DIR=/pod/scripts
+
+# Dir for saving running status
+PROC_DIR=/pod/running
+rm -rf ${PROC_DIR}
+mkdir -p ${PROC_DIR}
+
+# Dir for logs
+LOG_DIR=/pod/logs
+rm -rf ${LOG_DIR}
+mkdir -p ${LOG_DIR}
+
+# Save the pid.
+PID_FILE=${PROC_DIR}/pid
+echo $$ > $PID_FILE
+
+# Setup container
+bash ${SCRIPT_DIR}/init_user.sh &>> ${LOG_DIR}/init_user.log
+touch ${PROC_DIR}/CONTAINER_READY
+
+# Setup roles
+# TODO
+touch ${PROC_DIR}/ROLE_READY
+
+# Setup job
+# TODO
+touch ${PROC_DIR}/JOB_READY
+
+set +e
+# Execute user's command for the job
+chmod +x /pod/job_command.sh
+runuser -l ${DLWS_USER_NAME} -c /pod/job_command.sh
+# Save exit code
+EXIT_CODE=$?
+echo  `date` ": $EXIT_CODE"  > ${PROC_DIR}/EXIT_CODE

--- a/src/Jobs_Templete/init_user.sh
+++ b/src/Jobs_Templete/init_user.sh
@@ -5,7 +5,7 @@ set -ex
 #export DLWS_GID=
 #export DLWS_UID=
 #export DLWS_USER_NAME=
-export ENV_FILE=/dlws/pod.env
+export ENV_FILE=/pod/pod.env
 
 # setup user and group, fix permissions
 addgroup --force-badname --gid  ${DLWS_GID} domainusers
@@ -38,6 +38,5 @@ if [ -f ${ENV_FILE} ]; then
 fi
 SCRIPT
 
-touch /dlws/USER_READY
 # any command should run as ${DLWS_USER_NAME}
 #runuser -l ${DLWS_USER_NAME} -c your_commands

--- a/src/Jobs_Templete/init_user.sh
+++ b/src/Jobs_Templete/init_user.sh
@@ -11,8 +11,7 @@ export ENV_FILE=/pod/pod.env
 addgroup --force-badname --gid  ${DLWS_GID} domainusers
 adduser --force-badname --home /home/${DLWS_USER_NAME} --shell /bin/bash --uid ${DLWS_UID}  -gecos '' --gid ${DLWS_GID} --disabled-password ${DLWS_USER_NAME}
 usermod -p $(echo tryme2017 | openssl passwd -1 -stdin) ${DLWS_USER_NAME}
-chown ${DLWS_USER_NAME} /home/${DLWS_USER_NAME}/ /home/${DLWS_USER_NAME}/.profile || /bin/true
-chmod -R 600 /home/${DLWS_USER_NAME}/.ssh || /bin/true
+chown ${DLWS_USER_NAME} /home/${DLWS_USER_NAME}/ /home/${DLWS_USER_NAME}/.profile /home/${DLWS_USER_NAME}/.ssh || /bin/true
 chmod 700 /home/${DLWS_USER_NAME}/.ssh || /bin/true
 
 # setup sudoers

--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -77,9 +77,6 @@ spec:
         memory: job["memoryrequest"]
     {% endif %}
     volumeMounts:
-    - name: "init-user-script"
-      mountPath: /dlws/init_user.sh
-      subPath: init_user.sh
     - name: "dlws-scripts"
       mountPath: /pod/scripts
       readOnly: true
@@ -162,9 +159,6 @@ spec:
 
   restartPolicy: Never
   volumes:
-  - name: "init-user-script"
-    configMap:
-      name: "init-user-script"
   - name: "dlws-scripts"
     configMap:
       name: "dlws-scripts"

--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -80,6 +80,9 @@ spec:
     - name: "init-user-script"
       mountPath: /dlws/init_user.sh
       subPath: init_user.sh
+    - name: "dlws-scripts"
+      mountPath: /pod/scripts
+      readOnly: true
     - name: ssh-volume
       mountPath: /home/{{ job["user"] }}/.ssh
     - name: id-rsa-volume
@@ -162,6 +165,9 @@ spec:
   - name: "init-user-script"
     configMap:
       name: "init-user-script"
+  - name: "dlws-scripts"
+    configMap:
+      name: "dlws-scripts"
   - name: ssh-volume
     emptyDir: {}
   - name: id-rsa-volume

--- a/src/Jobs_Templete/setup_ssh_config.sh
+++ b/src/Jobs_Templete/setup_ssh_config.sh
@@ -1,0 +1,53 @@
+#! /bin/bash
+set -ex
+
+JOB_DIR='/job'
+
+# wait untill all workers are ready
+all_workers_ready=false
+while [ "$all_workers_ready" != true ]
+do
+    # update it to false if any woker is not ready
+    all_workers_ready=true
+
+    for i in $(seq 0 $(( ${DLWS_WORKER_NUM} - 1)) )
+    do
+        worker="worker${i}"
+        file="${JOB_DIR}/${worker}/running/ROLE_READY"
+        #echo $file
+
+        if [ ! -f $file ]; then
+        echo "${worker} not ready!"
+        all_workers_ready=false
+        sleep 10
+        fi
+    done
+done
+
+# setup ~/ssh_config
+SSH_CONFIG_FILE="/home/${DLWS_USER_NAME}/.ssh/config"
+echo > ${SSH_CONFIG_FILE}
+for role_dir in ${JOB_DIR}/*/ # list directories in the form "/JOB_DIR/role/"
+do
+    role_dir=${role_dir%*/} # remove the trailing "/"
+    if [[ $role_dir == *logs ]];
+    then
+        continue
+    fi
+    host=$(basename ${role_dir})
+    port=$(cat "${role_dir}/running/SSH_PORT")
+    ip=$(cat "${role_dir}/running/POD_IP")
+    cat <<EOF >>${SSH_CONFIG_FILE}
+
+Host ${host}
+  HostName ${ip}
+  Port ${port}
+  User ${DLWS_USER_NAME}
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+
+EOF
+    chown ${DLWS_USER_NAME} ${SSH_CONFIG_FILE}
+
+done
+

--- a/src/Jobs_Templete/setup_sshd.sh
+++ b/src/Jobs_Templete/setup_sshd.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+set -ex
+
+function fail {
+  echo $1 >&2
+  exit 1
+}
+
+function retry {
+  local n=1
+  local max=3
+  local delay=3
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed. Attempt $n/$max:"
+        sleep $delay;
+      else
+        fail "The command has failed after $n attempts."
+      fi
+    }
+  done
+}
+
+function setup_sshd {
+    apt-get update && apt-get install -y openssh-server
+
+    # if "DLWS_HOST_NETWORK" enabled, randomly generate port in range: 40000-49999
+    if [ "$DLWS_HOST_NETWORK" = "enable" ];
+    then
+        SSH_PORT=$(( $RANDOM % 10000 + 40000 ))
+        sed -i "s/^Port 22/Port ${SSH_PORT}/" /etc/ssh/sshd_config || exit 1
+    else
+        SSH_PORT=22
+    fi
+    echo "${SSH_PORT}" > ${PROC_DIR}/SSH_PORT
+    echo "${POD_IP}" > ${PROC_DIR}/POD_IP
+
+    service ssh restart || exit 1
+}
+
+retry setup_sshd

--- a/src/docker-images/RestfulAPI/Dockerfile
+++ b/src/docker-images/RestfulAPI/Dockerfile
@@ -27,4 +27,12 @@ ADD Jobs_Templete /DLWorkspace/src/Jobs_Templete
 ADD utils /DLWorkspace/src/utils
 ADD RestAPI /DLWorkspace/src/RestAPI
 ADD ClusterManager /DLWorkspace/src/ClusterManager
+
+# TODO refine later
+# install requirements
+RUN rm -rf /usr/lib/python2.7/dist-packages/yaml
+RUN rm -rf /usr/lib/python2.7/dist-packages/PyYAML-*
+RUN pip install -r /DLWorkspace/src/ClusterManager/requirements.txt
+
+
 CMD /run.sh

--- a/src/utils/k8sUtils.py
+++ b/src/utils/k8sUtils.py
@@ -357,19 +357,6 @@ def GetJobStatus(jobId):
     return output, detail
 
 
-def all_pod_ready(job_id):
-    pods = GetPod("run=" + job_id)
-    logger.info("\n\n\n--------------------------------------------\n\n")
-    logger.info("=======%s", pods)
-    if pods is None:
-        return False
-    if "items" in pods:
-        pod_status = [check_pod_status(pod) for pod in pods["items"]]
-        if any([status != "Running" for status in pod_status]):
-            return False
-    return True
-
-
 def get_node_labels(key):
     url = "%s/api/v1/nodes" % (config["apiserver"])
     responseStr = curl_get(url)


### PR DESCRIPTION
1. Refine job bootstrap script.
All pod execute the same init script: `/pod/scripts/bootstrap.sh`, it executes in four stages:
- [ ] Setup the container, for example, setup user and $HOME.
- [ ] Setup the role, for example, setup ssh server for role `worker`.
- [ ] Setup the job, for example, generate the .ssh/config, generate the /job/hostfile.
- [ ] Execute job command.

2. Pod exit status as the same as the job command.
3. Job status: Job succeed if the `ps` role exit with 0.
4. Unify the status process for dist/regular jobs.
5. Refactoring and misc.

