### PR TITLE
[Hold] Make inference job pods preemptable

### DIFF
--- a/src/Jobs_Templete/deployment.yaml.template
+++ b/src/Jobs_Templete/deployment.yaml.template
@@ -167,3 +167,5 @@ spec:
       - name: dshm
         emptyDir:
           medium: Memory
+
+      priorityClassName: inference-job-priority

--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -262,3 +262,4 @@ spec:
   - name: dshm
     emptyDir:
       medium: Memory
+  priorityClassName: job-priority


### PR DESCRIPTION
Other tasks:

Create 2 PriorityClass in kubernetes:

```shell
kubectl create priorityclass job-priority --value=1000 --description="job pod priority"
kubectl create priorityclass inference-job-priority --value=100 --description="inference job priority"
```

These should be set up during upgrading / *installing*(will look for a place in deploy script to put)
