### PR TITLE
add per vc gpu usage dashboard

### DIFF
--- a/src/ClusterBootstrap/services/monitor/grafana-config/per-vc-gpu-usage-dashboard.json
+++ b/src/ClusterBootstrap/services/monitor/grafana-config/per-vc-gpu-usage-dashboard.json
@@ -1,0 +1,190 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": null,
+    "links": [],
+    "refresh": "30s",
+    "rows": [
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 0,
+            "id": 1,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(k8s_vc_gpu_total{vc_name=\"$vc_name\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Total",
+                "refId": "A"
+              },
+              {
+                "expr": "sum(k8s_vc_gpu_available{vc_name=\"$vc_name\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Available",
+                "refId": "B"
+              },
+              {
+                "expr": "sum(k8s_vc_gpu_preemptive_availabe{vc_name=\"$vc_name\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Preemptive Available",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Per VC GPU Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "platform",
+            "value": "platform"
+          },
+          "datasource": "PM",
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "vc_name",
+          "options": [],
+          "query": "label_values(k8s_vc_gpu_total, vc_name)",
+          "refresh": 1,
+          "regex": "",
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Per VC Gpu statistic",
+    "version": 0
+  }
+}


### PR DESCRIPTION
Add per vc gpu usage dashboard.

Webportal should change url to `http://$url/dashboard/db/per-vc-gpu-statistic?var-vc_name=$vc_name` where $vc_name should be actual vc name like `vc1` or `platform`.

![image](https://user-images.githubusercontent.com/665253/63249031-2fd94b80-c29b-11e9-93b2-54d47e2ec3a0.png)
