### PR TITLE
support azure blob volume

### DIFF
--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -671,6 +671,7 @@ scriptblocks = {
         "-y kubernetes labels",
         "-y gpulabel",
         "kubernetes start nvidia-device-plugin",
+        "kubernetes start flexvolume",
         "webui",
         "docker push restfulapi",
         "docker push webui",

--- a/src/ClusterBootstrap/scripts/install-blobfuse.sh
+++ b/src/ClusterBootstrap/scripts/install-blobfuse.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+sudo rm -f packages-microsoft-prod.deb
+wget https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+sudo apt-get update
+sudo apt-get install -y blobfuse fuse jq
+sudo rm -f packages-microsoft-prod.deb
+sudo mkdir /etc/kubernetes/volumeplugins
+sed -e 's#ExecStart=/opt/bin/kubelet \\#ExecStart=/opt/bin/kubelet \\\n  --volume-plugin-dir=/etc/kubernetes/volumeplugins \\#g' /etc/systemd/system/kubelet.service > /tmp/newkubelet.service
+sudo mv /tmp/newkubelet.service /etc/systemd/system/kubelet.service
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet

--- a/src/ClusterBootstrap/services/flexvolume/flexvolume.yaml
+++ b/src/ClusterBootstrap/services/flexvolume/flexvolume.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: blobfuse-flexvol-installer
+  namespace: kube-system
+  labels:
+    k8s-app: blobfuse
+spec:
+  selector:
+    matchLabels:
+      name: blobfuse
+  template:
+    metadata:
+      labels:
+        name: blobfuse
+    spec:
+      containers:
+      - name: blobfuse-flexvol-installer
+        image: mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.9
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: volplugins
+          mountPath: /etc/kubernetes/volumeplugins/
+        - name: varlog
+          mountPath: /var/log/
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log/
+      - name: volplugins
+        hostPath:
+          path: /etc/kubernetes/volumeplugins/
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/src/ClusterBootstrap/template/kubelet/kubelet.service.template
+++ b/src/ClusterBootstrap/template/kubelet/kubelet.service.template
@@ -22,6 +22,7 @@ ExecStartPre=/bin/bash -c 'if  lspci | grep -qE "[0-9a-fA-F][0-9a-fA-F]:[0-9a-fA
 # 
 # https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/
 ExecStart=/opt/bin/kubelet \
+  --volume-plugin-dir=/etc/kubernetes/volumeplugins \
   --container-runtime={{'remote' if cnf["kube_custom_cri"] else 'docker'}} \
   --enable-server=true \
   --register-node=true \

--- a/src/ClusterBootstrap/template/kubelet/ubuntu/pre-worker-deploy.sh
+++ b/src/ClusterBootstrap/template/kubelet/ubuntu/pre-worker-deploy.sh
@@ -6,6 +6,7 @@ sudo docker rm -f $(docker ps -a | grep 'k8s_kube\|k8s_POD' | awk '{print $1}')
 sudo mkdir -p /etc/kubernetes
 sudo mkdir -p /etc/kubernetes/manifests
 sudo mkdir -p /etc/kubernetes/ssl/
+sudo mkdir -p /etc/kubernetes/volumeplugins
 sudo mkdir -p /etc/ssl/etcd
 sudo mkdir -p /opt/bin
 sudo mkdir -p /opt/addons/kube-addons

--- a/src/ClusterBootstrap/template/master/kubelet.service
+++ b/src/ClusterBootstrap/template/master/kubelet.service
@@ -15,6 +15,7 @@ ExecStartPre=/bin/bash -c 'if lspci | grep -qE "[0-9a-fA-F][0-9a-fA-F]:[0-9a-fA-
 #
 # https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/
 ExecStart=/opt/bin/kubelet \
+  --volume-plugin-dir=/etc/kubernetes/volumeplugins \
   --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
   --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
   --pod-infra-container-image={{cnf["dockers"]["container"]["podinfra"]["fullname"]}} \

--- a/src/ClusterBootstrap/template/master/ubuntu/pre-master-deploy.sh
+++ b/src/ClusterBootstrap/template/master/ubuntu/pre-master-deploy.sh
@@ -2,6 +2,7 @@ sudo mkdir -p /etc/kubernetes
 sudo mkdir -p /etc/kubernetes/manifests
 sudo mkdir -p /etc/kubernetes/ssl/
 sudo mkdir -p /etc/kubernetes/pki/
+sudo mkdir -p /etc/kubernetes/volumeplugins
 sudo mkdir -p /etc/ssl/etcd
 sudo mkdir -p /opt/addons
 sudo mkdir -p /opt/addons/kube-addons


### PR DESCRIPTION
For existing k8s cluster, admin should execute `./deploy.py runscriptonall scripts/install-blobfuse.sh` and `./deploy.py kubernetes start flexvolume` to enable this feature. Newly created cluster should already enabled this with normal setup procedure.

Already test in k8s v1.15.2. No user job was impacted.

Later admin should create k8s secret for pod to refer:

```
kubectl create secret generic blobfusecreds --from-literal accountname=ACCOUNT-NAME --from-literal accountkey="ACCOUNT-KEY" --type="azure/blobfuse"
```

And pod looks like:

```
apiVersion: v1
kind: Pod
metadata:
  name: nginx-flex-blobfuse
spec:
  containers:
  - name: nginx-flex-blobfuse
    image: nginx
    volumeMounts:
    - name: test
      mountPath: '/data'
  volumes:
  - name: test
    flexVolume:
      driver: "azure/blobfuse"
      readOnly: false
      secretRef:
        name: blobfusecreds
      options:
        container: 'CONTAINER_NAME'
        mountoptions: "--file-cache-timeout-in-seconds=120"
```