### PR TITLE
pull shorter logs

### DIFF
--- a/src/ClusterManager/joblog_manager.py
+++ b/src/ClusterManager/joblog_manager.py
@@ -51,7 +51,7 @@ def extract_job_log(jobId,logPath,userId):
     try:
         dataHandler = DataHandler()
 
-        logs = k8sUtils.GetLog(jobId)
+        logs = k8sUtils.GetLog(jobId, tail=3000)
 
         # Do not overwrite existing logs with empty log
         # DLTS bootstrap will generate logs for all containers.

--- a/src/utils/k8sUtils.py
+++ b/src/utils/k8sUtils.py
@@ -178,7 +178,7 @@ def GetPod(selector):
     return podInfo
 
 
-def GetLog(jobId):
+def GetLog(jobId, tail=None):
     # assume our job only one container per pod.
 
     selector = "run=" + jobId
@@ -194,7 +194,10 @@ def GetLog(jobId):
                 if "status" in item and "containerStatuses" in item["status"] and "containerID" in item["status"]["containerStatuses"][0]:
                     containerID = item["status"]["containerStatuses"][0]["containerID"].replace("docker://", "")
                     log["containerID"] = containerID
-                    log["containerLog"] = kubectl_exec(" logs " + log["podName"])
+                    if tail is not None:
+                        log["containerLog"] = kubectl_exec(" logs %s --tail=%s" % (log["podName"], str(tail)))
+                    else:
+                        log["containerLog"] = kubectl_exec(" logs " + log["podName"])
                     logs.append(log)
     return logs
 


### PR DESCRIPTION
joblog_manager hanging in pulling logs from jobs with a lot of output, and then later discard most of them. This will shorter the time spent.