### PR TITLE
Support per-job configurable docker registry secret

### DIFF
--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -677,7 +677,8 @@ default_config_parameters = {
     "infiniband_mounts": [],
     "custom_mounts": [],
     "enable_cpuworker": False,
-    "enable_blobfuse": False
+    "enable_blobfuse": False,
+    "enable_custom_image_secrets": False
 }
 
 # These are super scripts

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -678,7 +678,7 @@ default_config_parameters = {
     "custom_mounts": [],
     "enable_cpuworker": False,
     "enable_blobfuse": False,
-    "enable_custom_image_secrets": False
+    "enable_custom_registry_secrets": False
 }
 
 # These are super scripts

--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -64,4 +64,4 @@ enable_blobfuse: {{cnf["enable_blobfuse"]}}
 local_fast_storage: {{cnf["local_fast_storage"]}}
 user_sign_token: {{cnf["user_sign_token"]}}
 
-enable_custom_image_secrets: {{cnf["enable_custom_image_secrets"]}}
+enable_custom_registry_secrets: {{cnf["enable_custom_registry_secrets"]}}

--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -63,3 +63,5 @@ enable_blobfuse: {{cnf["enable_blobfuse"]}}
 
 local_fast_storage: {{cnf["local_fast_storage"]}}
 user_sign_token: {{cnf["user_sign_token"]}}
+
+enable_custom_image_secrets: {{cnf["enable_custom_image_secrets"]}}

--- a/src/ClusterManager/job.py
+++ b/src/ClusterManager/job.py
@@ -379,7 +379,7 @@ class Job:
         enable_custom_image_secrets = self.get_enable_custom_image_secrets()
         if enable_custom_image_secrets is None or \
                 enable_custom_image_secrets is False:
-            return None
+            return []
 
         image_pull_secrets = []
         for i, image_pull in enumerate(plugins):

--- a/src/ClusterManager/job.py
+++ b/src/ClusterManager/job.py
@@ -251,8 +251,8 @@ class Job:
     def get_enable_blobfuse(self):
         return self._get_cluster_config("enable_blobfuse")
 
-    def get_enable_custom_image_secrets(self):
-        return self._get_cluster_config("enable_custom_image_secrets")
+    def get_enable_custom_registry_secrets(self):
+        return self._get_cluster_config("enable_custom_registry_secrets")
 
     def _get_cluster_config(self, key):
         if key in self.cluster:
@@ -376,9 +376,9 @@ class Job:
     def get_image_pull_secret_plugins(self, plugins):
         """Constructs and returns a list of imagePullSecrets plugins."""
 
-        enable_custom_image_secrets = self.get_enable_custom_image_secrets()
-        if enable_custom_image_secrets is None or \
-                enable_custom_image_secrets is False:
+        enable_custom_registry_secrets = self.get_enable_custom_registry_secrets()
+        if enable_custom_registry_secrets is None or \
+                enable_custom_registry_secrets is False:
             return []
 
         image_pull_secrets = []

--- a/src/ClusterManager/job.py
+++ b/src/ClusterManager/job.py
@@ -406,7 +406,7 @@ class Job:
 
             secret = {
                 "enabled": True,
-                "name": "%s-imagePull-%d-secreds" % (self.job_id, i),
+                "name": "%s-imagepull-%d-secreds" % (self.job_id, i),
                 "dockerconfigjson": dockerconfigjson,
                 "jobId": self.job_id
             }

--- a/src/ClusterManager/job_launcher.py
+++ b/src/ClusterManager/job_launcher.py
@@ -534,21 +534,25 @@ class PythonLauncher(Launcher):
                 job_object.params["envs"] =[]
             job_object.params["envs"].append({"name": "DLTS_JOB_TOKEN", "value": job_object.params["job_token"]})              
 
-
             enable_custom_scheduler = job_object.is_custom_scheduler_enabled()
-            secret_template = job_object.get_blobfuse_secret_template()
+            blobfuse_secret_template = job_object.get_blobfuse_secret_template()
+            image_pull_secret_template = job_object.get_image_pull_secret_template()
+            secret_templates = {
+                "blobfuse": blobfuse_secret_template,
+                "imagePull": image_pull_secret_template
+            }
             if job_object.params["jobtrainingtype"] == "RegularJob":
                 pod_template = PodTemplate(job_object.get_template(),
                                            enable_custom_scheduler=enable_custom_scheduler,
-                                           secret_template=secret_template)
+                                           secret_templates=secret_templates)
             elif job_object.params["jobtrainingtype"] == "PSDistJob":
                 pod_template = DistPodTemplate(job_object.get_template(),
-                                               secret_template=secret_template)
+                                               secret_templates=secret_templates)
             elif job_object.params["jobtrainingtype"] == "InferenceJob":
                 pod_template = PodTemplate(job_object.get_template(),
                                            deployment_template=job_object.get_deployment_template(),
                                            enable_custom_scheduler=False,
-                                           secret_template=secret_template)
+                                           secret_templates=secret_templates)
             else:
                 dataHandler.SetJobError(job_object.job_id, "ERROR: invalid jobtrainingtype: %s" % job_object.params["jobtrainingtype"])
                 dataHandler.Close()

--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -12,11 +12,11 @@ from osUtils import mkdirsAsUser
 
 
 class PodTemplate():
-    def __init__(self, template, deployment_template=None, enable_custom_scheduler=False, secret_template=None):
+    def __init__(self, template, deployment_template=None, enable_custom_scheduler=False, secret_templates=None):
         self.template = template
         self.deployment_template = deployment_template
         self.enable_custom_scheduler = enable_custom_scheduler
-        self.secret_template = secret_template
+        self.secret_templates = secret_templates
 
     @staticmethod
     def generate_launch_script(job_id, path_to_save, user_id, gpu_num, user_script):
@@ -226,15 +226,31 @@ class PodTemplate():
 
         # Create secret config for each plugins
         k8s_secrets = []
-        for plugin, config in plugins.items():
-            if plugin == "blobfuse" and isinstance(plugins["blobfuse"], list):
-                for bf in plugins["blobfuse"]:
-                    k8s_secret = self.generate_secret(bf)
+        for plugin, plugin_config in plugins.items():
+            if plugin == "blobfuse" and isinstance(plugin_config, list):
+                for bf in plugin_config:
+                    k8s_secret = self.generate_blobfuse_secret(bf)
+                    k8s_secrets.append(k8s_secret)
+            elif plugin == "imagePull" and isinstance(plugin_config, list):
+                for image_pull in plugin_config:
+                    k8s_secret = self.generate_image_pull_secret(image_pull)
                     k8s_secrets.append(k8s_secret)
         return k8s_secrets
 
-    def generate_secret(self, plugin):
-        assert self.secret_template is not None
-        assert isinstance(self.template, Template)
-        secret_yaml = self.secret_template.render(plugin=plugin)
+    def generate_blobfuse_secret(self, plugin):
+        assert self.secret_templates is not None
+        assert "blobfuse" in self.secret_templates
+        secret_template = self.secret_templates["blobfuse"]
+        assert isinstance(secret_template, Template)
+
+        secret_yaml = secret_template.render(plugin=plugin)
+        return yaml.full_load(secret_yaml)
+
+    def generate_image_pull_secret(self, plugin):
+        assert self.secret_templates is not None
+        assert "imagePull" in self.secret_templates
+        secret_template = self.secret_templates["imagePull"]
+        assert isinstance(secret_template, Template)
+
+        secret_yaml = secret_template.render(plugin=plugin)
         return yaml.full_load(secret_yaml)

--- a/src/Jobs_Templete/image_pull_secret.yaml.template
+++ b/src/Jobs_Templete/image_pull_secret.yaml.template
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ plugin.name }}
+  namespace: default
+  labels:
+    run: {{ plugin.jobId }}
+data:
+  .dockerconfigjson: {{ plugin.dockerconfigjson }}
+type: kubernetes.io/dockerconfigjson

--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -231,6 +231,15 @@ spec:
     {% endfor %}
 
   imagePullSecrets:
+  {% if job["plugins"] %}
+    {% if job["plugins"]["imagePull"] %}
+      {% for secret in job["plugins"]["imagePull"] %}
+        {% if secret.enabled %}
+  - name: {{ secret.name }}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  {% endif %}
   - name: regcred
 
   restartPolicy: Never


### PR DESCRIPTION
To turn on custom docker registry support in a cluster, add to `config.yaml`:
```
enable_custom_registry_secrets: True
```

Example job:
```
~$ kubectl get pod 802e63ec-ca4b-4b1c-8218-6f438b16c0d1
NAME                                   READY   STATUS    RESTARTS   AGE
802e63ec-ca4b-4b1c-8218-6f438b16c0d1   1/1     Running   0          32m

~$ kubectl get secrets
NAME                                                       TYPE                                  DATA   AGE
802e63ec-ca4b-4b1c-8218-6f438b16c0d1-blobfuse-0-secreds    azure/blobfuse                        2      32m
802e63ec-ca4b-4b1c-8218-6f438b16c0d1-imagepull-0-secreds   kubernetes.io/dockerconfigjson        1      32m
```