### PR TITLE
Dashboard API: increase max-http-header-size to 64KB

### DIFF
--- a/src/dashboard/Dockerfile
+++ b/src/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:dubnium
+FROM node:erbium
 
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app

--- a/src/dashboard/Dockerfile
+++ b/src/dashboard/Dockerfile
@@ -3,6 +3,8 @@ FROM node:erbium
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
 
+ENV NODE_OPTIONS --max-http-header-size=65536
+
 COPY package.json yarn.lock ./
 RUN yarn --frozen-lockfile
 


### PR DESCRIPTION
Ref: https://nodejs.org/dist/latest-v12.x/docs/api/cli.html#cli_max_http_header_size_size