### PR TITLE
change gpu accouting in job_manager

### DIFF
--- a/src/ClusterManager/node_manager.py
+++ b/src/ClusterManager/node_manager.py
@@ -141,7 +141,7 @@ def get_cluster_status():
 
                 if "status" in node and "conditions" in node["status"]:
                     for condi in node["status"]["conditions"]:
-                        if "type" in condi and condi["type"] == "Ready" and "status" in condi and condi["status"] == "Unknown":
+                        if "type" in condi and condi["type"] == "Ready" and "status" in condi and condi["status"] != "True":
                             node_status["unschedulable"] = True
 
                 nodes_status[node_status["name"]] = node_status
@@ -198,7 +198,6 @@ def get_cluster_status():
         gpu_reserved    = ResourceInfo()
         gpu_capacity = ResourceInfo()
         gpu_unschedulable = ResourceInfo()
-        gpu_schedulable = ResourceInfo()
         gpu_used = ResourceInfo()
 
         for node_name, node_status in nodes_status.iteritems():
@@ -207,7 +206,6 @@ def get_cluster_status():
                 gpu_reserved.Add(ResourceInfo.Difference(ResourceInfo(node_status["gpu_capacity"]), ResourceInfo(node_status["gpu_used"])))
             else:
                 gpu_avaliable.Add(ResourceInfo.Difference(ResourceInfo(node_status["gpu_allocatable"]), ResourceInfo(node_status["gpu_used"])))
-                gpu_schedulable.Add(ResourceInfo(node_status["gpu_capacity"]))
                 gpu_unschedulable.Add(ResourceInfo.Difference(ResourceInfo(node_status["gpu_capacity"]), ResourceInfo(node_status["gpu_allocatable"])))
                 gpu_reserved.Add(ResourceInfo.Difference(ResourceInfo(node_status["gpu_capacity"]), ResourceInfo(node_status["gpu_allocatable"])))
 

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -531,7 +531,7 @@ def GetVC(userName, vcName):
                         user_status[username].Add(ResourceInfo({jobParam["gpuType"] : GetJobTotalGpu(jobParam)}))
 
             vcReservedRes = clusterReservedRes.GetFraction(vc_quota, vc_quota_sum)
-            vcAvailableRes = ResourceInfo.Difference(ResourceInfo.Difference(vc_quota, vcConsumedRes), vcReservedRes)
+            vcAvailableRes = ResourceInfo.Difference(ResourceInfo.Difference(vcTotalRes, vcConsumedRes), vcReservedRes)
 
             vc["gpu_capacity"] = vcTotalRes.ToSerializable()
             vc["gpu_used"] = vcConsumedRes.ToSerializable()

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -504,9 +504,18 @@ def GetVC(userName, vcName):
     user_status = {}
 
     vcList =  DataManager.ListVCs()
+
+    vc_quota_sum = ResourceInfo()
+
+    for vc in vcList:
+        vc_quota_sum.Add(ResourceInfo(json.loads(vc["quota"])))
+
     for vc in vcList:
         if vc["vcName"] == vcName and AuthorizationManager.HasAccess(userName, ResourceType.VC, vcName, Permission.User):
-            vcTotalRes = ResourceInfo(json.loads(vc["quota"]))
+            vc_quota = ResourceInfo(json.loads(vc["quota"]))
+
+            vcTotalRes = clusterTotalRes.GetFraction(vc_quota, vc_quota_sum)
+
             vcConsumedRes = ResourceInfo()
             jobs = DataManager.GetAllPendingJobs(vcName)
             num_active_jobs = 0
@@ -521,8 +530,8 @@ def GetVC(userName, vcName):
                             user_status[username] = ResourceInfo()
                         user_status[username].Add(ResourceInfo({jobParam["gpuType"] : GetJobTotalGpu(jobParam)}))
 
-            vcReservedRes = clusterReservedRes.GetFraction(vcTotalRes, clusterTotalRes)
-            vcAvailableRes = ResourceInfo.Difference(ResourceInfo.Difference(vcTotalRes, vcConsumedRes), vcReservedRes)
+            vcReservedRes = clusterReservedRes.GetFraction(vc_quota, vc_quota_sum)
+            vcAvailableRes = ResourceInfo.Difference(ResourceInfo.Difference(vc_quota, vcConsumedRes), vcReservedRes)
 
             vc["gpu_capacity"] = vcTotalRes.ToSerializable()
             vc["gpu_used"] = vcConsumedRes.ToSerializable()


### PR DESCRIPTION
Total GPU will show total cluster capacity reported by k8s * VC quota / sum(VC quota). It will vary.
 
Used GPU will show number of GPUs used by this VC.
 
Reserved GPU will show number of unschedulable GPUs in the cluster * VC quota / sum(VC quota).
 
Available GPU will show Total GPU – Used GPU – Reserved GPU.