### PR TITLE
Inference job: add soft podAffinity to deployment

### DIFF
--- a/src/Jobs_Templete/deployment.yaml.template
+++ b/src/Jobs_Templete/deployment.yaml.template
@@ -22,11 +22,25 @@ spec:
   replicas: {{ job["deployment_replicas"] }}
   selector:
     matchLabels:
+      jobId: {{ job["jobId"] }}
       worker: active
   template:
     metadata:
       labels:
+        jobId: {{ job["jobId"] }}
         worker: active
+    affinity:
+      podAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: jobId
+                operator: In
+                values:
+                - {{ job["jobId"] }}
+            topologyKey: kubernetes.io/hostname
     spec:
       containers:
       - name: {{ job["podName"] }}-deployment


### PR DESCRIPTION
Current test result:

Using hard affinity, all pods will be scheduled to one node, until not enough resources.

Using soft affinity, the first 2 pods will be scheduled to the node with the master pod, the 3rd and latter pods will be scheduled to other nodes until all nodes have 2 pods.