### PR TITLE
Dashboard frontent: Remove uid dependency

### DIFF
--- a/src/dashboard/src/App.tsx
+++ b/src/dashboard/src/App.tsx
@@ -28,7 +28,6 @@ const theme = createMuiTheme();
 
 interface BootstrapProps {
   email?: string;
-  uid?: string;
   familyName?: string;
   givenName?: string;
   password?: any;
@@ -42,10 +41,10 @@ const Loading = (
   </Box>
 );
 
-const Contexts: React.FC<BootstrapProps> = ({ email, uid, familyName, givenName,password ,WikiLink,addGroupLink,children }) => {
+const Contexts: React.FC<BootstrapProps> = ({ email, familyName, givenName,password ,WikiLink,addGroupLink,children }) => {
   return (
     <BrowserRouter>
-      <UserProvider email={email} uid={uid} familyName={familyName} givenName={givenName} token={password} >
+      <UserProvider email={email} familyName={familyName} givenName={givenName} token={password} >
         <TeamProvider addGroupLink={addGroupLink} WikiLink={WikiLink}>
           <ClustersProvider>
             <ThemeProvider theme={theme}>

--- a/src/dashboard/src/contexts/User.tsx
+++ b/src/dashboard/src/contexts/User.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 interface Context {
   email?: string;
-  uid?: string;
   familyName?: string;
   givenName?: string;
   token?: any;
@@ -14,19 +13,18 @@ export default Context;
 
 interface ProviderProps {
   email?: string;
-  uid?: string;
   familyName?: string;
   givenName?: string;
   token?: any;
 }
 
-export const Provider: React.FC<ProviderProps> = ({ email, uid,familyName, givenName,token,children }) => {
+export const Provider: React.FC<ProviderProps> = ({ email, familyName, givenName,token,children }) => {
   if (token) {
     token = new Buffer(token.data).toString('hex');
   }
   return (
     <Context.Provider
-      value={{ email,uid,familyName,givenName,token }}
+      value={{ email,familyName,givenName,token }}
       children={children}
     />
   );

--- a/src/dashboard/src/pages/Submission/DataJob.tsx
+++ b/src/dashboard/src/pages/Submission/DataJob.tsx
@@ -47,7 +47,7 @@ const DataJob: React.FC = (props: any) => {
   const [openDialog, setOpenDialog] = useState(false);
   const[dialogContentText, setDialogContentText] = useState('');
   const [submittable, setSubmittable] = useState(true);
-  const {email,uid } = React.useContext(UserContext);
+  const {email} = React.useContext(UserContext);
   const {teams, selectedTeam} = React.useContext(TeamsContext);
   const { selectedCluster,saveSelectedCluster } = React.useContext(ClustersContext);
   const [workStorage, setWorkStorage ] = useState('');
@@ -138,7 +138,6 @@ const DataJob: React.FC = (props: any) => {
     dataJob.runningasroot = "1";
     dataJob.resourcegpu = 0;
     dataJob.containerUserId = 0;
-    dataJob.userId = uid;
     dataJob.image = "indexserveregistry.azurecr.io/dlts-data-transfer-image";
     dataJob.cmd = [
       "cd /DataUtils && ./copy_data.sh",

--- a/src/dashboard/src/pages/Submission/Training.tsx
+++ b/src/dashboard/src/pages/Submission/Training.tsx
@@ -74,7 +74,7 @@ const sanitizePath = (path: string) => {
 }
 const Training: React.ComponentClass = withRouter(({ history }) => {
   const { selectedCluster,saveSelectedCluster } = React.useContext(ClustersContext);
-  const { email, uid } = React.useContext(UserContext);
+  const { email } = React.useContext(UserContext);
   const { teams, selectedTeam }= React.useContext(TeamsContext);
   //const team = 'platform';
   const [showGPUFragmentation, setShowGPUFragmentation] = React.useState(false)
@@ -603,7 +603,6 @@ const Training: React.ComponentClass = withRouter(({ history }) => {
     plugins['imagePull'].push(imagePullObj)
     const job: any = {
       userName: email,
-      userId: uid,
       jobType: 'training',
       gpuType: gpuModel,
       vcName: selectedTeam,


### PR DESCRIPTION
This PR is for: removing WinBind dependency

It seems that the only effect of removing 'uid' in frontend will be lacking `userId` field in job params, which is auto filled in <https://github.com/microsoft/DLWorkspace/blob/2957ca7/src/utils/JobRestAPIUtils.py#L98-L99>.

Moreover, `gid` / `groups` fields are not used in frontend.