### PR TITLE
Handle terminating pods when machines are taken away for k8s > 1.13 +  expose more job info

### DIFF
--- a/src/ClusterManager/job_launcher.py
+++ b/src/ClusterManager/job_launcher.py
@@ -535,7 +535,7 @@ class PythonLauncher(Launcher):
             job_object.params["user"] = job_object.get_alias()
 
             if "job_token" not in job_object.params:
-                if "user_sign_token" in config and "user_sign_token" is not None and "userName" in job_object.params:
+                if "user_sign_token" in config and config["user_sign_token"] is not None and "userName" in job_object.params:
                     job_object.params["job_token"] = hashlib.md5(job_object.params["userName"]+":"+config["user_sign_token"]).hexdigest()
                 else:
                     job_object.params["job_token"] = "tryme2017"

--- a/src/ClusterManager/job_launcher.py
+++ b/src/ClusterManager/job_launcher.py
@@ -390,6 +390,13 @@ class JobRole(object):
 
         return phase
 
+    def pod_restricted_details(self):
+        detail = dict()
+        detail["node_name"] = self.pod.spec.node_name
+        detail["host_ip"] = self.pod.status.host_ip
+        detail["pod_ip"] = self.pod.status.pod_ip
+        return detail
+
     def pod_details(self):
         return self.pod
 

--- a/src/ClusterManager/job_launcher.py
+++ b/src/ClusterManager/job_launcher.py
@@ -391,10 +391,11 @@ class JobRole(object):
         return phase
 
     def pod_restricted_details(self):
-        detail = dict()
-        detail["node_name"] = self.pod.spec.node_name
-        detail["host_ip"] = self.pod.status.host_ip
-        detail["pod_ip"] = self.pod.status.pod_ip
+        detail = {
+            "node_name": self.pod.spec.node_name,
+            "host_ip": self.pod.status.host_ip,
+            "pod_ip": self.pod.status.pod_ip
+        }
         return detail
 
     def pod_details(self):

--- a/src/ClusterManager/job_launcher.py
+++ b/src/ClusterManager/job_launcher.py
@@ -535,7 +535,7 @@ class PythonLauncher(Launcher):
             job_object.params["user"] = job_object.get_alias()
 
             if "job_token" not in job_object.params:
-                if "user_sign_token" in config and "userName" in job_object.params:
+                if "user_sign_token" in config and "user_sign_token" is not None and "userName" in job_object.params:
                     job_object.params["job_token"] = hashlib.md5(job_object.params["userName"]+":"+config["user_sign_token"]).hexdigest()
                 else:
                     job_object.params["job_token"] = "tryme2017"

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -564,7 +564,7 @@ def TakeJobActions(data_handler, redis_conn, launcher, jobs):
                 vc_name = sji["job"]["vcName"]
                 available_resource = vc_resources[vc_name]
                 requested_resource = sji["globalResInfo"]
-                detail = [{"message": "waiting for available resource. requested: %s. available: %s" % (available_resource, requested_resource)}]
+                detail = [{"message": "waiting for available resource. requested: %s. available: %s" % (requested_resource, available_resource)}]
                 data_handler.UpdateJobTextField(sji["jobId"], "jobStatusDetail", base64.b64encode(json.dumps(detail)))
         except Exception as e:
             logging.error("Process job failed {}".format(sji["job"]), exc_info=True)

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -560,6 +560,12 @@ def TakeJobActions(data_handler, redis_conn, launcher, jobs):
             elif sji["preemptionAllowed"] and (sji["job"]["jobStatus"] == "scheduling" or sji["job"]["jobStatus"] == "running") and (sji["allowed"] is False):
                 launcher.kill_job(sji["job"]["jobId"], "queued")
                 logging.info("TakeJobActions : pre-empting job : %s : %s" % (sji["jobId"], sji["sortKey"]))
+            elif sji["job"]["jobStatus"] == "queued" and sji["allowed"] is False:
+                vc_name = sji["job"]["vcName"]
+                available_resource = vc_resources[vc_name]
+                requested_resource = sji["globalResInfo"]
+                detail = [{"message": "waiting for available resource. requested: %s. available: %s" % (available_resource, requested_resource)}]
+                data_handler.UpdateJobTextField(sji["jobId"], "jobStatusDetail", base64.b64encode(json.dumps(detail)))
         except Exception as e:
             logging.error("Process job failed {}".format(sji["job"]), exc_info=True)
 

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -391,7 +391,12 @@ def check_job_status(job_id):
     details = []
     for job_role in job_roles:
         details.append(job_role.pod_details().to_dict())
-    logging.info("Job {}, details: {}".format(job_id, details))
+    logging.debug("Job {}, details: {}".format(job_id, details))
+
+    restricted_details = [
+        job_role.pod_restricted_details() for job_role in job_roles
+    ]
+    logging.info("Job: {}, restricted details: {}".format(job_id, restricted_details))
 
     job_status = "Running"
 


### PR DESCRIPTION
1. Handle terminating pods when machines are taken away - [Issues 72226](https://github.com/kubernetes/kubernetes/issues/72226)
2. Add check for `config["user_sign_token"]` being `None`
3. Print `node_name`, `host_ip`, `pod_ip` for jobs in restricted detail
4. Expose requested and available GPU resources for user visibility in queued jobs