### PR TITLE
use readiness probe result to accelerate job role status check

### DIFF
--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -366,7 +366,6 @@ def check_job_status(job_id):
     details = []
     for job_role in job_roles:
         details.append(job_role.pod_details().to_dict())
-    logging.info("Job {}, details: {}".format(job_id, details))
 
     if "Failed" in statuses:
         return "Failed"

--- a/src/ClusterManager/job_role.py
+++ b/src/ClusterManager/job_role.py
@@ -2,6 +2,7 @@ import logging
 import logging.config
 from job_deployer import JobDeployer
 
+log = logging.getLogger(__name__)
 
 class JobRole:
     MARK_ROLE_READY_FILE = "/pod/running/ROLE_READY"
@@ -66,4 +67,11 @@ class JobRole:
         return status_code == 0
 
     def isRoleReady(self):
+        for container in self.pod.spec.containers:
+            if container.name == self.pod_name and container.readiness_probe is not None:
+                for status in self.pod.status.container_statuses:
+                    if status.name == self.pod_name:
+                        log.info("pod %s have readiness_probe result", self.pod_name)
+                        return status.ready
+        # no readiness_probe defined, fallback to old way
         return self.isFileExisting(JobRole.MARK_ROLE_READY_FILE)

--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -109,6 +109,11 @@ spec:
     image: {{ job["image"] }}
     imagePullPolicy: Always
     command: {{ job["LaunchCMD"] }}
+    readinessProbe:
+      exec:
+        command: ["ls", "/pod/running/ROLE_READY"]
+      initialDelaySeconds: 3
+      periodSeconds: 30
     securityContext:
       runAsUser: {{ job["containerUserId"] }}
     {% if job["isPrivileged"] %}


### PR DESCRIPTION
Previous job manager will exec `ls /pod/running/ROLE_READY` in every pod to check if they are ready, this is rather time consuming which will slow loop in job manager.

This PR leverage k8s readiness probe, so that kubelet will execute the command and modify pod readiness, so that job manager can get their readiness in one RPC.

This PR is backward compatible, it will first check if the pod have readiness probe defined, if not, it will fallback to the old way.