### PR TITLE
Dashboard/remove winbind dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,7 @@ matrix:
     node_js: lts/*
     before_install: cd src/dashboard
     install: yarn --frozen-lockfile
-    script: npm run coverage:backend
+    script:
+    - npm run lint:backend
+    - npm run coverage:backend
     after_success: npx nyc --nycrc-path server/.nycrc.js report --reporter=text-lcov | npx coveralls

--- a/src/dashboard/config/test.yaml
+++ b/src/dashboard/config/test.yaml
@@ -1,6 +1,5 @@
 sign: DashboardSign
 
-winbind: http://winbind
 masterToken: DashboardMasterToken
 
 activeDirectory:

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -58,7 +58,6 @@
     "@types/react-swipeable-views": "^0.13.0",
     "@types/recharts": "^1.1.16",
     "@types/should": "^13.0.0",
-    "@types/sinon": "^7.5.0",
     "@types/tough-cookie": "^2.3.5",
     "@types/uuid": "^3.4.5",
     "axiosist": "^0.7.0",
@@ -74,7 +73,6 @@
     "nyc": "^14.1.1",
     "react-scripts": "^3.0.1",
     "should": "^13.2.3",
-    "sinon": "^7.5.0",
     "tough-cookie": "^3.0.1",
     "typescript": "^3.5.2"
   },

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -81,6 +81,7 @@
     "frontend": "react-scripts start",
     "build": "react-scripts build",
     "backend": "nodemon server",
+    "lint:backend": "eslint server",
     "test:backend": "mocha --config server/.mocharc.js",
     "coverage:backend": "nyc --nycrc-path server/.nycrc.js npm run test:backend",
     "report:backend": "nyc --nycrc-path server/.nycrc.js report --reporter html"

--- a/src/dashboard/server/api/controllers/authenticate/index.js
+++ b/src/dashboard/server/api/controllers/authenticate/index.js
@@ -67,8 +67,6 @@ module.exports = async context => {
     context.log.info(idToken, 'Id token')
 
     const user = User.fromIdToken(context, idToken)
-    const data = await user.fillIdFromWinbind()
-    user.addUserToCluster(data)
 
     context.cookies.set('token', user.toCookieToken())
 

--- a/src/dashboard/server/api/controllers/team/jobs.js
+++ b/src/dashboard/server/api/controllers/team/jobs.js
@@ -10,7 +10,7 @@ const DEFAULT_PRIORITY = 100
 /** @type {import('koa').Middleware} */
 module.exports = async context => {
   const { teamId } = context.params
-  //const offset = Number(context.query.offset) || 0
+  // const offset = Number(context.query.offset) || 0
   const limit = Number(context.query.limit) || 10
   const all = context.query.user === 'all'
 
@@ -45,6 +45,6 @@ module.exports = async context => {
     return jobBDate - jobADate
   })
 
-  //context.body = jobs.slice(offset, offset + limit)
+  // context.body = jobs.slice(offset, offset + limit)
   context.body = jobs
 }

--- a/src/dashboard/server/api/middlewares/user.js
+++ b/src/dashboard/server/api/middlewares/user.js
@@ -12,7 +12,6 @@ module.exports = (forceAuthenticated = true) => async (context, next) => {
 
     if (password) {
       const user = context.state.user = User.fromPassword(context, email, password)
-      await user.fillIdFromWinbind()
       context.log.debug(user, 'Authenticated by password')
     }
   } else if (context.cookies.get('token')) {

--- a/src/dashboard/server/api/validator/config.schema.json
+++ b/src/dashboard/server/api/validator/config.schema.json
@@ -7,11 +7,6 @@
       "description": "Sign key for JWT",
       "type": "string"
     },
-    "winbind": {
-      "title": "WinBind server for get user's id info",
-      "description": "Will call /domaininfo/GetUserId with userName query to get the user's id info",
-      "type": "string"
-    },
     "masterToken": {
       "title": "Access token of all users",
       "type": "string"

--- a/src/dashboard/server/test/.setup.js
+++ b/src/dashboard/server/test/.setup.js
@@ -1,14 +1,11 @@
 const nock = require('nock')
-const sinon = require('sinon')
 
 process.env.NODE_ENV = 'test'
 
 beforeEach(() => {
   nock.cleanAll()
-  sinon.restore()
 })
 
 afterEach(() => {
   nock.pendingMocks().should.be.empty()
-  sinon.verify()
 })

--- a/src/dashboard/server/test/authenticate.js
+++ b/src/dashboard/server/test/authenticate.js
@@ -1,11 +1,9 @@
 const axiosist = require('axiosist')
 const nock = require('nock')
 const jwt = require('jsonwebtoken')
-const sinon = require('sinon')
 const touge = require('tough-cookie')
 
 const api = require('../api').callback()
-const User = require('../api/services/user')
 
 describe('GET /authenticate', () => {
   it('should redirect the user to login page.', async () => {
@@ -28,10 +26,6 @@ describe('GET /authenticate', () => {
       .reply(200, {
         id_token: jwt.sign({ upn: email }, 'fake sign')
       })
-
-    const mock = sinon.mock(User.prototype)
-    mock.expects('fillIdFromWinbind').once().resolves()
-    mock.expects('addUserToCluster').once().resolves()
 
     const response = await axiosist(api).get('/authenticate', {
       params: {

--- a/src/dashboard/server/test/controllers/bootstrap.js
+++ b/src/dashboard/server/test/controllers/bootstrap.js
@@ -10,6 +10,7 @@ const api = require('../../api').callback()
  */
 const getBootstrapArgument = (code) => {
   const bootstrap = argument => argument
+  // eslint-disable-next-line no-new-func
   return new Function('bootstrap', `return ${code}`)(bootstrap)
 }
 

--- a/src/dashboard/server/test/controllers/cluster/index.js
+++ b/src/dashboard/server/test/controllers/cluster/index.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const User = require('../../../api/services/user')
 const api = require('../../../api').callback()
 
@@ -10,8 +9,6 @@ const userParams = {
 
 describe('GET /clusters/:clusterId', () => {
   it('should response cluster config', async () => {
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
-
     const response = await axiosist(api).get('/clusters/Universe', {
       params: userParams
     })
@@ -19,8 +16,6 @@ describe('GET /clusters/:clusterId', () => {
   })
 
   it('should response 404 when cluster not exist', async () => {
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
-
     const response = await axiosist(api).get('/clusters/NewCluster', {
       params: userParams
     })

--- a/src/dashboard/server/test/controllers/cluster/job/getJobDetail.js
+++ b/src/dashboard/server/test/controllers/cluster/job/getJobDetail.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const nock = require('nock')
 const User = require('../../../../api/services/user')
 const api = require('../../../../api').callback()
@@ -27,7 +26,6 @@ describe('GET /clusters/:clusterId/jobs/:jobId', () => {
       .reply(200, {
         message: 'job detail retrieved'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/clusters/Universe/jobs/testjob', {
       params: userParams
@@ -41,7 +39,6 @@ describe('GET /clusters/:clusterId/jobs/:jobId', () => {
     nock('http://universe')
       .get('/GetJobDetail?' + getJobParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/clusters/Universe/jobs/testjob', {
       params: userParams
@@ -59,7 +56,6 @@ describe('GET /clusters/:clusterId/jobs/:jobId/status', () => {
         jobStatus: 'OK',
         errorMsg: null
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/clusters/Universe/jobs/testjob/status', {
       params: userParams
@@ -73,7 +69,6 @@ describe('GET /clusters/:clusterId/jobs/:jobId/status', () => {
     nock('http://universe')
       .get('/GetJobStatus?' + getJobStatusParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/clusters/Universe/jobs/testjob/status', {
       params: userParams
@@ -89,7 +84,6 @@ describe('GET /clusters/:clusterId/jobs/:jobId/status', () => {
         jobStatus: 'an error happened',
         errorMsg: 'Job Status Not Found'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/clusters/Universe/jobs/testjob/status', {
       params: userParams
@@ -107,7 +101,6 @@ describe('GET /clusters/:clusterId/jobs/:jobId/commands', () => {
       .reply(200, {
         commands: 'test job commands'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/clusters/Universe/jobs/testjob/commands', {
       params: userParams
@@ -121,7 +114,6 @@ describe('GET /clusters/:clusterId/jobs/:jobId/commands', () => {
     nock('http://universe')
       .get('/GetCommands?' + getJobParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/clusters/Universe/jobs/testjob/commands', {
       params: userParams
@@ -138,7 +130,6 @@ describe('GET /clusters/:clusterId/jobs/:jobId/endpoints', () => {
       .reply(200, {
         endpoints: 'test job endpoints'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/clusters/Universe/jobs/testjob/endpoints', {
       params: userParams
@@ -152,7 +143,6 @@ describe('GET /clusters/:clusterId/jobs/:jobId/endpoints', () => {
     nock('http://universe')
       .get('/endpoints?' + getJobParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/clusters/Universe/jobs/testjob/endpoints', {
       params: userParams

--- a/src/dashboard/server/test/controllers/cluster/job/postJob.js
+++ b/src/dashboard/server/test/controllers/cluster/job/postJob.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const nock = require('nock')
 const User = require('../../../../api/services/user')
 const api = require('../../../../api').callback()
@@ -37,7 +36,6 @@ describe('POST /clusters/:clusterId/jobs/:jobId/commands', () => {
       .reply(200, {
         message: 'command adding succeeded'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).post('/clusters/Universe/jobs/testjob/commands',
     {command: 'testcommand'}, {params: userParams})
@@ -50,7 +48,6 @@ describe('POST /clusters/:clusterId/jobs/:jobId/commands', () => {
     nock('http://universe')
       .get('/AddCommand?' + addCommandParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).post('/clusters/Universe/jobs/testjob/commands',
     {command: 'testcommand'}, {params: userParams})
@@ -66,7 +63,6 @@ describe('POST /clusters/:clusterId/jobs/:jobId/endpoints', () => {
       .reply(200, {
         message: 'endpoints adding succeeded'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).post('/clusters/Universe/jobs/testjob/endpoints',
     testEndpoints, {params: userParams})
@@ -79,7 +75,6 @@ describe('POST /clusters/:clusterId/jobs/:jobId/endpoints', () => {
     nock('http://universe')
       .post('/endpoints?' + addEndpointsParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).post('/clusters/Universe/jobs/testjob/endpoints',
     testEndpoints, {params: userParams})

--- a/src/dashboard/server/test/controllers/cluster/job/postJob.js
+++ b/src/dashboard/server/test/controllers/cluster/job/postJob.js
@@ -21,12 +21,12 @@ const addEndpointsParams = new URLSearchParams({
 
 const testEndpoints = {
   endpoints: [{
-      name: 'testname',
-      podPort: 0
-    }, {
-      name: 'testname2',
-      podPort: 1
-    }]
+    name: 'testname',
+    podPort: 0
+  }, {
+    name: 'testname2',
+    podPort: 1
+  }]
 }
 
 describe('POST /clusters/:clusterId/jobs/:jobId/commands', () => {
@@ -38,7 +38,7 @@ describe('POST /clusters/:clusterId/jobs/:jobId/commands', () => {
       })
 
     const response = await axiosist(api).post('/clusters/Universe/jobs/testjob/commands',
-    {command: 'testcommand'}, {params: userParams})
+      { command: 'testcommand' }, { params: userParams })
 
     response.status.should.equal(201)
     response.data.should.have.property('message', 'command adding succeeded')
@@ -50,7 +50,7 @@ describe('POST /clusters/:clusterId/jobs/:jobId/commands', () => {
       .reply(500)
 
     const response = await axiosist(api).post('/clusters/Universe/jobs/testjob/commands',
-    {command: 'testcommand'}, {params: userParams})
+      { command: 'testcommand' }, { params: userParams })
 
     response.status.should.equal(502)
   })
@@ -65,7 +65,7 @@ describe('POST /clusters/:clusterId/jobs/:jobId/endpoints', () => {
       })
 
     const response = await axiosist(api).post('/clusters/Universe/jobs/testjob/endpoints',
-    testEndpoints, {params: userParams})
+      testEndpoints, { params: userParams })
 
     response.status.should.equal(200)
     response.data.should.have.property('message', 'endpoints adding succeeded')
@@ -77,7 +77,7 @@ describe('POST /clusters/:clusterId/jobs/:jobId/endpoints', () => {
       .reply(500)
 
     const response = await axiosist(api).post('/clusters/Universe/jobs/testjob/endpoints',
-    testEndpoints, {params: userParams})
+      testEndpoints, { params: userParams })
 
     response.status.should.equal(502)
   })

--- a/src/dashboard/server/test/controllers/cluster/job/putJobPriority.js
+++ b/src/dashboard/server/test/controllers/cluster/job/putJobPriority.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const nock = require('nock')
 const User = require('../../../../api/services/user')
 const api = require('../../../../api').callback()
@@ -20,7 +19,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/priority', () => {
       .reply(200, {
         message: 'priority set successfully'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/priority',
     {priority: 0}, {params: userParams})
@@ -33,7 +31,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/priority', () => {
     nock('http://universe')
       .post('/jobs/priorities?' + setPriorityParams, {['testjob']: /[0-9]+/})
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/priority',
     {priority: 0}, {params: userParams})

--- a/src/dashboard/server/test/controllers/cluster/job/putJobPriority.js
+++ b/src/dashboard/server/test/controllers/cluster/job/putJobPriority.js
@@ -15,13 +15,13 @@ const setPriorityParams = new URLSearchParams({
 describe('PUT /clusters/:clusterId/jobs/:jobId/priority', () => {
   it('should return OK if priority set successfully', async () => {
     nock('http://universe')
-      .post('/jobs/priorities?' + setPriorityParams, {['testjob']: /[0-9]+/})
+      .post('/jobs/priorities?' + setPriorityParams, { 'testjob': /[0-9]+/ })
       .reply(200, {
         message: 'priority set successfully'
       })
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/priority',
-    {priority: 0}, {params: userParams})
+      { priority: 0 }, { params: userParams })
 
     response.status.should.equal(200)
     response.data.should.have.property('message', 'priority set successfully')
@@ -29,11 +29,11 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/priority', () => {
 
   it('should return 502 Bad Gateway error if priority setting failed', async () => {
     nock('http://universe')
-      .post('/jobs/priorities?' + setPriorityParams, {['testjob']: /[0-9]+/})
+      .post('/jobs/priorities?' + setPriorityParams, { 'testjob': /[0-9]+/ })
       .reply(500)
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/priority',
-    {priority: 0}, {params: userParams})
+      { priority: 0 }, { params: userParams })
 
     response.status.should.equal(502)
   })

--- a/src/dashboard/server/test/controllers/cluster/job/putJobStatus.js
+++ b/src/dashboard/server/test/controllers/cluster/job/putJobStatus.js
@@ -22,7 +22,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       })
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
-    {status: 'approved'}, {params: userParams})
+      { status: 'approved' }, { params: userParams })
 
     response.status.should.equal(200)
     response.data.should.have.property('message', 'status approved set successfully')
@@ -36,7 +36,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       })
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
-    {status: 'killing'}, {params: userParams})
+      { status: 'killing' }, { params: userParams })
 
     response.status.should.equal(200)
     response.data.should.have.property('message', 'status killing set successfully')
@@ -50,7 +50,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       })
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
-    {status: 'pausing'}, {params: userParams})
+      { status: 'pausing' }, { params: userParams })
 
     response.status.should.equal(200)
     response.data.should.have.property('message', 'status pausing set successfully')
@@ -65,7 +65,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       })
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
-    {status: 'queued'}, {params: userParams})
+      { status: 'queued' }, { params: userParams })
 
     response.status.should.equal(200)
     response.data.should.have.property('message', 'status queued set successfully')
@@ -77,10 +77,10 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       .reply(500)
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
-    {status: 'approved'}, {params: userParams})
+      { status: 'approved' }, { params: userParams })
 
     response.status.should.equal(500)
-    })
+  })
 
   it('[N-02] should return response status if killing set failed', async () => {
     nock('http://universe')
@@ -88,7 +88,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       .reply(500)
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
-    {status: 'killing'}, {params: userParams})
+      { status: 'killing' }, { params: userParams })
 
     response.status.should.equal(500)
   })
@@ -99,7 +99,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       .reply(500)
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
-    {status: 'pausing'}, {params: userParams})
+      { status: 'pausing' }, { params: userParams })
 
     response.status.should.equal(500)
   })
@@ -110,15 +110,14 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       .reply(500)
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
-    {status: 'queued'}, {params: userParams})
+      { status: 'queued' }, { params: userParams })
 
     response.status.should.equal(500)
   })
 
   it('[N-05] should return 400 Invalid status when status is invalid', async () => {
-
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
-    {status: 'invalid'}, {params: userParams})
+      { status: 'invalid' }, { params: userParams })
 
     response.status.should.equal(400)
   })

--- a/src/dashboard/server/test/controllers/cluster/job/putJobStatus.js
+++ b/src/dashboard/server/test/controllers/cluster/job/putJobStatus.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const nock = require('nock')
 const User = require('../../../../api/services/user')
 const api = require('../../../../api').callback()
@@ -21,7 +20,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       .reply(200, {
         message: 'status approved set successfully'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
     {status: 'approved'}, {params: userParams})
@@ -36,7 +34,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       .reply(200, {
         message: 'status killing set successfully'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
     {status: 'killing'}, {params: userParams})
@@ -51,7 +48,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       .reply(200, {
         message: 'status pausing set successfully'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
     {status: 'pausing'}, {params: userParams})
@@ -67,7 +63,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
       .reply(200, {
         message: 'status queued set successfully'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
     {status: 'queued'}, {params: userParams})
@@ -80,7 +75,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     nock('http://universe')
       .get('/ApproveJob?' + setStatusParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
     {status: 'approved'}, {params: userParams})
@@ -92,7 +86,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     nock('http://universe')
       .get('/KillJob?' + setStatusParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
     {status: 'killing'}, {params: userParams})
@@ -104,7 +97,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     nock('http://universe')
       .get('/PauseJob?' + setStatusParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
     {status: 'pausing'}, {params: userParams})
@@ -116,7 +108,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     nock('http://universe')
       .get('/ResumeJob?' + setStatusParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
     {status: 'queued'}, {params: userParams})
@@ -125,7 +116,6 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
   })
 
   it('[N-05] should return 400 Invalid status when status is invalid', async () => {
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
     {status: 'invalid'}, {params: userParams})

--- a/src/dashboard/server/test/controllers/cluster/jobs.post.js
+++ b/src/dashboard/server/test/controllers/cluster/jobs.post.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const nock = require('nock')
 const _ = require('lodash')
 
@@ -18,7 +17,6 @@ describe('POST /clusters/:clusterid/jobs', () => {
       .reply(200, {
         message: 'job adding succeeded'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).post('/clusters/Universe/jobs',
       { vcName: 'test' }, { params: userParams })
@@ -32,7 +30,6 @@ describe('POST /clusters/:clusterid/jobs', () => {
       .reply(200, {
         message: 'job adding succeeded'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).post('/clusters/Universe/jobs',
       { vcName: 'test', team: null }, { params: userParams })
@@ -41,7 +38,6 @@ describe('POST /clusters/:clusterid/jobs', () => {
     response.data.should.have.property('message', 'job adding succeeded')
   })
   it('should response 400 Bad Request if job schema is invalid', async () => {
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).post('/clusters/Universe/jobs',
       {}, {params: userParams})
@@ -54,7 +50,6 @@ describe('POST /clusters/:clusterid/jobs', () => {
       .reply(200, {
         message: 'job adding succeeded'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves()
 
     const response = await axiosist(api).post('/clusters/Universe/jobs',
       { vcName: 'test', userName: 'foo' }, { params: userParams })

--- a/src/dashboard/server/test/controllers/cluster/jobs.post.js
+++ b/src/dashboard/server/test/controllers/cluster/jobs.post.js
@@ -38,9 +38,8 @@ describe('POST /clusters/:clusterid/jobs', () => {
     response.data.should.have.property('message', 'job adding succeeded')
   })
   it('should response 400 Bad Request if job schema is invalid', async () => {
-
     const response = await axiosist(api).post('/clusters/Universe/jobs',
-      {}, {params: userParams})
+      {}, { params: userParams })
     response.status.should.equal(400)
   })
 

--- a/src/dashboard/server/test/controllers/team/cluster.js
+++ b/src/dashboard/server/test/controllers/team/cluster.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const nock = require('nock')
 const api = require('../../../api').callback()
 const User = require('../../../api/services/user')
@@ -22,7 +21,6 @@ describe('GET /teams/:teamId/clusters/:clusterId', () => {
       .reply(200, {
         message: 'test team info'
       })
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams/testteam/clusters/Universe', {
       params: userParams
@@ -36,7 +34,6 @@ describe('GET /teams/:teamId/clusters/:clusterId', () => {
     nock('http://Universe')
       .get('/GetVC?' + getTeamParams)
       .reply(500)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams/testteam/clusters/Universe', {
       params: userParams
@@ -49,7 +46,6 @@ describe('GET /teams/:teamId/clusters/:clusterId', () => {
     nock('http://Universe')
       .get('/GetVC?' + getTeamParams)
       .reply(200, null)
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams/testteam/clusters/Universe', {
       params: userParams

--- a/src/dashboard/server/test/controllers/team/jobs.js
+++ b/src/dashboard/server/test/controllers/team/jobs.js
@@ -44,7 +44,7 @@ const testJobs = {
 
 describe('GET /teams/:teamId/jobs', () => {
   it('[P-01] should return jobs info in the team with user as all', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       // nock for getJobs()
       nock(clusterConfig[key]['restfulapi'])
         .get('/ListJobs?' + getJobsParams)
@@ -65,14 +65,14 @@ describe('GET /teams/:teamId/jobs', () => {
     }
 
     const response = await axiosist(api).get('/teams/testteam/jobs?user=all',
-      {params: userParams})
+      { params: userParams })
 
     response.status.should.equal(200)
     response.data.length.should.equal(8)
   })
 
   it('[P-02] should return jobs info in the team with specific user', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       // change the jobOwner in getJobs params
       getJobsParams.set('jobOwner', userParams.email)
 
@@ -96,7 +96,7 @@ describe('GET /teams/:teamId/jobs', () => {
     }
 
     const response = await axiosist(api).get('/teams/testteam/jobs',
-      {params: userParams})
+      { params: userParams })
 
     response.status.should.equal(200)
     response.data.length.should.equal(8)
@@ -106,7 +106,7 @@ describe('GET /teams/:teamId/jobs', () => {
     // change back the jobOwner in getJobs params
     getJobsParams.set('jobOwner', 'all')
 
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       // nock for getJobs()
       nock(clusterConfig[key]['restfulapi'])
         .get('/ListJobs?' + getJobsParams)
@@ -122,14 +122,14 @@ describe('GET /teams/:teamId/jobs', () => {
     }
 
     const response = await axiosist(api).get('/teams/testteam/jobs?user=all',
-      {params: userParams})
+      { params: userParams })
 
     response.status.should.equal(200)
     response.data.should.be.empty()
   })
 
   it('[N-02] should ignore errors if getJobsPriority failed', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       // nock for getJobs()
       nock(clusterConfig[key]['restfulapi'])
         .get('/ListJobs?' + getJobsParams)
@@ -146,7 +146,7 @@ describe('GET /teams/:teamId/jobs', () => {
     }
 
     const response = await axiosist(api).get('/teams/testteam/jobs?user=all',
-      {params: userParams})
+      { params: userParams })
 
     response.status.should.equal(200)
     response.data.length.should.equal(8)

--- a/src/dashboard/server/test/controllers/team/jobs.js
+++ b/src/dashboard/server/test/controllers/team/jobs.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const nock = require('nock')
 const config = require('config')
 const api = require('../../../api').callback()
@@ -64,7 +63,6 @@ describe('GET /teams/:teamId/jobs', () => {
           runjob: 2
         })
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams/testteam/jobs?user=all',
       {params: userParams})
@@ -96,7 +94,6 @@ describe('GET /teams/:teamId/jobs', () => {
           runjob: 2
         })
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams/testteam/jobs',
       {params: userParams})
@@ -123,7 +120,6 @@ describe('GET /teams/:teamId/jobs', () => {
           runjob: 2
         })
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams/testteam/jobs?user=all',
       {params: userParams})
@@ -148,7 +144,6 @@ describe('GET /teams/:teamId/jobs', () => {
         .get('/jobs/priorities')
         .reply(500)
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams/testteam/jobs?user=all',
       {params: userParams})

--- a/src/dashboard/server/test/controllers/team/template.delete.js
+++ b/src/dashboard/server/test/controllers/team/template.delete.js
@@ -22,7 +22,7 @@ const deleteTemplateParams = new URLSearchParams({
 
 describe('DELETE /teams/:teamId/templates/:templateName', () => {
   it('should return 204 if template deleted successfully', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .delete('/templates?' + deleteTemplateParams)
         .reply(200, {
@@ -38,7 +38,7 @@ describe('DELETE /teams/:teamId/templates/:templateName', () => {
   })
 
   it('should return 502 if template deleting failed', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .delete('/templates?' + deleteTemplateParams)
         .reply(500)

--- a/src/dashboard/server/test/controllers/team/template.delete.js
+++ b/src/dashboard/server/test/controllers/team/template.delete.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const nock = require('nock')
 const config = require('config')
 const api = require('../../../api').callback()
@@ -30,7 +29,6 @@ describe('DELETE /teams/:teamId/templates/:templateName', () => {
           message: 'template deleted successfully'
         })
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).delete('/teams/testteam/templates/newtemplate', {
       params: userParams
@@ -45,7 +43,6 @@ describe('DELETE /teams/:teamId/templates/:templateName', () => {
         .delete('/templates?' + deleteTemplateParams)
         .reply(500)
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).delete('/teams/testteam/templates/newtemplate', {
       params: userParams

--- a/src/dashboard/server/test/controllers/team/template.js
+++ b/src/dashboard/server/test/controllers/team/template.js
@@ -20,7 +20,7 @@ const getTemplatesParams = new URLSearchParams({
 
 describe('GET /teams/:teamId/templates', () => {
   it('should return template info', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .get('/templates?' + getTemplatesParams)
         .reply(200, {
@@ -38,7 +38,7 @@ describe('GET /teams/:teamId/templates', () => {
   })
 
   it('response should be empty if templates getting failed', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .get('/templates?' + getTemplatesParams)
         .reply(500)

--- a/src/dashboard/server/test/controllers/team/template.js
+++ b/src/dashboard/server/test/controllers/team/template.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const nock = require('nock')
 const config = require('config')
 const api = require('../../../api').callback()
@@ -28,7 +27,6 @@ describe('GET /teams/:teamId/templates', () => {
           name: key
         })
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams/testteam/templates', {
       params: userParams
@@ -45,7 +43,6 @@ describe('GET /teams/:teamId/templates', () => {
         .get('/templates?' + getTemplatesParams)
         .reply(500)
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams/testteam/templates', {
       params: userParams

--- a/src/dashboard/server/test/controllers/team/template.put.js
+++ b/src/dashboard/server/test/controllers/team/template.put.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const nock = require('nock')
 const config = require('config')
 const api = require('../../../api').callback()
@@ -30,7 +29,6 @@ describe('PUT /teams/:teamId/templates/:templateName', () => {
           message: 'template updated successfully'
         })
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api)
       .put('/teams/testteam/templates/newtemplate', null, {
@@ -46,7 +44,6 @@ describe('PUT /teams/:teamId/templates/:templateName', () => {
         .post('/templates?' + updateTemplateParams)
         .reply(500)
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api)
       .put('/teams/testteam/templates/newtemplate', null, {

--- a/src/dashboard/server/test/controllers/team/template.put.js
+++ b/src/dashboard/server/test/controllers/team/template.put.js
@@ -22,7 +22,7 @@ const updateTemplateParams = new URLSearchParams({
 
 describe('PUT /teams/:teamId/templates/:templateName', () => {
   it('should return 204 if template updated successfully', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .post('/templates?' + updateTemplateParams)
         .reply(200, {
@@ -39,7 +39,7 @@ describe('PUT /teams/:teamId/templates/:templateName', () => {
   })
 
   it('should return 502 if template updating failed', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .post('/templates?' + updateTemplateParams)
         .reply(500)

--- a/src/dashboard/server/test/controllers/teams.js
+++ b/src/dashboard/server/test/controllers/teams.js
@@ -1,6 +1,5 @@
 const axiosist = require('axiosist')
 const config = require('config')
-const sinon = require('sinon')
 const nock = require('nock')
 const api = require('../../api').callback()
 const User = require('../../api/services/user')
@@ -44,7 +43,6 @@ describe('GET /teams', () => {
         .get('/ListVCs?' + fetchParams)
         .reply(200, posTeamData[key])
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams', {
       params: userParams
@@ -72,7 +70,6 @@ describe('GET /teams', () => {
         .get('/ListVCs?' + fetchParams)
         .reply(200, negTeamData)
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams', {
       params: userParams
@@ -95,7 +92,6 @@ describe('GET /teams', () => {
         .get('/ListVCs?' + fetchParams)
         .reply(500, negTeamData)
     }
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/teams', {
       params: userParams

--- a/src/dashboard/server/test/controllers/teams.js
+++ b/src/dashboard/server/test/controllers/teams.js
@@ -38,7 +38,7 @@ const fetchParams = new URLSearchParams({
 
 describe('GET /teams', () => {
   it('[P-01] should return the teams info of cluster', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .get('/ListVCs?' + fetchParams)
         .reply(200, posTeamData[key])
@@ -55,7 +55,7 @@ describe('GET /teams', () => {
   })
 
   it('[N-01] should return empty gpus info with incorrect metadata or quota format', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       // team data for the wrong format negative case
       const negTeamData = {
         result: [{
@@ -82,7 +82,7 @@ describe('GET /teams', () => {
   })
 
   it('[N-02] response data should be empty when there is a server error', async () => {
-    for(let key in clusterConfig) {
+    for (let key in clusterConfig) {
       // team data for the empty data case
       const negTeamData = {
         result: {}

--- a/src/dashboard/server/test/controllers/user.js
+++ b/src/dashboard/server/test/controllers/user.js
@@ -1,5 +1,4 @@
 const axiosist = require('axiosist')
-const sinon = require('sinon')
 const User = require('../../api/services/user')
 const api = require('../../api').callback()
 
@@ -10,8 +9,6 @@ const userParams = {
 
 describe('GET /user', () => {
   it('should response user password', async () => {
-    sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
-
     const response = await axiosist(api).get('/user', {
       params: userParams
     })

--- a/src/dashboard/src/contexts/User.tsx
+++ b/src/dashboard/src/contexts/User.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 interface Context {
   email?: string;
-  uid?: string;
   familyName?: string;
   givenName?: string;
   password?: string;
@@ -14,16 +13,15 @@ export default Context;
 
 interface ProviderProps {
   email?: string;
-  uid?: string;
   familyName?: string;
   givenName?: string;
   password?: string;
 }
 
-export const Provider: React.FC<ProviderProps> = ({ email, uid, familyName, givenName, password, children }) => {
+export const Provider: React.FC<ProviderProps> = ({ email, familyName, givenName, password, children }) => {
   return (
     <Context.Provider
-      value={{ email,uid, familyName, givenName, password }}
+      value={{ email, familyName, givenName, password }}
       children={children}
     />
   );

--- a/src/dashboard/src/pages/Submission/DataJob.tsx
+++ b/src/dashboard/src/pages/Submission/DataJob.tsx
@@ -47,7 +47,7 @@ const DataJob: React.FC = (props: any) => {
   const [openDialog, setOpenDialog] = useState(false);
   const[dialogContentText, setDialogContentText] = useState('');
   const [submittable, setSubmittable] = useState(true);
-  const {email,uid } = React.useContext(UserContext);
+  const {email} = React.useContext(UserContext);
   const {teams, selectedTeam} = React.useContext(TeamsContext);
   const { selectedCluster,saveSelectedCluster } = React.useContext(ClustersContext);
   const [workStorage, setWorkStorage ] = useState('');
@@ -138,7 +138,6 @@ const DataJob: React.FC = (props: any) => {
     dataJob.runningasroot = "1";
     dataJob.resourcegpu = 0;
     dataJob.containerUserId = 0;
-    dataJob.userId = uid;
     dataJob.image = "indexserveregistry.azurecr.io/dlts-data-transfer-image";
     dataJob.cmd = [
       "cd /DataUtils && ./copy_data.sh",

--- a/src/dashboard/src/pages/Submission/Training.tsx
+++ b/src/dashboard/src/pages/Submission/Training.tsx
@@ -74,7 +74,7 @@ const sanitizePath = (path: string) => {
 }
 const Training: React.ComponentClass = withRouter(({ history }) => {
   const { selectedCluster,saveSelectedCluster } = React.useContext(ClustersContext);
-  const { email, uid } = React.useContext(UserContext);
+  const { email } = React.useContext(UserContext);
   const { teams, selectedTeam }= React.useContext(TeamsContext);
   //const team = 'platform';
   const [showGPUFragmentation, setShowGPUFragmentation] = React.useState(false)
@@ -603,7 +603,6 @@ const Training: React.ComponentClass = withRouter(({ history }) => {
     plugins['imagePull'].push(imagePullObj)
     const job: any = {
       userName: email,
-      userId: uid,
       jobType: 'training',
       gpuType: gpuModel,
       vcName: selectedTeam,

--- a/src/dashboard/yarn.lock
+++ b/src/dashboard/yarn.lock
@@ -2040,35 +2040,6 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
-  integrity sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
-  dependencies:
-    type-detect "4.0.8"
-
-"@sinonjs/formatio@^3.2.1":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
-  integrity sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
-  dependencies:
-    "@sinonjs/commons" "^1"
-    "@sinonjs/samsam" "^3.1.0"
-
-"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.3":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
-  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
-  dependencies:
-    "@sinonjs/commons" "^1.3.0"
-    array-from "^2.1.1"
-    lodash "^4.17.15"
-
-"@sinonjs/text-encoding@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
-  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
-
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"
@@ -2538,11 +2509,6 @@
   integrity sha512-Mi6YZ2ABnnGGFMuiBDP0a8s1ZDCDNHqP97UH8TyDmCWuGGavpsFMfJnAMYaaqmDlSCOCNbVLHBrSDEOpx/oLhw==
   dependencies:
     should "*"
-
-"@types/sinon@^7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.5.0.tgz#f5a10c27175465a0b001b68d8b9f761582967cc6"
-  integrity sha512-NyzhuSBy97B/zE58cDw4NyGvByQbAHNP9069KVSgnXt/sc0T6MFRh0InKAeBVHJWdSXG1S3+PxgVIgKo9mTHbw==
 
 "@types/sonic-boom@*":
   version "0.6.2"
@@ -3082,11 +3048,6 @@ array-flatten@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
-
-array-from@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
-  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-ify@^1.0.0:
   version "1.0.0"
@@ -5304,7 +5265,7 @@ diff-sequences@^24.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
-diff@3.5.0, diff@^3.5.0:
+diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -8607,11 +8568,6 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
-just-extend@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
-  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
-
 jwa@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
@@ -9095,11 +9051,6 @@ loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
-
-lolex@^4.1.0, lolex@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
-  integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -9714,17 +9665,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-nise@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.2.tgz#b6d29af10e48b321b307e10e065199338eeb2652"
-  integrity sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==
-  dependencies:
-    "@sinonjs/formatio" "^3.2.1"
-    "@sinonjs/text-encoding" "^0.7.1"
-    just-extend "^4.0.2"
-    lolex "^4.1.0"
-    path-to-regexp "^1.7.0"
 
 no-case@^2.2.0:
   version "2.3.2"
@@ -13000,19 +12940,6 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-sinon@^7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
-  integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
-  dependencies:
-    "@sinonjs/commons" "^1.4.0"
-    "@sinonjs/formatio" "^3.2.1"
-    "@sinonjs/samsam" "^3.3.3"
-    diff "^3.5.0"
-    lolex "^4.2.0"
-    nise "^1.5.2"
-    supports-color "^5.5.0"
-
 sisteransi@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.0.tgz#77d9622ff909080f1c19e5f4a1df0c1b0a27b88c"
@@ -13559,7 +13486,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.5.0:
+supports-color@^5.2.0, supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -13969,7 +13896,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
Depends on user-synchronizer, ~only backend changes included~

~@LeoHongyi since there will be no `uid` `gid` in user session, could you please continue this branch to check if there introduces extra breaking changes.~

Edited:

It seems that the only effect of removing 'uid' in frontend will be lacking userId field in job params, which is auto filled in https://github.com/microsoft/DLWorkspace/blob/2957ca7/src/utils/JobRestAPIUtils.py#L98-L99.

Moreover, gid / groups fields are not used in frontend.