### PR TITLE
support config notifier through config.yaml

### DIFF
--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -31,3 +31,16 @@ webportal_node: {{cnf["webportal_node"]}}
 datasource : {{cnf["datasource"]}}
 kube_custom_scheduler: {{cnf["kube_custom_scheduler"]}}
 WinbindServers: {{cnf["WinbindServers"]}}
+
+{% if cnf["job-manager"] %}
+job-manager:
+  {% if cnf["job-manager"]["notifier"] %}
+  notifier:
+    {% if cnf["job-manager"]["notifier"]["cluster"] %}
+    cluster: {{ cnf["job-manager"]["notifier"]["cluster"] }}
+    {% endif %}
+    {% if cnf["job-manager"]["notifier"]["alert-manager-url"] %}
+    alert-manager-url: {{ cnf["job-manager"]["notifier"]["alert-manager-url"] }}
+    {% endif %}
+  {% endif %}
+{% endif %}


### PR DESCRIPTION
related to #407 
Should config notifier in config.yaml like:

```yaml
job-manager:
  notifier:
    cluster: $user_friendly_cluster_name # e.g. Azure-EastUS-V100
    alert-manager-url: $alert_manager_url # e.g. http://localhost:9093/alert-manager
```

Still relay on config.yaml in infra node. need to push change using `./deploy.py webui` command.