### PR TITLE
default using localhost as prometheus ip in grafana

### DIFF
--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -23,7 +23,7 @@ default_config_parameters = {
     "job-exporter": { "port": 9102 },
     "node-exporter": { "port": 9100 },
     "watchdog": { "port": 9101 },
-    "grafana": { "port": 3000 },
+    "grafana": { "port": 3000, "prometheus-ip": "localhost" },
     "alert-manager": {
         "port": 9093,
         "configured": False,

--- a/src/ClusterBootstrap/services/monitor/grafana-config/prom-datasource.json
+++ b/src/ClusterBootstrap/services/monitor/grafana-config/prom-datasource.json
@@ -1,6 +1,6 @@
 {
   "name": "PM",
-  "url": "http://{{cnf['prometheus']['host']}}:9091/prometheus",
+  "url": "http://{{cnf['grafana']['prometheus-ip']}}:9091/prometheus",
   "basicAuth": false,
   "access": "proxy",
   "type": "prometheus",


### PR DESCRIPTION
We blocked 9091 visit from within cluster, so to connect to prometheus we should use localhost default. And config grafana.prometheus-ip if prometheus and grafana are not co-located.