### PR TITLE
let prometheus ignore redis port

### DIFF
--- a/src/ClusterBootstrap/services/jobmanager/jobmanager.yaml
+++ b/src/ClusterBootstrap/services/jobmanager/jobmanager.yaml
@@ -98,7 +98,7 @@ spec:
         ports:
         - containerPort: 9300
           hostPort: 9300
-          name: redis-port
+          name: prom-ign-redis
           protocol: TCP
       volumes:
       - name: certs

--- a/src/ClusterBootstrap/services/monitor/prometheus.yaml
+++ b/src/ClusterBootstrap/services/monitor/prometheus.yaml
@@ -37,6 +37,9 @@ data:
           replacement: ${1}:${2}
           action: replace
           target_label: __address__
+        - source_labels: [__meta_kubernetes_pod_container_port_name]
+          regex: 'prom-ign-.*'
+          action: drop
         - source_labels: [__meta_kubernetes_pod_name]
           action: replace
           target_label: scraped_from


### PR DESCRIPTION
fix log from redis:

```
Possible SECURITY ATTACK detected. It looks like somebody is sending POST or Host: commands to Redis. This is likely due to an attacker attempting to use Cross Protocol Scripting to compromise your Redis instance. Connection aborted.

```