### PR TITLE
adapt k8s 1.15 changes on date

### DIFF
--- a/src/utils/k8sUtils.py
+++ b/src/utils/k8sUtils.py
@@ -31,6 +31,11 @@ from StringIO import StringIO
 
 logger = logging.getLogger(__name__)
 
+def localize_time(date):
+    if type(date) == str:
+        date = datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
+    return pytz.utc.localize(date).isoformat()
+
 def curl_get(url):
     curl = pycurl.Curl()
     curl.setopt(pycurl.URL, url)
@@ -304,14 +309,14 @@ def get_pod_status(pod):
                 ret += ":\n" + containerStatus["state"]["terminated"]["message"]
             podstatus["message"] = ret
             if "finishedAt" in containerStatus["state"]["terminated"]:
-                podstatus["finishedAt"] = pytz.utc.localize(containerStatus["state"]["terminated"]["finishedAt"]).isoformat()
+                podstatus["finishedAt"] = localize_time(containerStatus["state"]["terminated"]["finishedAt"])
 
             if "startedAt" in containerStatus["state"]["terminated"]:
-                podstatus["startedAt"] = pytz.utc.localize(containerStatus["state"]["terminated"]["startedAt"]).isoformat()
+                podstatus["startedAt"] = localize_time(containerStatus["state"]["terminated"]["startedAt"])
         elif "state" in containerStatus and "running" in containerStatus["state"] and "startedAt" in containerStatus["state"]["running"]:
-            podstatus["message"] = "started at: " + pytz.utc.localize(containerStatus["state"]["running"]["startedAt"]).isoformat()
+            podstatus["message"] = "started at: " + localize_time(containerStatus["state"]["running"]["startedAt"])
             if "startedAt" in containerStatus["state"]["running"]:
-                podstatus["startedAt"] = pytz.utc.localize(containerStatus["state"]["running"]["startedAt"]).isoformat()
+                podstatus["startedAt"] = localize_time(containerStatus["state"]["running"]["startedAt"])
 
         if "finishedAt" not in podstatus:
             podstatus["finishedAt"] = datetime.now(get_localzone()).isoformat()


### PR DESCRIPTION
in k8s v1.15 `kubectl get pod -o yaml` will output date as string, whereas in v1.9, it will output as date.