### PR TITLE
Add SKU meta section to support scheduling on CPU machines

### DIFF
--- a/src/ClusterBootstrap/deploy.py
+++ b/src/ClusterBootstrap/deploy.py
@@ -2901,7 +2901,7 @@ def kubernetes_label_cpuworker():
     sku_meta = get_sku_meta(config)
     workers = get_machines_by_roles("worker", config)
 
-    for machine_name, machine_info in workers:
+    for machine_name, machine_info in workers.items():
         if "sku" in machine_info and machine_info["sku"] in sku_meta:
             sku = machine_info["sku"]
             if "gpu" not in sku_meta[sku]:
@@ -2913,7 +2913,7 @@ def kubernetes_label_sku():
     sku_meta = get_sku_meta(config)
     machines = get_machines_by_roles("all", config)
 
-    for machine_name, machine_info in machines:
+    for machine_name, machine_info in machines.items():
         if "sku" in machine_info and machine_info["sku"] in sku_meta:
             sku = machine_info["sku"]
             kubernetes_label_node("--overwrite", machine_name, "sku=%s" % sku)

--- a/src/ClusterBootstrap/deploy.py
+++ b/src/ClusterBootstrap/deploy.py
@@ -2834,14 +2834,6 @@ def kubernetes_label_GpuTypes():
             kubernetes_label_node("--overwrite", nodename, "gpuType="+nodeInfo["gpu-type"])
 
 
-# Label kubernetes nodes with custom node labels defined for each node under "custom_node_labels"
-def kubernetes_label_custom_node_labels():
-    for nodename, nodeinfo in config["machines"].items():
-        if "custom_node_labels" in nodeinfo:
-            for nodelabel in nodeinfo["custom_node_labels"]:
-                kubernetes_label_node("--overwrite", nodename, nodelabel)
-
-
 def populate_machine_sku(machine_info):
     """Potentially adds sku for and returns the modified machine_info.
 
@@ -3776,9 +3768,6 @@ def run_command( args, command, nargs, parser ):
 
     elif command == "gpulabel":
         kubernetes_label_GpuTypes()
-
-    elif command == "customlabel":
-        kubernetes_label_custom_node_labels()
 
     elif command == "labelcpuworker":
         kubernetes_label_cpuworker()

--- a/src/ClusterBootstrap/deploy.py
+++ b/src/ClusterBootstrap/deploy.py
@@ -4098,7 +4098,8 @@ Command:
   upgrade_masters Upgrade the master nodes.
   upgrade_workers [nodes] Upgrade the worker nodes. If no additional node is specified, all nodes will be updated.
   upgrade [nodes] Upgrade the cluster and nodes. If no additional node is specified, all nodes will be updated.
-  customlabel Label nodes with custom defined node labels under custom_node_labels
+  labelcpuworker Label CPU nodes with "worker" role with cpuworker=active if their SKU is defined in sku_meta.
+  labelsku       Label nodes with sku=<sku_value> if their SKU is defined in sku_meta.
   ''') )
     parser.add_argument("-y", "--yes",
         help="Answer yes automatically for all prompt",

--- a/src/ClusterBootstrap/deploy.py
+++ b/src/ClusterBootstrap/deploy.py
@@ -2890,13 +2890,13 @@ def get_sku_meta(cnf):
         cnf: Configuration dictionary containing machines.
 
     Returns:
-
+        SKU meta dictionary from configuration.
     """
     return cnf.get("sku_meta", {})
 
 
-# Label kubernetes nodes with cpuworker=active
 def kubernetes_label_cpuworker():
+    """Label kubernetes nodes with cpuworker=active."""
     label = "cpuworker=active"
     sku_meta = get_sku_meta(config)
     workers = get_machines_by_roles("worker", config)
@@ -2908,8 +2908,8 @@ def kubernetes_label_cpuworker():
                 kubernetes_label_node("--overwrite", machine_name, label)
 
 
-# Label kubernetes nodes with sku=<sku_value>
 def kubernetes_label_sku():
+    """Label kubernetes nodes with sku=<sku_value>"""
     sku_meta = get_sku_meta(config)
     machines = get_machines_by_roles("all", config)
 

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -669,28 +669,25 @@ default_config_parameters = {
     "custom_mounts": [],
     "enable_blobfuse": False,
 
+    # To use CPU nodes,
+    # 1. CPU nodes must have node label cpuworker=active
+    # 2. enable_cpuworker is set to True
+    # 3. default_cpu_sku is set to a valid value that exists in sku_meta
     "enable_cpuworker": False,
+    "default_cpu_sku": "Standard_D2s_v3",
 
-    # The complementary of system reserved resource can be used for
-    # user applications. They can be overridden by configuration in
-    # each SKU
-    "user_allowed": {
-        "cpu": {
-            "ratio": 0.9
-        },
-        "memory": {
-            "ratio": 0.9
-        }
-    },
-    # SKU meta defines CPU, memory, GPU, GPU memory, etc. for each SKU
+    # SKU meta defines different types of resources for each SKU
+    # and their allowed usage ratio.
     "sku_meta": {
+        "default": {
+            "cpu_ratio": 0.8,
+            "memory_ratio": 0.8
+        },
         "Standard_D2s_v3": {
-            "cpu": {
-                "value": 2
-            },
-            "memory": {
-                "value": 8
-            }
+            "cpu": 2,
+            "cpu_ratio": 0.9,
+            "memory": 8,
+            "memory_ratio": 0.9
         }
     }
 }

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -668,7 +668,50 @@ default_config_parameters = {
     "infiniband_mounts": [],
     "custom_mounts": [],
     "enable_cpuworker": False,
-    "enable_blobfuse": False
+    "enable_blobfuse": False,
+
+    # The complementary of system reserved resource can be used for
+    # user applications. They can be overridden by configuration in
+    # each SKU
+    "system_reserved": {
+        "cpu": {
+            "ratio": 0.05
+        },
+        "memory": {
+            "ratio": 0.1
+        }
+    },
+    # SKU meta defines CPU, memory, GPU, GPU memory, etc. for each SKU
+    "sku_meta": {
+        "Standard_D2s_v3": {
+            "cpu": {
+                "value": 2,
+                "system_reserved": {
+                    "ratio": 0.02
+                }
+            },
+            "memory": {
+                "value": 8,
+                "system_reserved": {
+                    "ratio": 0.1
+                }
+            }
+        },
+        "Standard_ND24rs": {
+            "cpu": {
+                "value": 24
+            },
+            "memory": {
+                "value": 448
+            },
+            "gpu": {
+                "value": 4
+            },
+            "gpu_memory": {
+                "value": 22
+            }
+        }
+    }
 }
 
 # These are super scripts

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -676,36 +676,20 @@ default_config_parameters = {
     # each SKU
     "user_allowed": {
         "cpu": {
-            "ratio": 0.05
+            "ratio": 0.9
         },
         "memory": {
-            "ratio": 0.1
+            "ratio": 0.9
         }
     },
     # SKU meta defines CPU, memory, GPU, GPU memory, etc. for each SKU
     "sku_meta": {
         "Standard_D2s_v3": {
             "cpu": {
-                "value": 2,
-                "ratio": 0.02
+                "value": 2
             },
             "memory": {
-                "value": 8,
-                "ratio": 0.1
-            }
-        },
-        "Standard_ND24rs": {
-            "cpu": {
-                "value": 24
-            },
-            "memory": {
-                "value": 448
-            },
-            "gpu": {
-                "value": 4
-            },
-            "gpu_memory": {
-                "value": 22
+                "value": 8
             }
         }
     }

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -677,7 +677,7 @@ default_config_parameters = {
     "default_cpu_sku": "Standard_D2s_v3",
 
     # SKU meta defines different types of resources for each SKU
-    # and their allowed usage ratio.
+    # and their allowed usage ratio by user applications.
     "sku_meta": {
         "default": {
             "cpu_ratio": 0.8,

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -667,13 +667,14 @@ default_config_parameters = {
     },
     "infiniband_mounts": [],
     "custom_mounts": [],
-    "enable_cpuworker": False,
     "enable_blobfuse": False,
+
+    "enable_cpuworker": False,
 
     # The complementary of system reserved resource can be used for
     # user applications. They can be overridden by configuration in
     # each SKU
-    "system_reserved": {
+    "user_allowed": {
         "cpu": {
             "ratio": 0.05
         },
@@ -686,15 +687,11 @@ default_config_parameters = {
         "Standard_D2s_v3": {
             "cpu": {
                 "value": 2,
-                "system_reserved": {
-                    "ratio": 0.02
-                }
+                "ratio": 0.02
             },
             "memory": {
                 "value": 8,
-                "system_reserved": {
-                    "ratio": 0.1
-                }
+                "ratio": 0.1
             }
         },
         "Standard_ND24rs": {

--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -59,7 +59,6 @@ default_cpulimit: {{cnf["default_cpulimit"]}}
 default_memoryrequest: {{cnf["default_memoryrequest"]}}
 default_memorylimit: {{cnf["default_memorylimit"]}}
 default_cpu_sku: {{cnf["default_cpu_sku"]}}
-user_allowed: {{cnf["user_allowed"]}}
 sku_meta: {{cnf["sku_meta"]}}
 
 enable_blobfuse: {{cnf["enable_blobfuse"]}}

--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -58,6 +58,9 @@ default_cpurequest: {{cnf["default_cpurequest"]}}
 default_cpulimit: {{cnf["default_cpulimit"]}}
 default_memoryrequest: {{cnf["default_memoryrequest"]}}
 default_memorylimit: {{cnf["default_memorylimit"]}}
+default_cpu_sku: {{cnf["default_cpu_sku"]}}
+user_allowed: {{cnf["user_allowed"]}}
+sku_meta: {{cnf["sku_meta"]}}
 
 enable_blobfuse: {{cnf["enable_blobfuse"]}}
 

--- a/src/ClusterManager/dist_pod_template.py
+++ b/src/ClusterManager/dist_pod_template.py
@@ -12,6 +12,7 @@ from job import Job
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../utils"))
 from config import config
 from osUtils import mkdirsAsUser
+from pod_template_utils import enable_cpu_config
 
 
 class DistPodTemplate():
@@ -149,6 +150,7 @@ class DistPodTemplate():
                 pod["distRole"] = role
                 pod["distRoleIdx"] = idx
                 pod["distId"] = "%s%d" % (role, idx)
+                pod = enable_cpu_config(params=params, config=job.cluster)
                 # mount /pod
                 local_pod_path = job.get_hostpath(job.job_path, "%s-%d" % (role, idx))
                 pod["mountpoints"].append({"name": "pod", "containerPath": "/pod", "hostPath": local_pod_path, "enabled": True})

--- a/src/ClusterManager/dist_pod_template.py
+++ b/src/ClusterManager/dist_pod_template.py
@@ -150,7 +150,7 @@ class DistPodTemplate():
                 pod["distRole"] = role
                 pod["distRoleIdx"] = idx
                 pod["distId"] = "%s%d" % (role, idx)
-                pod = enable_cpu_config(params=params, config=job.cluster)
+                pod = enable_cpu_config(params=pod, config=job.cluster)
                 # mount /pod
                 local_pod_path = job.get_hostpath(job.job_path, "%s-%d" % (role, idx))
                 pod["mountpoints"].append({"name": "pod", "containerPath": "/pod", "hostPath": local_pod_path, "enabled": True})

--- a/src/ClusterManager/dist_pod_template.py
+++ b/src/ClusterManager/dist_pod_template.py
@@ -150,7 +150,7 @@ class DistPodTemplate():
                 pod["distRole"] = role
                 pod["distRoleIdx"] = idx
                 pod["distId"] = "%s%d" % (role, idx)
-                pod = enable_cpu_config(params=pod, config=job.cluster)
+                pod = enable_cpu_config(pod, job.cluster)
                 # mount /pod
                 local_pod_path = job.get_hostpath(job.job_path, "%s-%d" % (role, idx))
                 pod["mountpoints"].append({"name": "pod", "containerPath": "/pod", "hostPath": local_pod_path, "enabled": True})

--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -118,8 +118,6 @@ class PodTemplate():
         if "gpuType" in params:
             params["nodeSelector"]["gpuType"] = params["gpuType"]
 
-        # CPU job should be assigned to CPU node if it's enabled and
-        # there is any available in the cluster
         params = enable_cpu_config(params=params, config=job.cluster)
 
         local_pod_path = job.get_hostpath(job.job_path, "master")

--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -118,7 +118,7 @@ class PodTemplate():
         if "gpuType" in params:
             params["nodeSelector"]["gpuType"] = params["gpuType"]
 
-        params = enable_cpu_config(params=params, config=job.cluster)
+        params = enable_cpu_config(params, job.cluster)
 
         local_pod_path = job.get_hostpath(job.job_path, "master")
         params["LaunchCMD"] = PodTemplate.generate_launch_script(params["jobId"], local_pod_path, params["userId"], params["resourcegpu"], params["cmd"])

--- a/src/ClusterManager/pod_template_utils.py
+++ b/src/ClusterManager/pod_template_utils.py
@@ -1,0 +1,122 @@
+def cpu_format(cpu, ratio=1.0):
+    """Convert number of cpu to cpu cycle.
+
+    Args:
+        cpu: Number of cpu.
+        ratio: The percent that can be used.
+
+    Returns:
+        Formatted string of cpu cycle.
+    """
+    if cpu is None:
+        return None
+    return "%dm" % int(ratio * cpu * 1000)
+
+
+def memory_format(memory, ratio=1.0):
+    """Convert memory in G to memory requirement.
+
+    Args:
+        memory: Memory size in G.
+        ratio: The percent that can be used.
+
+    Returns:
+        Formatted string of memory size.
+    """
+    if memory is None:
+        return None
+    return "%dM" % int(ratio * memory * 1024)
+
+
+def get_sku_info(sku, config):
+    if sku is None:
+        return None
+
+    sku_meta = config.get("sku_meta", {})
+    sku_info = sku_meta.get(sku, None)
+    if sku_info is None:
+        return None
+
+    for key in ["cpu", "memory"]:
+        if key not in sku_info:
+            return None
+        if "value" not in sku_info[key]:
+            return None
+
+    user_allowed = config.get("user_allowed", {})
+
+    if "cpu" not in user_allowed:
+        user_allowed["cpu"] = {}
+    if "ratio" not in user_allowed["cpu"]:
+        user_allowed["cpu"]["ratio"] = 0.05
+    if "memory" not in user_allowed:
+        user_allowed["memory"] = {}
+    if "ratio" not in user_allowed["memory"]:
+        user_allowed["memory"]["ratio"] = 0.1
+
+    for key in ["cpu", "memory"]:
+        if "ratio" not in sku_info[key]:
+            sku_info[key]["ratio"] = user_allowed[key]["ratio"]
+
+    return sku_info
+
+
+def enable_cpu_config(params, config):
+    # Only works for 0-GPU pod
+    if "resourcegpu" not in params or int(params["resourcegpu"]) != 0:
+        return params
+
+    # Ignore if cpuworker is not enabled
+    enable_cpuworker = config.get("enable_cpuworker", False)
+    if enable_cpuworker is False:
+        return params
+
+    # Add node selector cpuworker=active
+    if "nodeSelector" not in params:
+        params["nodeSelector"] = {}
+    params["nodeSelector"]["cpuworker"] = "active"
+
+    # Add node selector sku=<sku_value>
+    job_training_type = params.get("jobtrainingtype", None)
+    default_cpu_sku = config.get("default_cpu_sku")
+    if "sku" in params:
+        params["nodeSelector"]["sku"] = params["sku"]
+    elif default_cpu_sku is not None and job_training_type == "PSDistJob":
+        params["nodeSelector"]["sku"] = default_cpu_sku
+
+    # Assign resource requirement based on job type and default configurations
+    default_cpu_request = None
+    default_cpu_limit = None
+    default_memory_request = None
+    default_memory_limit = None
+
+    entire_node = job_training_type == "PSDistJob" and params["distRole"] == "worker"
+
+    if entire_node is True:
+        sku = params["nodeSelector"].get("sku", None)
+        sku_info = get_sku_info(sku=sku, config=config)
+        if sku_info is not None:
+            default_cpu_request = cpu_format(sku_info["cpu"]["value"],
+                                             sku_info["cpu"]["ratio"])
+            default_cpu_limit = cpu_format(sku_info["cpu"]["value"],
+                                           sku_info["cpu"]["ratio"])
+            default_memory_request = cpu_format(sku_info["memory"]["value"],
+                                                sku_info["memory"]["ratio"])
+            default_memory_limit = cpu_format(sku_info["memory"]["value"],
+                                              sku_info["memory"]["ratio"])
+    else:
+        default_cpu_request = cpu_format(config.get("default_cpurequest"))
+        default_cpu_limit = cpu_format(config.get("default_cpulimit"))
+        default_memory_request = memory_format(config.get("default_memoryrequest"))
+        default_memory_limit = memory_format(config.get("default_memorylimit"))
+
+    if "cpurequest" not in params and default_cpu_request is not None:
+        params["cpurequest"] = default_cpu_request
+    if "cpulimit" not in params and default_cpu_limit is not None:
+        params["cpulimit"] = default_cpu_limit
+    if "memoryrequest" not in params and default_memory_request is not None:
+        params["memoryrequest"] = default_memory_request
+    if "memorylimit" not in params and default_memory_limit is not None:
+        params["memorylimit"] = default_memory_limit
+
+    return params

--- a/src/ClusterManager/pod_template_utils.py
+++ b/src/ClusterManager/pod_template_utils.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 def cpu_format(cpu, ratio=1.0):
     """Convert number of cpu to cpu cycle.
 
@@ -6,14 +7,14 @@ def cpu_format(cpu, ratio=1.0):
         ratio: The percent that can be used.
 
     Returns:
-        Formatted string of cpu cycle.
+        Formatted string of cpu cycle if cpu is valid, None otherwise.
     """
     if cpu is None:
         return None
     return "%dm" % int(ratio * cpu * 1000)
 
 
-def memory_format(memory, ratio=1.0):
+def mem_format(memory, ratio=1.0):
     """Convert memory in G to memory requirement.
 
     Args:
@@ -21,7 +22,7 @@ def memory_format(memory, ratio=1.0):
         ratio: The percent that can be used.
 
     Returns:
-        Formatted string of memory size.
+        Formatted string of memory size if memory is valid, None otherwise.
     """
     if memory is None:
         return None
@@ -29,6 +30,21 @@ def memory_format(memory, ratio=1.0):
 
 
 def get_sku_info(sku, config):
+    """Returns a sku info dictionary for sku.
+
+    Args:
+        sku: String specifying machine's SKU.
+        config: Configuration containing sku_meta.
+
+    Returns:
+        A dictionary containing sku info for the given machine sku, including
+        - cpu
+        - cpu usable ratio
+        - memory
+        - memory usable ratio
+        if sku and sku_info in config["sku_meta"] are valid, None otherwise.
+    """
+    # Ignore invalid sku and sku_info.
     if sku is None:
         return None
 
@@ -41,15 +57,15 @@ def get_sku_info(sku, config):
         if key not in sku_info:
             return None
 
-    # default sku_info must contain ratio info
-    default_sku_info = sku_meta.get("default", None)
-    if default_sku_info is None:
-        default_sku_info = {}
+    # Default sku_info must contain ratio info.
+    # Assign 0.8 as default if default values are not defined.
+    default_sku_info = sku_meta.get("default", {})
 
     for key in ["cpu_ratio", "memory_ratio"]:
         if key not in default_sku_info:
             default_sku_info[key] = 0.8
 
+    # Override ratios in sku_info with default values if absent.
     for key in ["cpu_ratio", "memory_ratio"]:
         if key not in sku_info:
             sku_info[key] = default_sku_info[key]
@@ -57,62 +73,78 @@ def get_sku_info(sku, config):
     return sku_info
 
 
-def enable_cpu_config(params, config):
+def enable_cpu_config(pod, config):
+    """Add node selector and cpu, memory requirement info for CPU pod.
+
+    Args:
+        pod: Pod configuration directory to for starting a Kubernetes pod.
+        config: Configuration containing cluster-wide info.
+
+    Returns:
+        Potentially modified pod.
+    """
     # Only works for 0-GPU pod
-    if "resourcegpu" not in params or int(params["resourcegpu"]) != 0:
-        return params
+    if "resourcegpu" not in pod or int(pod["resourcegpu"]) != 0:
+        return pod
 
     # Ignore if cpuworker is not enabled
     enable_cpuworker = config.get("enable_cpuworker", False)
     if enable_cpuworker is False:
-        return params
+        return pod
 
     # Add node selector cpuworker=active
-    if "nodeSelector" not in params:
-        params["nodeSelector"] = {}
-    params["nodeSelector"]["cpuworker"] = "active"
+    if "nodeSelector" not in pod:
+        pod["nodeSelector"] = {}
+    pod["nodeSelector"]["cpuworker"] = "active"
 
     # Add node selector sku=<sku_value>
-    job_training_type = params.get("jobtrainingtype", None)
-    default_cpu_sku = config.get("default_cpu_sku")
-    if "sku" in params:
-        params["nodeSelector"]["sku"] = params["sku"]
+    job_training_type = pod.get("jobtrainingtype", None)
+    default_cpu_sku = config.get("default_cpu_sku", None)
+    if "sku" in pod:
+        pod["nodeSelector"]["sku"] = pod["sku"]
     elif default_cpu_sku is not None and job_training_type == "PSDistJob":
-        params["nodeSelector"]["sku"] = default_cpu_sku
+        pod["nodeSelector"]["sku"] = default_cpu_sku
 
-    # Assign resource requirement based on job type and default configurations
+    # Assign resource requirement based on job type and default configuration.
+    # Pod requiring a full node requires occupying cpu and memory as much as
+    # possible on a node. We attempt to achieve this by using cluster-wide
+    # cpu usable ratio multiplied into cpu count, and memory usable ratio
+    # multiplied into memory size.
     default_cpu_request = None
     default_cpu_limit = None
-    default_memory_request = None
-    default_memory_limit = None
+    default_mem_request = None
+    default_mem_limit = None
 
-    entire_node = job_training_type == "PSDistJob" and params["distRole"] == "worker"
+    if job_training_type == "PSDistJob" and pod["distRole"] == "worker":
+        full_node = True
+    else:
+        full_node = False
 
-    if entire_node is True:
-        sku = params["nodeSelector"].get("sku", None)
+    if full_node is True:
+        sku = pod["nodeSelector"].get("sku", None)
         sku_info = get_sku_info(sku=sku, config=config)
         if sku_info is not None:
             default_cpu_request = cpu_format(sku_info["cpu"]["value"],
                                              sku_info["cpu"]["ratio"])
             default_cpu_limit = cpu_format(sku_info["cpu"]["value"],
                                            sku_info["cpu"]["ratio"])
-            default_memory_request = memory_format(sku_info["memory"]["value"],
-                                                   sku_info["memory"]["ratio"])
-            default_memory_limit = memory_format(sku_info["memory"]["value"],
-                                                 sku_info["memory"]["ratio"])
+            default_mem_request = mem_format(sku_info["memory"]["value"],
+                                             sku_info["memory"]["ratio"])
+            default_mem_limit = mem_format(sku_info["memory"]["value"],
+                                           sku_info["memory"]["ratio"])
     else:
         default_cpu_request = cpu_format(config.get("default_cpurequest"))
         default_cpu_limit = cpu_format(config.get("default_cpulimit"))
-        default_memory_request = memory_format(config.get("default_memoryrequest"))
-        default_memory_limit = memory_format(config.get("default_memorylimit"))
+        default_mem_request = mem_format(config.get("default_memoryrequest"))
+        default_mem_limit = mem_format(config.get("default_memorylimit"))
 
-    if "cpurequest" not in params and default_cpu_request is not None:
-        params["cpurequest"] = default_cpu_request
-    if "cpulimit" not in params and default_cpu_limit is not None:
-        params["cpulimit"] = default_cpu_limit
-    if "memoryrequest" not in params and default_memory_request is not None:
-        params["memoryrequest"] = default_memory_request
-    if "memorylimit" not in params and default_memory_limit is not None:
-        params["memorylimit"] = default_memory_limit
+    if "cpurequest" not in pod and default_cpu_request is not None:
+        pod["cpurequest"] = default_cpu_request
+    if "cpulimit" not in pod and default_cpu_limit is not None:
+        pod["cpulimit"] = default_cpu_limit
+    if "memoryrequest" not in pod and default_mem_request is not None:
+        pod["memoryrequest"] = default_mem_request
+    if "memorylimit" not in pod and default_mem_limit is not None:
+        pod["memorylimit"] = default_mem_limit
 
-    return params
+    return pod

--- a/src/ClusterManager/pod_template_utils.py
+++ b/src/ClusterManager/pod_template_utils.py
@@ -100,10 +100,10 @@ def enable_cpu_config(params, config):
                                              sku_info["cpu"]["ratio"])
             default_cpu_limit = cpu_format(sku_info["cpu"]["value"],
                                            sku_info["cpu"]["ratio"])
-            default_memory_request = cpu_format(sku_info["memory"]["value"],
-                                                sku_info["memory"]["ratio"])
-            default_memory_limit = cpu_format(sku_info["memory"]["value"],
-                                              sku_info["memory"]["ratio"])
+            default_memory_request = memory_format(sku_info["memory"]["value"],
+                                                   sku_info["memory"]["ratio"])
+            default_memory_limit = memory_format(sku_info["memory"]["value"],
+                                                 sku_info["memory"]["ratio"])
     else:
         default_cpu_request = cpu_format(config.get("default_cpurequest"))
         default_cpu_limit = cpu_format(config.get("default_cpulimit"))

--- a/src/ClusterManager/pod_template_utils.py
+++ b/src/ClusterManager/pod_template_utils.py
@@ -40,23 +40,19 @@ def get_sku_info(sku, config):
     for key in ["cpu", "memory"]:
         if key not in sku_info:
             return None
-        if "value" not in sku_info[key]:
-            return None
 
-    user_allowed = config.get("user_allowed", {})
+    # default sku_info must contain ratio info
+    default_sku_info = sku_meta.get("default", None)
+    if default_sku_info is None:
+        default_sku_info = {}
 
-    if "cpu" not in user_allowed:
-        user_allowed["cpu"] = {}
-    if "ratio" not in user_allowed["cpu"]:
-        user_allowed["cpu"]["ratio"] = 0.05
-    if "memory" not in user_allowed:
-        user_allowed["memory"] = {}
-    if "ratio" not in user_allowed["memory"]:
-        user_allowed["memory"]["ratio"] = 0.1
+    for key in ["cpu_ratio", "memory_ratio"]:
+        if key not in default_sku_info:
+            default_sku_info[key] = 0.8
 
-    for key in ["cpu", "memory"]:
-        if "ratio" not in sku_info[key]:
-            sku_info[key]["ratio"] = user_allowed[key]["ratio"]
+    for key in ["cpu_ratio", "memory_ratio"]:
+        if key not in sku_info:
+            sku_info[key] = default_sku_info[key]
 
     return sku_info
 

--- a/src/ClusterManager/pod_template_utils.py
+++ b/src/ClusterManager/pod_template_utils.py
@@ -124,14 +124,14 @@ def enable_cpu_config(pod, config):
         sku = pod["nodeSelector"].get("sku", None)
         sku_info = get_sku_info(sku=sku, config=config)
         if sku_info is not None:
-            default_cpu_request = cpu_format(sku_info["cpu"]["value"],
-                                             sku_info["cpu"]["ratio"])
-            default_cpu_limit = cpu_format(sku_info["cpu"]["value"],
-                                           sku_info["cpu"]["ratio"])
-            default_mem_request = mem_format(sku_info["memory"]["value"],
-                                             sku_info["memory"]["ratio"])
-            default_mem_limit = mem_format(sku_info["memory"]["value"],
-                                           sku_info["memory"]["ratio"])
+            default_cpu_request = cpu_format(sku_info["cpu"],
+                                             sku_info["cpu_ratio"])
+            default_cpu_limit = cpu_format(sku_info["cpu"],
+                                           sku_info["cpu_ratio"])
+            default_mem_request = mem_format(sku_info["memory"],
+                                             sku_info["memory_ratio"])
+            default_mem_limit = mem_format(sku_info["memory"],
+                                           sku_info["memory_ratio"])
     else:
         default_cpu_request = cpu_format(config.get("default_cpurequest"))
         default_cpu_limit = cpu_format(config.get("default_cpulimit"))


### PR DESCRIPTION
1. `./deploy.py labelcpuworker`: Replace using `./deploy.py customlabel` to label CPU workers in #640 
2. `./deploy.py labelsku`: Label nodes with their respective SKU.

For the above to take effect for Azure VM size `Standard_E16s_v3`, define in `src/ClusterBootstrap/config.yaml`:

```
enable_cpuworker: True
default_cpurequest: 0.1
default_cpulimit: 1
default_memoryrequest: 1
default_memorylimit: 3
default_cpu_sku: Standard_E16s_v3
sku_meta:
  Standard_E16s_v3:
    cpu: 16
    cpu_ratio: 0.9
    memory: 128
    memory_ratio: 0.9
```

- `enable_cpuworker` is the on/off flag for using CPU workers in job scheduling.
- When `enable_cpuworker` is on, `default_cpurequest`, `default_cpulimit`, `default_memoryrequest`, and `default_memorylimit` defines the resource requirement of pod in RegularJob and ps pod in PSDistJob.
- `default_cpu_sku` and `sku_meta` is used for filling in resource requirement of worker CPU pods in PSDistJob.