### PR TITLE
Increase the prometheus request timeout in gpu reporter

### DIFF
--- a/src/docker-images/gpu-reporter/reporter.py
+++ b/src/docker-images/gpu-reporter/reporter.py
@@ -63,7 +63,7 @@ def walk_json_field_safe(obj, *fields):
         return None
 
 
-def request_with_error_handling(url, timeout=15):
+def request_with_error_handling(url, timeout=60):
     try:
         response = requests.get(url, allow_redirects=True, timeout=timeout)
         response.raise_for_status()


### PR DESCRIPTION
31d prometheus data (with 5min interval) has 8928 datapoints. It takes around 30s to transfer. Increasing the prometheus request timeout in gpu reporter to 60s to guarantee successful data transfer.