### PR TITLE
fix a crash

### DIFF
--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -179,7 +179,9 @@ def UpdateJobStatus(launcher, job, notifier=None, dataHandlerOri=None):
     localJobPath = os.path.join(config["storage-mount-path"], jobPath)
     logPath = os.path.join(localJobPath, "logs/joblog.txt")
 
-    jobDescriptionPath = os.path.join(config["storage-mount-path"], job["jobDescriptionPath"]) if "jobDescriptionPath" in job else None
+    jobDescriptionPath = None
+    if "jobDescriptionPath" in job and job["jobDescriptionPath"] is not None:
+        jobDescriptionPath = os.path.join(config["storage-mount-path"], job["jobDescriptionPath"])
     if "userId" not in jobParams:
         jobParams["userId"] = "0"
 


### PR DESCRIPTION
```
2019-10-16 03:30:33,653 - WARNING - job_manager.py:537 - 'NoneType' object has no attribute 'startswith'
Traceback (most recent call last):
  File "/DLWorkspace/src/ClusterManager/job_manager.py", line 532, in Run
    UpdateJobStatus(job, notifier,dataHandlerOri = dataHandler)
  File "/DLWorkspace/src/ClusterManager/job_manager.py", line 259, in UpdateJobStatus
    jobDescriptionPath = os.path.join(config["storage-mount-path"], job["jobDescriptionPath"]) if "jobDescriptionPath" in job else None
  File "/usr/lib/python2.7/posixpath.py", line 68, in join
    if b.startswith('/'):
AttributeError: 'NoneType' object has no attribute 'startswith'
```