### PR TITLE
Add lock for cache

### DIFF
--- a/src/dev-utils/cache_race_repro.py
+++ b/src/dev-utils/cache_race_repro.py
@@ -1,0 +1,61 @@
+import time
+import hashlib
+import argparse
+import os
+import sys
+import random
+import logging
+
+from cachetools import cached, TTLCache
+from threading import Lock, Thread
+
+
+NUM_THREADS = 4
+if os.getenv("NUM_THREADS"):
+   NUM_THREADS = int(os.getenv("NUM_THREADS"))
+
+NUM_RUNS = 100
+if os.getenv("NUM_RUNS"):
+   NUM_THREADS = int(os.getenv("NUM_RUNS"))
+
+LOCK = None
+if os.getenv("LOCK_CACHE"):
+   LOCK = Lock()
+
+KEYS = ["key%s" % str(i) for i in range(8)]
+
+@cached(cache=TTLCache(maxsize=4, ttl=1), lock=LOCK)
+def generate(key):
+   return hashlib.md5((str(key) + str(time.time())).encode())
+
+
+def run(worker_id):
+   i = 0
+   while i < NUM_RUNS:
+      key = KEYS[random.randint(0, 7)]
+      value = generate(key)
+      logging.info("Worker %s run %s (%s, %s)" % (worker_id, i, key, value))
+      time.sleep(0.1)
+      i += 1
+
+
+def main():
+   threads = []
+   for i in range(NUM_THREADS):
+      t = Thread(target=run, args=(i,))
+      threads.append(t)
+      t.start()
+
+   for t in threads:
+      t.join()
+
+if __name__ == "__main__":
+   root = logging.getLogger()
+   root.setLevel(logging.INFO)
+   handler = logging.StreamHandler(sys.stdout)
+   handler.setLevel(logging.INFO)
+   formatter = logging.Formatter("[%(levelname)s %(asctime)s] %(message)s")
+   handler.setFormatter(formatter)
+   root.addHandler(handler)
+
+   main()

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -29,6 +29,7 @@ import quota
 import copy
 import logging
 from cachetools import cached, TTLCache
+from threading import Lock
 
 
 DEFAULT_JOB_PRIORITY = 100
@@ -532,7 +533,7 @@ def AddVC(userName, vcName, quota, metadata):
     return ret
 
 
-@cached(cache=TTLCache(maxsize=81920, ttl=300))
+@cached(cache=TTLCache(maxsize=10240, ttl=1800), lock=Lock())
 def ListVCs(userName):
     ret = []
     vcList =  DataManager.ListVCs()

--- a/src/utils/authorization.py
+++ b/src/utils/authorization.py
@@ -29,7 +29,7 @@ INVALID_INFO = {
 }
 
 
-DEFAULT_EXPIRATION = 5 * 60
+DEFAULT_EXPIRATION = 30 * 60
 
 
 # TODO: Replace with TTLCache in cachetools after refactoring


### PR DESCRIPTION
In the code, Flask app uses `threaded` option to handle client requests concurrently. When multiple threads are accessing (potentially invalidating) the cache concurrently, race occurs that results in `KeyError`. This is reproducible by running `src/dev-utils/cache_race_repro.py` several times. Adding a lock, however, resolves the issue.
```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "cache_race_repro.py", line 36, in run
    value = generate(key)
  File "/usr/local/lib/python2.7/dist-packages/cachetools/__init__.py", line 48, in wrapper
    cache[k] = v
  File "/usr/local/lib/python2.7/dist-packages/cachetools/ttl.py", line 95, in __setitem__
    cache_setitem(self, key, value)
  File "/usr/local/lib/python2.7/dist-packages/cachetools/cache.py", line 52, in __setitem__
    self.popitem()
  File "/usr/local/lib/python2.7/dist-packages/cachetools/ttl.py", line 209, in popitem
    return (key, self.pop(key))
  File "/usr/local/lib/python2.7/dist-packages/cachetools/ttl.py", line 191, in pop
    return Cache.pop(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/cachetools/abc.py", line 39, in pop
    raise KeyError(key)
KeyError: ('key6',)
```