### PR TITLE
Dashboard/https support

### DIFF
--- a/src/dashboard/README.md
+++ b/src/dashboard/README.md
@@ -8,7 +8,14 @@ DLTS dashboard is using [config](https://npmjs.com/package/config) to maintain c
 
 The configuration schema (with description) is maintained in [config.schema.json](./server/api/validator/config.schema.json).
 
-## Local development
+## Environment Variables
+
+- `HOST` the host of server listening, default `::` (IPv6) or `0.0.0.0` (IPv4).
+- `PORT` the port of server listening, default `3000`.
+- `SSL_KEY` the SSL/TLS private key file for HTTPS / HTTP2 support.
+- `SSL_CERT` the SSL/TLS certificate file for HTTPS / HTTP2 support.
+
+## Local Development
 
 1. Install [Node.js](https://nodejs.org/), version 10 is recommended.
 2. Install [Yarn](https://yarnpkg.com/) for package maintaince.

--- a/src/dashboard/server/index.js
+++ b/src/dashboard/server/index.js
@@ -14,14 +14,14 @@ if (require.main === module) {
   const {
     HOST,
     PORT = 3000,
-    TLS_KEY,
-    TLS_CERT
+    SSL_KEY,
+    SSL_CERT
   } = process.env
 
-  const server = TLS_KEY && TLS_CERT
+  const server = SSL_KEY && SSL_CERT
     ? https.createServer({
-      key: fs.readFileSync(TLS_KEY),
-      cert: fs.readFileSync(TLS_CERT)
+      key: fs.readFileSync(SSL_KEY),
+      cert: fs.readFileSync(SSL_CERT)
     })
     : http.createServer()
 

--- a/src/dashboard/server/index.js
+++ b/src/dashboard/server/index.js
@@ -7,5 +7,24 @@ app.use(mount('/api', require('./api')))
 app.use(require('./frontend'))
 
 if (require.main === module) {
-  app.listen(process.env.PORT || 3000, process.env.HOST)
+  const http = require('http')
+  const https = require('https')
+  const fs = require('fs')
+
+  const {
+    HOST,
+    PORT = 3000,
+    TLS_KEY,
+    TLS_CERT
+  } = process.env
+
+  const server = TLS_KEY && TLS_CERT
+    ? https.createServer({
+      key: fs.readFileSync(TLS_KEY),
+      cert: fs.readFileSync(TLS_CERT)
+    })
+    : http.createServer()
+
+  server.on('request', app.callback())
+  server.listen(PORT, HOST)
 }

--- a/src/dashboard/server/index.js
+++ b/src/dashboard/server/index.js
@@ -8,7 +8,7 @@ app.use(require('./frontend'))
 
 if (require.main === module) {
   const http = require('http')
-  const https = require('https')
+  const http2 = require('http2')
   const fs = require('fs')
 
   const {
@@ -19,7 +19,8 @@ if (require.main === module) {
   } = process.env
 
   const server = SSL_KEY && SSL_CERT
-    ? https.createServer({
+    ? http2.createSecureServer({
+      allowHTTP1: true,
       key: fs.readFileSync(SSL_KEY),
       cert: fs.readFileSync(SSL_CERT)
     })


### PR DESCRIPTION
Background: Azure AD auth does not support HTTP redirect URI for newly created applications. So we need to enable HTTPS scheme to make it works with newer applications.