### PR TITLE
Support existing storage mounts

### DIFF
--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -830,5 +830,6 @@ scriptblocks = {
         "docker push kubernetes",
     ],
 
-    "infiniband_mounts": []
+    "infiniband_mounts": [],
+    "custom_mounts": []
 }

--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -52,3 +52,4 @@ job-manager:
 {% endif %}
 
 infiniband_mounts: {{cnf["infiniband_mounts"]}}
+custom_mounts: {{cnf["custom_mounts"]}}

--- a/src/ClusterManager/dist_pod_template.py
+++ b/src/ClusterManager/dist_pod_template.py
@@ -106,6 +106,7 @@ class DistPodTemplate():
             job.add_mountpoints(params["mountpoints"])
         job.add_mountpoints(job.work_path_mountpoint())
         job.add_mountpoints(job.data_path_mountpoint())
+        job.add_mountpoints(job.vc_custom_storage_mountpoints())
         job.add_mountpoints(job.vc_storage_mountpoints())
         job.add_mountpoints(job.infiniband_mountpoints())
         params["mountpoints"] = job.mountpoints

--- a/src/ClusterManager/job.py
+++ b/src/ClusterManager/job.py
@@ -128,6 +128,7 @@ class Job:
             if vc is None or vc != vc_name:
                 continue
             if name is None or host_path is None or container_path is None:
+                logging.warn("Ignore invalid mount %s" % mount)
                 continue
             vc_mount = {
                 "name": name,

--- a/src/ClusterManager/job.py
+++ b/src/ClusterManager/job.py
@@ -79,10 +79,11 @@ class Job:
             mountpoint["name"] = mountpoint["containerPath"]
         mountpoint["name"] = ''.join(c for c in mountpoint["name"] if c.isalnum() or c == "-")
 
-        # skip dulicate entry
+        # skip duplicate entry
+        # NOTE: mountPath "/data" is the same as "data" in k8s
         for item in self.mountpoints:
-            if item["name"] == mountpoint["name"] or item["containerPath"] == mountpoint["containerPath"]:
-                logging.warn("Duplciate mountpoint: %s" % mountpoint)
+            if item["name"] == mountpoint["name"] or item["containerPath"].strip("/") == mountpoint["containerPath"].strip("/"):
+                logging.warn("Current mountpoint: %s is a duplicate of mountpoint: %s" % (mountpoint, item))
                 return
 
         self.mountpoints.append(mountpoint)
@@ -111,6 +112,32 @@ class Job:
         assert(self.data_path is not None)
         data_host_path = os.path.join(self.cluster["storage-mount-path"], "storage", self.data_path)
         return {"name": "data", "containerPath": "/data", "hostPath": data_host_path, "enabled": True}
+
+    def vc_custom_storage_mountpoints(self):
+        vc_name = self.params["vcName"]
+        custom_mounts = self.get_custom_mounts()
+        if not isinstance(custom_mounts, list):
+            return None
+
+        vc_custom_mounts = []
+        for mount in custom_mounts:
+            name = mount.get("name")
+            container_path = mount.get("containerPath")
+            host_path = mount.get("hostPath")
+            vc = mount.get("vc")
+            if vc is None or vc != vc_name:
+                continue
+            if name is None or host_path is None or container_path is None:
+                continue
+            vc_mount = {
+                "name": name,
+                "containerPath": container_path,
+                "hostPath": host_path,
+                "enabled": True
+            }
+            vc_custom_mounts.append(vc_mount)
+
+        return vc_custom_mounts
 
     def vc_storage_mountpoints(self):
         vc_name = self.params["vcName"]
@@ -179,6 +206,9 @@ class Job:
             return None
         # TODO why random.choice?
         return random.choice(racks)
+
+    def get_custom_mounts(self):
+        return self._get_cluster_config("custom_mounts")
 
     def get_infiniband_mounts(self):
         return self._get_cluster_config("infiniband_mounts")

--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -100,6 +100,7 @@ class PodTemplate():
             job.add_mountpoints(params["mountpoints"])
         job.add_mountpoints(job.work_path_mountpoint())
         job.add_mountpoints(job.data_path_mountpoint())
+        job.add_mountpoints(job.vc_custom_storage_mountpoints())
         job.add_mountpoints(job.vc_storage_mountpoints())
         params["mountpoints"] = job.mountpoints
 


### PR DESCRIPTION
Consolidate all existing storage mountpoints (that do not conform with VC storage setup rule) in `config.yaml` for backward compatibility:
```
custom_mounts:
  - name: platform-stor0
    hostPath: /dlwsdata/stor0
    containerPath: /data0-platform
    vc: platform
  - name: platform-stor0-old
    hostPath: /dlwsdata/stor0
    containerPath: /stor0
    vc: platform
  - name: platform-stor0-ignore
    hostPath: /dlwsdata/stor0
    containerPath: /stor0-ignore
```