### PR TITLE
Support infiniband for distributed jobs in clusters with infiniband

### DIFF
--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -829,4 +829,6 @@ scriptblocks = {
         "docker push gobld",
         "docker push kubernetes",
     ],
+
+    "infiniband_mounts": []
 }

--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -50,3 +50,5 @@ job-manager:
     {% endif %}
   {% endif %}
 {% endif %}
+
+infiniband_mounts: {{cnf["infiniband_mounts"]}}

--- a/src/ClusterManager/dist_pod_template.py
+++ b/src/ClusterManager/dist_pod_template.py
@@ -107,6 +107,7 @@ class DistPodTemplate():
         job.add_mountpoints(job.work_path_mountpoint())
         job.add_mountpoints(job.data_path_mountpoint())
         job.add_mountpoints(job.vc_storage_mountpoints())
+        job.add_mountpoints(job.infiniband_mountpoints())
         params["mountpoints"] = job.mountpoints
 
         params["user_email"] = params["userName"]


### PR DESCRIPTION
In `config.yaml`, add IB devices to mount, e.g.
```
infiniband_mounts:
  - name: rdma-cm
    hostPath: /dev/infiniband/rdma_cm
    containerPath: /dev/infiniband/rdma_cm
  - name: ib-uverbs0
    hostPath: /dev/infiniband/uverbs0
    containerPath: /dev/infiniband/uverbs0
  - name: ib-issm0
    hostPath: /dev/infiniband/issm0
    containerPath: /dev/infiniband/issm0
  - name: ib-umad0
    hostPath: /dev/infiniband/umad0
    containerPath: /dev/infiniband/umad0
```
