### PR TITLE
fix date is none in pod state

### DIFF
--- a/src/utils/k8sUtils.py
+++ b/src/utils/k8sUtils.py
@@ -308,10 +308,10 @@ def get_pod_status(pod):
             if "message" in containerStatus["state"]["terminated"]:
                 ret += ":\n" + containerStatus["state"]["terminated"]["message"]
             podstatus["message"] = ret
-            if "finishedAt" in containerStatus["state"]["terminated"]:
+            if "finishedAt" in containerStatus["state"]["terminated"] and containerStatus["state"]["terminated"]["finishedAt"] is not None:
                 podstatus["finishedAt"] = localize_time(containerStatus["state"]["terminated"]["finishedAt"])
 
-            if "startedAt" in containerStatus["state"]["terminated"]:
+            if "startedAt" in containerStatus["state"]["terminated"] and containerStatus["state"]["terminated"]["startedAt"] is not None:
                 podstatus["startedAt"] = localize_time(containerStatus["state"]["terminated"]["startedAt"])
         elif "state" in containerStatus and "running" in containerStatus["state"] and "startedAt" in containerStatus["state"]["running"]:
             podstatus["message"] = "started at: " + localize_time(containerStatus["state"]["running"]["startedAt"])


### PR DESCRIPTION
```
2019-09-21 02:15:59,072 - WARNING - job_manager.py:492 - 'NoneType' object has no attribute 'tzinfo'
Traceback (most recent call last):
  File "/DLWorkspace/src/ClusterManager/job_manager.py", line 484, in Run
    KillJob(job["jobId"], "killed")
  File "/DLWorkspace/src/ClusterManager/job_manager.py", line 152, in KillJob
    result, detail = k8sUtils.GetJobStatus(job_id)
  File "/DLWorkspace/src/ClusterManager/../utils/k8sUtils.py", line 360, in GetJobStatus
    detail = [get_pod_status(pod) for i, pod in enumerate(podInfo["items"])]
  File "/DLWorkspace/src/ClusterManager/../utils/k8sUtils.py", line 312, in get_pod_status
    podstatus["finishedAt"] = localize_time(containerStatus["state"]["terminated"]["finishedAt"])
  File "/DLWorkspace/src/ClusterManager/../utils/k8sUtils.py", line 37, in localize_time
    return pytz.utc.localize(date).isoformat()
  File "/usr/local/lib/python2.7/dist-packages/pytz/__init__.py", line 231, in localize
    if dt.tzinfo is not None:
AttributeError: 'NoneType' object has no attribute 'tzinfo'
```