### PR TITLE
use redis to save job status info

### DIFF
--- a/src/ClusterBootstrap/services/jobmanager/jobmanager.yaml
+++ b/src/ClusterBootstrap/services/jobmanager/jobmanager.yaml
@@ -80,6 +80,14 @@ spec:
           tcpSocket:
             port: 9200
           timeoutSeconds: 10
+      - name: redis
+        image: redis:5.0.6-alpine
+        command: ["redis-server", "--port", "9300", "--maxmemory", "100mb", "--maxmemory-policy", "allkeys-lru"]
+        ports:
+        - containerPort: 9300
+          hostPort: 9300
+          name: redis-port
+          protocol: TCP
       volumes:
       - name: certs
         hostPath:

--- a/src/ClusterManager/requirements.txt
+++ b/src/ClusterManager/requirements.txt
@@ -4,3 +4,4 @@ PyYAML>=5.1.1
 prometheus-client==0.7.1
 twisted==19.2.1
 cachetools==3.1.1
+redis==3.2.1


### PR DESCRIPTION
future refactoring may split jobmanager into several process. use redis as LRU cache and inter-process storage to save job timing data.