### PR TITLE
wrap all verification script together

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,7 @@ steps:
 - script: |
     cd src/ClusterBootstrap/scripts
     CONFIG_TYPE="${CONFIG_TYPE:-cpu}"
+    echo $CONFIG_TYPE
     ./set_config.sh $CONFIG_TYPE
     cd ..
     ./bash_step_by_step_deploy.sh
@@ -30,20 +31,11 @@ steps:
     cd src/ClusterBootstrap/
     USER=$(grep -B3 admin_username cluster.yaml | awk '{print $2}')
     CONFIG_TYPE="${CONFIG_TYPE:-cpu}"
+    WAITMIN="${WAITMIN:-5}"
+    POLLSEC="${POLLSEC:-30}"
+    echo $CONFIG_TYPE $WAITMIN $POLLSEC
     cd scripts
-    ./timed_check.sh 5 30 ./pscp_role.sh worker check_machine.sh /home/${USER}
-    ./timed_check.sh 5 30 ./pssh_role.sh worker \"bash check_machine.sh $CONFIG_TYPE\"
-
-    ./timed_check.sh 5 30 ./check_node_ready.sh infra
-    ./timed_check.sh 5 30 ./pscp_role.sh infra check_docker_ready.sh /home/${USER}
-    ./timed_check.sh 5 30 ./pssh_role.sh infra \"bash ./check_docker_ready.sh infra\"
-
-    ./timed_check.sh 5 30 ./check_node_ready.sh worker
-    ./timed_check.sh 5 30 ./pscp_role.sh worker check_docker_ready.sh /home/${USER}
-    ./timed_check.sh 5 30 ./pssh_role.sh worker \"bash ./check_docker_ready.sh worker\"
-
-    ./timed_check.sh 5 30 ./pssh_role.sh worker \"bash ./check_docker_ready.sh postlbl\"
-    ./timed_check.sh 10 30 ./pssh_role.sh infra \"bash check_docker_ready.sh services\"
+    ./verify_deployment.sh $USER $CONFIG_TYPE $WAITMIN $POLLSEC
   displayName: 'Verify deployment'
 
 - script: |

--- a/src/ClusterBootstrap/scripts/verify_deployment.sh
+++ b/src/ClusterBootstrap/scripts/verify_deployment.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+USER=$1
+CONFIG_TYPE=$2
+waitmin=$3
+pollsec=$4
+echo $USER
+echo $CONFIG_TYPE
+
+./timed_check.sh $waitmin $pollsec ./pscp_role.sh worker check_machine.sh /home/${USER}
+./timed_check.sh $waitmin $pollsec ./pssh_role.sh worker \"bash check_machine.sh $CONFIG_TYPE\"
+./timed_check.sh $waitmin $pollsec ./check_node_ready.sh infra
+./timed_check.sh $waitmin $pollsec ./pscp_role.sh infra check_docker_ready.sh /home/${USER}
+./timed_check.sh $waitmin $pollsec ./pssh_role.sh infra \"bash ./check_docker_ready.sh infra\"
+./timed_check.sh $waitmin $pollsec ./check_node_ready.sh worker
+./timed_check.sh $waitmin $pollsec ./pscp_role.sh worker check_docker_ready.sh /home/${USER}
+./timed_check.sh $waitmin $pollsec ./pssh_role.sh worker \"bash ./check_docker_ready.sh worker\"
+./timed_check.sh $waitmin $pollsec ./pssh_role.sh worker \"bash ./check_docker_ready.sh postlbl\"
+./timed_check.sh $waitmin $pollsec ./pssh_role.sh infra \"bash check_docker_ready.sh services\"


### PR DESCRIPTION
wrap all verification script into a single one and use "set -e" so the CI build would fail as long as any one of those steps failed. support configurable waiting time and polling frequency