### PR TITLE
perf optimization for job list and detail

### DIFF
--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -210,10 +210,12 @@ def ApproveJob(redis_conn, job, dataHandlerOri=None):
             logger.info("Job {} preemptible, approve!".format(job_id))
             detail = [{"message": "waiting for available preemptible resource."}]
 
-            fields = {}
-            fields["jobStatusDetail"] = base64.b64encode(json.dumps(detail))
-            fields["jobStatus"] = "queued"
-            dataHandler.UpdateJobTextFields(job_id, fields)
+            dataFields = {
+                "jobStatusDetail": base64.b64encode(json.dumps(detail)),
+                "jobStatus": "queued"
+            }
+            conditionFields = {"jobId": job_id}
+            dataHandler.UpdateJobTextFields(conditionFields, dataFields)
             update_job_state_latency(redis_conn, job_id, "approved")
             if dataHandlerOri is None:
                 dataHandler.Close()
@@ -254,10 +256,12 @@ def ApproveJob(redis_conn, job, dataHandlerOri=None):
 
         detail = [{"message": "waiting for available resource."}]
 
-        fields = {}
-        fields["jobStatusDetail"] = base64.b64encode(json.dumps(detail))
-        fields["jobStatus"] = "queued"
-        dataHandler.UpdateJobTextFields(job_id, fields)
+        dataFields = {
+            "jobStatusDetail": base64.b64encode(json.dumps(detail)),
+            "jobStatus": "queued"
+        }
+        conditionFields = {"jobId": job_id}
+        dataHandler.UpdateJobTextFields(conditionFields, dataFields)
         update_job_state_latency(redis_conn, job_id, "approved")
         if dataHandlerOri is None:
             dataHandler.Close()
@@ -300,10 +304,12 @@ def UpdateJobStatus(redis_conn, launcher, job, notifier=None, dataHandlerOri=Non
         detail = get_job_status_detail(job)
         detail = job_status_detail_with_finished_time(detail, "finished")
 
-        fields = {}
-        fields["jobStatusDetail"] = base64.b64encode(json.dumps(detail))
-        fields["jobStatus"] = "finished"
-        dataHandler.UpdateJobTextFields(job_id, fields)
+        dataFields = {
+            "jobStatusDetail": base64.b64encode(json.dumps(detail)),
+            "jobStatus": "finished"
+        }
+        conditionFields = {"jobId": job["jobId"]}
+        dataHandler.UpdateJobTextFields(conditionFields, dataFields)
 
         # Retain the old code for reference
         # if jobDescriptionPath is not None and os.path.isfile(jobDescriptionPath):
@@ -321,10 +327,12 @@ def UpdateJobStatus(redis_conn, launcher, job, notifier=None, dataHandlerOri=Non
             started_at = k8sUtils.localize_time(datetime.datetime.now())
             detail = [{"startedAt": started_at, "message": "started at: {}".format(started_at)}]
 
-            fields = {}
-            fields["jobStatusDetail"] = base64.b64encode(json.dumps(detail))
-            fields["jobStatus"] = "running"
-            dataHandler.UpdateJobTextFields(job_id, fields)
+            dataFields = {
+                "jobStatusDetail": base64.b64encode(json.dumps(detail)),
+                "jobStatus":"running"
+            }
+            conditionFields = {"jobId": job["jobId"]}
+            dataHandler.UpdateJobTextFields(conditionFields, dataFields)
 
     elif result == "Failed":
         logger.warning("Job %s fails, cleaning...", job["jobId"])
@@ -339,11 +347,13 @@ def UpdateJobStatus(redis_conn, launcher, job, notifier=None, dataHandlerOri=Non
         detail = get_job_status_detail(job)
         detail = job_status_detail_with_finished_time(detail, "failed")
 
-        fields = {}
-        fields["jobStatusDetail"] = base64.b64encode(json.dumps(detail))
-        fields["jobStatus"] = "failed"
-        fields["errorMsg"] = "pod failed"
-        dataHandler.UpdateJobTextFields(job_id, fields)
+        dataFields = {
+            "jobStatusDetail": base64.b64encode(json.dumps(detail)),
+            "jobStatus": "failed",
+            "errorMsg": "pod failed"
+        }
+        conditionFields = {"jobId": job["jobId"]}
+        dataHandler.UpdateJobTextFields(conditionFields, dataFields)
 
         # Retain the old code for reference
         # if jobDescriptionPath is not None and os.path.isfile(jobDescriptionPath):

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -209,8 +209,11 @@ def ApproveJob(redis_conn, job, dataHandlerOri=None):
         if "preemptionAllowed" in jobParams and jobParams["preemptionAllowed"] is True:
             logger.info("Job {} preemptible, approve!".format(job_id))
             detail = [{"message": "waiting for available preemptible resource."}]
-            dataHandler.UpdateJobTextField(job["jobId"], "jobStatusDetail", base64.b64encode(json.dumps(detail)))
-            dataHandler.UpdateJobTextField(job_id, "jobStatus", "queued")
+
+            fields = {}
+            fields["jobStatusDetail"] = base64.b64encode(json.dumps(detail))
+            fields["jobStatus"] = "queued"
+            dataHandler.UpdateJobTextFields(job_id, fields)
             update_job_state_latency(redis_conn, job_id, "approved")
             if dataHandlerOri is None:
                 dataHandler.Close()
@@ -250,8 +253,11 @@ def ApproveJob(redis_conn, job, dataHandlerOri=None):
                 return False
 
         detail = [{"message": "waiting for available resource."}]
-        dataHandler.UpdateJobTextField(job["jobId"], "jobStatusDetail", base64.b64encode(json.dumps(detail)))
-        dataHandler.UpdateJobTextField(job_id, "jobStatus", "queued")
+
+        fields = {}
+        fields["jobStatusDetail"] = base64.b64encode(json.dumps(detail))
+        fields["jobStatus"] = "queued"
+        dataHandler.UpdateJobTextFields(job_id, fields)
         update_job_state_latency(redis_conn, job_id, "approved")
         if dataHandlerOri is None:
             dataHandler.Close()
@@ -293,8 +299,11 @@ def UpdateJobStatus(redis_conn, launcher, job, notifier=None, dataHandlerOri=Non
         # TODO: Refactor
         detail = get_job_status_detail(job)
         detail = job_status_detail_with_finished_time(detail, "finished")
-        dataHandler.UpdateJobTextField(job["jobId"], "jobStatusDetail", base64.b64encode(json.dumps(detail)))
-        dataHandler.UpdateJobTextField(job["jobId"], "jobStatus", "finished")
+
+        fields = {}
+        fields["jobStatusDetail"] = base64.b64encode(json.dumps(detail))
+        fields["jobStatus"] = "finished"
+        dataHandler.UpdateJobTextFields(job_id, fields)
 
         # Retain the old code for reference
         # if jobDescriptionPath is not None and os.path.isfile(jobDescriptionPath):
@@ -311,8 +320,11 @@ def UpdateJobStatus(redis_conn, launcher, job, notifier=None, dataHandlerOri=Non
         if job["jobStatus"] != "running":
             started_at = k8sUtils.localize_time(datetime.datetime.now())
             detail = [{"startedAt": started_at, "message": "started at: {}".format(started_at)}]
-            dataHandler.UpdateJobTextField(job["jobId"], "jobStatusDetail", base64.b64encode(json.dumps(detail)))
-            dataHandler.UpdateJobTextField(job["jobId"], "jobStatus", "running")
+
+            fields = {}
+            fields["jobStatusDetail"] = base64.b64encode(json.dumps(detail))
+            fields["jobStatus"] = "running"
+            dataHandler.UpdateJobTextFields(job_id, fields)
 
     elif result == "Failed":
         logger.warning("Job %s fails, cleaning...", job["jobId"])
@@ -326,9 +338,12 @@ def UpdateJobStatus(redis_conn, launcher, job, notifier=None, dataHandlerOri=Non
         # TODO: Refactor
         detail = get_job_status_detail(job)
         detail = job_status_detail_with_finished_time(detail, "failed")
-        dataHandler.UpdateJobTextField(job["jobId"], "jobStatusDetail", base64.b64encode(json.dumps(detail)))
-        dataHandler.UpdateJobTextField(job["jobId"], "jobStatus", "failed")
-        dataHandler.UpdateJobTextField(job["jobId"], "errorMsg", "pod failed")
+
+        fields = {}
+        fields["jobStatusDetail"] = base64.b64encode(json.dumps(detail))
+        fields["jobStatus"] = "failed"
+        fields["errorMsg"] = "pod failed"
+        dataHandler.UpdateJobTextFields(job_id, fields)
 
         # Retain the old code for reference
         # if jobDescriptionPath is not None and os.path.isfile(jobDescriptionPath):

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -92,13 +92,6 @@ def tolist(value):
     else:
         return value
 
-def getAlias(username):
-    if "@" in username:
-        username = username.split("@")[0].strip()
-    if "/" in username:
-        username = username.split("/")[1].strip()
-    return username
-
 
 def remove_creds(job):
     job_params = job.get("jobParams", None)
@@ -246,7 +239,7 @@ class SubmitJob(Resource):
             params["mountpoints"] = []
             addcmd = ""
             if "mounthomefolder" in config and istrue(config["mounthomefolder"]) and "storage-mount-path" in config:
-                alias = getAlias(params["userName"])
+                alias = JobRestAPIUtils.getAlias(params["userName"])
                 params["mountpoints"].append({"name":"homeholder","containerPath":os.path.join("/home", alias),"hostPath":os.path.join(config["storage-mount-path"], "work", alias)})
             if "mountpoints" in config and "storage-mount-path" in config:
                 # see link_fileshares in deploy.py
@@ -257,7 +250,7 @@ class SubmitJob(Resource):
                                 hostBase = os.path.join(config["storage-mount-path"], basename[1:]) if os.path.isabs(basename) else os.path.join(config["storage-mount-path"], basename)
                                 basealias = basename[1:] if os.path.isabs(basename) else basename
                                 containerBase = os.path.join("/", basename)
-                                alias = getAlias(params["userName"])
+                                alias = JobRestAPIUtils.getAlias(params["userName"])
                                 shares = [alias]
                                 if "publicshare" in v:
                                     if "all" in v["publicshare"]:
@@ -1149,7 +1142,7 @@ class Endpoint(Resource):
                 return ("Bad request, interactive port name length shoule be less than 16: %s" % requested_endpoints), 400
             interactive_ports.append(interactive_port)
 
-        msg, statusCode = JobRestAPIUtils.UpdateEndpoints(userName, job_id, requested_endpoints, interactive_ports)
+        msg, statusCode = JobRestAPIUtils.UpdateEndpoints(username, job_id, requested_endpoints, interactive_ports)
         if statusCode != 200:
             return msg, statusCode
 

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -121,6 +121,11 @@ def remove_creds(job):
             i_p.pop("username", None)
             i_p.pop("password", None)
 
+def generateResponse(result):
+    resp = jsonify(result)
+    resp.headers["Access-Control-Allow-Origin"] = "*"
+    resp.headers["dataType"] = "json"
+    return resp
 
 class SubmitJob(Resource):
     def get(self):
@@ -404,13 +409,35 @@ class ListJobs(Resource):
         resp = jsonify(ret)
         resp.headers["Access-Control-Allow-Origin"] = "*"
         resp.headers["dataType"] = "json"
-
         return resp
 ##
 ## Actually setup the Api resource routing here
 ##
 api.add_resource(ListJobs, '/ListJobs')
 
+# shows a list of all todos, and lets you POST to add new tasks
+class ListJobsV2(Resource):
+    def get(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument('userName')
+        parser.add_argument('num')
+        parser.add_argument('vcName')
+        parser.add_argument('jobOwner')
+        args = parser.parse_args()
+        num = None
+        if args["num"] is not None:
+            try:
+                num = int(args["num"])
+            except:
+                pass
+
+        jobs = JobRestAPIUtils.GetJobListV2(args["userName"], args["vcName"], args["jobOwner"], num)
+        resp = generateResponse(jobs)
+        return resp
+##
+## Actually setup the Api resource routing here
+##
+api.add_resource(ListJobsV2, '/ListJobsV2')
 
 
 class KillJob(Resource):
@@ -603,6 +630,23 @@ class GetJobDetail(Resource):
 ## Actually setup the Api resource routing here
 ##
 api.add_resource(GetJobDetail, '/GetJobDetail')
+
+
+class GetJobDetailV2(Resource):
+    def get(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument('jobId')
+        parser.add_argument('userName')
+        args = parser.parse_args()
+        jobId = args["jobId"]
+        userName = args["userName"]
+        job = JobRestAPIUtils.GetJobDetailV2(userName, jobId)
+        resp = generateResponse(job)
+        return resp
+##
+## Actually setup the Api resource routing here
+##
+api.add_resource(GetJobDetailV2, '/GetJobDetailV2')
 
 
 class GetJobStatus(Resource):

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -130,12 +130,7 @@ def SubmitJob(jobParamsJsonStr):
     if "isParent" not in jobParams:
         jobParams["isParent"] = 1
 
-    userName = jobParams["userName"]
-    if "@" in userName:
-        userName = userName.split("@")[0].strip()
-
-    if "/" in userName:
-        userName = userName.split("/")[1].strip()
+    userName = getAlias(jobParams["userName"])
 
     if not AuthorizationManager.HasAccess(jobParams["userName"], ResourceType.VC, jobParams["vcName"].strip(), Permission.User):
         ret["error"] = "Access Denied!"
@@ -380,7 +375,7 @@ def ResumeJob(userName, jobId):
 def PauseJob(userName, jobId):
     dataHandler = DataHandler()
     ret = False
-    job = dataHandler.GetJobTextFields(jobId, ["userName", "vcName"])
+    job = dataHandler.GetJobTextFields(jobId, ["userName", "vcName", "jobStatus"])
     if job is not None and job["jobStatus"] in ["unapproved", "queued", "scheduling", "running"]:
         if job["userName"] == userName or AuthorizationManager.HasAccess(userName, ResourceType.VC, job["vcName"], Permission.Admin):
             ret = dataHandler.UpdateJobTextField(jobId,"jobStatus","pausing")
@@ -945,7 +940,7 @@ def update_job_priorites(username, job_priorities):
         pendingJobs = {}
         for job_id in job_priorities:
             priority = job_priorities[job_id]
-            job = dataHandler.GetJobTextFields(job_id, ["userName", "vcName", "jobStatus"])
+            job = data_handler.GetJobTextFields(job_id, ["userName", "vcName", "jobStatus"])
             if job is None:
                 continue
 

--- a/src/utils/MySQLDBUtilsPoolDataHandler.py
+++ b/src/utils/MySQLDBUtilsPoolDataHandler.py
@@ -46,14 +46,12 @@ class SingletonDBPool(object):
     __instance_lock = threading.Lock()
 
     def __init__(self, *args, **kwargs):
-        assert(kwargs.get('config') is not None)
-        config = kwargs.get('config')
         database = "DLWSCluster-%s" % config["clusterId"]
         server = config["mysql"]["hostname"]
         username = config["mysql"]["username"]
         password = config["mysql"]["password"]
         with db_connect_histogram.time():
-            self.pool = PooledDB(creator=MySQLdb, maxconnections=1000, blocking=False, 
+            self.pool = PooledDB(creator=MySQLdb, maxconnections=150, blocking=False,
                             host=server, db=database, user=username, passwd=password)
             logger.info("init MySQL DBUtils pool succeed")
 
@@ -81,9 +79,9 @@ class DataHandler(object):
         self.commandtablename = "commands"
         self.templatetablename = "templates"
         self.jobprioritytablename = "job_priorities"
-        self.pool = SingletonDBPool.instance(config=config)
+        self.pool = SingletonDBPool.instance()
         elapsed = timeit.default_timer() - start_time
-        logger.info("DataHandler initialization, time elapsed %f s", elapsed)
+        logger.info("DB Utils DataHandler initialization, time elapsed %f s", elapsed)
 
     def CreateDatabase(self):
         if "initSQLDB" not in global_vars or not global_vars["initSQLDB"]:
@@ -818,6 +816,73 @@ class DataHandler(object):
         return ret
 
     @record
+    def GetJobListV2(self, userName, vcName, num = None, status = None, op = ("=","or")):
+        ret = {}
+        ret["queuedJobs"] = []
+        ret["runningJobs"] = []
+        ret["finishedJobs"] = []
+        ret["visualizationJobs"] = []
+
+        conn = None
+        cursor = None
+        try:
+            conn = self.pool.get_connection()
+            cursor = conn.cursor()
+
+            query = ""
+            if userName == "all":
+                query = "SELECT {}.jobId, jobName, userName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams, priority FROM {} left join {} on {}.jobId = {}.jobId where 1".format(self.jobtablename, self.jobtablename, self.jobprioritytablename, self.jobtablename, self.jobprioritytablename)
+            else:
+                query = "SELECT jobId, jobName, userName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams FROM {} where userName = '{}'".format(self.jobtablename, userName)
+
+            if vcName != "all":
+                query += " and vcName = '%s'" % vcName
+
+            if status is not None:
+                if "," not in status:
+                    query += " and jobStatus %s '%s'" % (op[0], status)
+                else:
+                    status_list = [" jobStatus %s '%s' " % (op[0], s) for s in status.split(',')]
+                    status_statement = (" "+op[1]+" ").join(status_list)
+                    query += " and ( %s ) " % status_statement
+
+            query += " order by jobTime Desc"
+
+            if num is not None:
+                query += " limit %s " % str(num)
+            cursor.execute(query)
+
+            columns = [column[0] for column in cursor.description]
+            data = cursor.fetchall()
+            for item in data:
+                record = dict(zip(columns, item))
+                if record["jobStatusDetail"] is not None:
+                    record["jobStatusDetail"] = self.load_json(base64.b64decode(record["jobStatusDetail"]))
+                if record["jobParams"] is not None:
+                    record["jobParams"] = self.load_json(base64.b64decode(record["jobParams"]))
+
+                if record["jobStatus"] == "running":
+                    if record["jobType"] == "training":
+                        ret["runningJobs"].append(record)
+                    elif record["jobType"] == "visualization":
+                        ret["visualizationJobs"].append(record)
+                elif record["jobStatus"] == "queued" or record["jobStatus"] == "scheduling" or record["jobStatus"] == "unapproved":
+                    ret["queuedJobs"].append(record)
+                else:
+                    ret["finishedJobs"].append(record)
+            conn.commit()
+        except Exception as e:
+            logger.error('GetJobListV2 Exception: %s', str(e))
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+
+        ret["meta"] = {"queuedJobs": len(ret["queuedJobs"]),"runningJobs": len(ret["runningJobs"]),"finishedJobs": len(ret["finishedJobs"]),"visualizationJobs": len(ret["visualizationJobs"])}
+        return ret
+
+    @record
     def GetActiveJobList(self):
         ret = []
         conn = None
@@ -980,6 +1045,8 @@ class DataHandler(object):
         return ret
 
     def load_json(self, raw_str):
+        if raw_str is None:
+            return {}
         if isinstance(raw_str, unicode):
             raw_str = str(raw_str)
         try:
@@ -989,35 +1056,57 @@ class DataHandler(object):
 
     @record
     def GetPendingEndpoints(self):
+        conn = None
+        cursor = None
+        ret = {}
         try:
-            jobs = self.GetJob(jobStatus="running")
+            conn = self.pool.get_connection()
+            cursor = conn.cursor()
+            query = "SELECT `endpoints` from `%s` where `jobStatus` = '%s' and `endpoints` is not null" % (self.jobtablename, "running")
+            cursor.execute(query)
+            jobs = cursor.fetchall()
+            self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
+            endpoints = map(lambda job: self.load_json(job[0]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
-            pendingEndpoints = {k: v for d in endpoints for k, v in d.items() if v["status"] == "pending"}
-
-            return pendingEndpoints
+            ret = {k: v for d in endpoints for k, v in d.items() if v["status"] == "pending"}
         except Exception as e:
             logger.exception("Query pending endpoints failed!")
-            return {}
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+        return ret
 
     @record
     def GetJobEndpoints(self, job_id):
+        conn = None
+        cursor = None
+        ret = {}
         try:
-            jobs = self.GetJob(jobId=job_id)
+            conn = self.pool.get_connection()
+            cursor = conn.cursor()
+            query = "SELECT `endpoints` from `%s` where `jobId` = '%s'" % (self.jobtablename, job_id)
+            cursor.execute(query)
+            jobs = cursor.fetchall()
+            self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
+            endpoints = map(lambda job: self.load_json(job[0]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
-            endpoints = {k: v for d in endpoints for k, v in d.items()}
-
-            return endpoints
+            ret = {k: v for d in endpoints for k, v in d.items()}
         except Exception as e:
             logger.warning("Query job endpoints failed! Job {}".format(job_id), exc_info=True)
-            return {}
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+        return ret
 
     @record
     def GetDeadEndpoints(self):
@@ -1050,9 +1139,7 @@ class DataHandler(object):
         conn = None
         cursor = None
         try:
-            job_id = endpoint["jobId"]
-            job = self.GetJob(jobId=job_id)[0]
-            job_endpoints = self.load_json(job["endpoints"])
+            job_endpoints = self.GetJobEndpoints(endpoint["jobId"])
 
             # update jobEndpoints
             job_endpoints[endpoint["id"]] = endpoint
@@ -1150,6 +1237,35 @@ class DataHandler(object):
         except Exception as e:
             logger.error('UpdateJobTextField Exception: %s', str(e))
             ret = False
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+        return ret
+
+    @record
+    def UpdateJobTextFields(self, jobId, fields):
+        conn = None
+        cursor = None
+        ret = False
+        if not isinstance(fields, dict) or not fields:
+            return ret
+
+        try:
+            sql = "update `%s` set" % (self.jobtablename)
+            for field, value in fields.items():
+                sql += " `%s` = '%s'," % (field, value)
+            sql = sql[:-1]
+            sql += " where `jobId` = '%s'" % (jobId)
+
+            conn = self.pool.get_connection()
+            cursor = conn.cursor()
+            cursor.execute(sql)
+            self.conn.commit()
+            ret = True
+        except Exception as e:
+            logger.error('updateJobTextFields Exception: %s, ex: %s', fields, str(e))
         finally:
             if cursor is not None:
                 cursor.close()

--- a/src/utils/MySQLDBUtilsPoolDataHandler.py
+++ b/src/utils/MySQLDBUtilsPoolDataHandler.py
@@ -794,11 +794,9 @@ class DataHandler(object):
             conn = self.pool.get_connection()
             cursor = conn.cursor()
 
-            query = ""
-            if userName == "all":
-                query = "SELECT {}.jobId, jobName, userName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams, priority FROM {} left join {} on {}.jobId = {}.jobId where 1".format(self.jobtablename, self.jobtablename, self.jobprioritytablename, self.jobtablename, self.jobprioritytablename)
-            else:
-                query = "SELECT jobId, jobName, userName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams FROM {} where userName = '{}'".format(self.jobtablename, userName)
+            query = "SELECT {}.jobId, jobName, userName, vcName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams, priority FROM {} left join {} on {}.jobId = {}.jobId where 1".format(self.jobtablename, self.jobtablename, self.jobprioritytablename, self.jobtablename, self.jobprioritytablename)
+            if userName != "all":
+                query += " and userName = '%s'" % userName
 
             if vcName != "all":
                 query += " and vcName = '%s'" % vcName

--- a/src/utils/MySQLDBUtilsPoolDataHandler.py
+++ b/src/utils/MySQLDBUtilsPoolDataHandler.py
@@ -1063,7 +1063,7 @@ class DataHandler(object):
             self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
+            endpoints = map(lambda job: self.load_json(job[0]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
             ret = {k: v for d in endpoints for k, v in d.items() if v["status"] == "pending"}
@@ -1090,7 +1090,7 @@ class DataHandler(object):
             self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
+            endpoints = map(lambda job: self.load_json(job[0]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
             ret = {k: v for d in endpoints for k, v in d.items()}
@@ -1143,7 +1143,7 @@ class DataHandler(object):
             cursor = conn.cursor()
             
             sql = "UPDATE jobs SET endpoints=%s where jobId=%s"
-            cursor.execute(sql, (json.dumps(job_endpoints), job_id))
+            cursor.execute(sql, (json.dumps(job_endpoints), endpoint["jobId"]))
             conn.commit()
             ret = True
         except Exception as e:

--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -630,11 +630,9 @@ class DataHandler(object):
         try:
             cursor = self.conn.cursor()
 
-            query = ""
-            if userName == "all":
-                query = "SELECT {}.jobId, jobName, userName, vcName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams, priority FROM {} left join {} on {}.jobId = {}.jobId where 1".format(self.jobtablename, self.jobtablename, self.jobprioritytablename, self.jobtablename, self.jobprioritytablename)
-            else:
-                query = "SELECT jobId, jobName, userName, vcName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams FROM {} where userName = '{}'".format(self.jobtablename, userName)
+            query = "SELECT {}.jobId, jobName, userName, vcName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams, priority FROM {} left join {} on {}.jobId = {}.jobId where 1".format(self.jobtablename, self.jobtablename, self.jobprioritytablename, self.jobtablename, self.jobprioritytablename)
+            if userName != "all":
+                query += " and userName = '%s'" % userName
 
             if vcName != "all":
                 query += " and vcName = '%s'" % vcName

--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -359,7 +359,6 @@ class DataHandler(object):
             logger.error('AddVC Exception: %s', str(e))
             return False
 
-
     @record
     def ListVCs(self):
         cursor = self.conn.cursor()
@@ -854,7 +853,7 @@ class DataHandler(object):
             self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
+            endpoints = map(lambda job: self.load_json(job[0]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
             ret = {k: v for d in endpoints for k, v in d.items()}
@@ -893,7 +892,7 @@ class DataHandler(object):
 
             sql = "UPDATE jobs SET endpoints=%s where jobId=%s"
             cursor = self.conn.cursor()
-            cursor.execute(sql, (json.dumps(job_endpoints), job_id))
+            cursor.execute(sql, (json.dumps(job_endpoints), endpoint["jobId"]))
             self.conn.commit()
             cursor.close()
             return True

--- a/src/utils/MySQLPoolDataHandler.py
+++ b/src/utils/MySQLPoolDataHandler.py
@@ -45,8 +45,6 @@ class SingletonDBPool(object):
     __instance_lock = threading.Lock()
 
     def __init__(self, *args, **kwargs):
-        assert(kwargs.get("config") is not None)
-        config = kwargs.get("config")
         database = "DLWSCluster-%s" % config["clusterId"]
         server = config["mysql"]["hostname"]
         username = config["mysql"]["username"]
@@ -822,6 +820,73 @@ class DataHandler(object):
         return ret
 
     @record
+    def GetJobListV2(self, userName, vcName, num = None, status = None, op = ("=","or")):
+        ret = {}
+        ret["queuedJobs"] = []
+        ret["runningJobs"] = []
+        ret["finishedJobs"] = []
+        ret["visualizationJobs"] = []
+
+        conn = None
+        cursor = None
+        try:
+            conn = self.pool.get_connection()
+            cursor = conn.cursor()
+
+            query = ""
+            if userName == "all":
+                query = "SELECT {}.jobId, jobName, userName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams, priority FROM {} left join {} on {}.jobId = {}.jobId where 1".format(self.jobtablename, self.jobtablename, self.jobprioritytablename, self.jobtablename, self.jobprioritytablename)
+            else:
+                query = "SELECT jobId, jobName, userName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams FROM {} where userName = '{}'".format(self.jobtablename, userName)
+
+            if vcName != "all":
+                query += " and vcName = '%s'" % vcName
+
+            if status is not None:
+                if "," not in status:
+                    query += " and jobStatus %s '%s'" % (op[0], status)
+                else:
+                    status_list = [" jobStatus %s '%s' " % (op[0], s) for s in status.split(',')]
+                    status_statement = (" "+op[1]+" ").join(status_list)
+                    query += " and ( %s ) " % status_statement
+
+            query += " order by jobTime Desc"
+
+            if num is not None:
+                query += " limit %s " % str(num)
+            cursor.execute(query)
+
+            columns = [column[0] for column in cursor.description]
+            data = cursor.fetchall()
+            for item in data:
+                record = dict(zip(columns, item))
+                if record["jobStatusDetail"] is not None:
+                    record["jobStatusDetail"] = self.load_json(base64.b64decode(record["jobStatusDetail"]))
+                if record["jobParams"] is not None:
+                    record["jobParams"] = self.load_json(base64.b64decode(record["jobParams"]))
+
+                if record["jobStatus"] == "running":
+                    if record["jobType"] == "training":
+                        ret["runningJobs"].append(record)
+                    elif record["jobType"] == "visualization":
+                        ret["visualizationJobs"].append(record)
+                elif record["jobStatus"] == "queued" or record["jobStatus"] == "scheduling" or record["jobStatus"] == "unapproved":
+                    ret["queuedJobs"].append(record)
+                else:
+                    ret["finishedJobs"].append(record)
+            conn.commit()
+        except Exception as e:
+            logger.error('GetJobListV2 Exception: %s', str(e))
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+
+        ret["meta"] = {"queuedJobs": len(ret["queuedJobs"]),"runningJobs": len(ret["runningJobs"]),"finishedJobs": len(ret["finishedJobs"]),"visualizationJobs": len(ret["visualizationJobs"])}
+        return ret
+
+    @record
     def GetActiveJobList(self):
         ret = []
         conn = None
@@ -984,6 +1049,8 @@ class DataHandler(object):
         return ret
 
     def load_json(self, raw_str):
+        if raw_str is None:
+            return {}
         if isinstance(raw_str, unicode):
             raw_str = str(raw_str)
         try:
@@ -993,35 +1060,57 @@ class DataHandler(object):
 
     @record
     def GetPendingEndpoints(self):
+        conn = None
+        cursor = None
+        ret = {}
         try:
-            jobs = self.GetJob(jobStatus="running")
+            conn = self.pool.get_connection()
+            cursor = conn.cursor()
+            query = "SELECT `endpoints` from `%s` where `jobStatus` = '%s' and `endpoints` is not null" % (self.jobtablename, "running")
+            cursor.execute(query)
+            jobs = cursor.fetchall()
+            self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
+            endpoints = map(lambda job: self.load_json(job[0]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
-            pendingEndpoints = {k: v for d in endpoints for k, v in d.items() if v["status"] == "pending"}
-
-            return pendingEndpoints
+            ret = {k: v for d in endpoints for k, v in d.items() if v["status"] == "pending"}
         except Exception as e:
             logger.exception("Query pending endpoints failed!")
-            return {}
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+        return ret
 
     @record
     def GetJobEndpoints(self, job_id):
+        conn = None
+        cursor = None
+        ret = {}
         try:
-            jobs = self.GetJob(jobId=job_id)
+            conn = self.pool.get_connection()
+            cursor = conn.cursor()
+            query = "SELECT `endpoints` from `%s` where `jobId` = '%s'" % (self.jobtablename, job_id)
+            cursor.execute(query)
+            jobs = cursor.fetchall()
+            self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
+            endpoints = map(lambda job: self.load_json(job[0]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
-            endpoints = {k: v for d in endpoints for k, v in d.items()}
-
-            return endpoints
+            ret = {k: v for d in endpoints for k, v in d.items()}
         except Exception as e:
             logger.warning("Query job endpoints failed! Job {}".format(job_id), exc_info=True)
-            return {}
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+        return ret
 
     @record
     def GetDeadEndpoints(self):
@@ -1054,9 +1143,7 @@ class DataHandler(object):
         conn = None
         cursor = None
         try:
-            job_id = endpoint["jobId"]
-            job = self.GetJob(jobId=job_id)[0]
-            job_endpoints = self.load_json(job["endpoints"])
+            job_endpoints = self.GetJobEndpoints(endpoint["jobId"])
 
             # update jobEndpoints
             job_endpoints[endpoint["id"]] = endpoint
@@ -1154,6 +1241,35 @@ class DataHandler(object):
         except Exception as e:
             logger.error('UpdateJobTextField Exception: %s', str(e))
             ret = False
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+        return ret
+
+    @record
+    def UpdateJobTextFields(self, jobId, fields):
+        conn = None
+        cursor = None
+        ret = False
+        if not isinstance(fields, dict) or not fields:
+            return ret
+
+        try:
+            sql = "update `%s` set" % (self.jobtablename)
+            for field, value in fields.items():
+                sql += " `%s` = '%s'," % (field, value)
+            sql = sql[:-1]
+            sql += " where `jobId` = '%s'" % (jobId)
+
+            conn = self.pool.get_connection()
+            cursor = conn.cursor()
+            cursor.execute(sql)
+            self.conn.commit()
+            ret = True
+        except Exception as e:
+            logger.error('updateJobTextFields Exception: %s, ex: %s', fields, str(e))
         finally:
             if cursor is not None:
                 cursor.close()

--- a/src/utils/MySQLPoolDataHandler.py
+++ b/src/utils/MySQLPoolDataHandler.py
@@ -1067,7 +1067,7 @@ class DataHandler(object):
             self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
+            endpoints = map(lambda job: self.load_json(job[0]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
             ret = {k: v for d in endpoints for k, v in d.items() if v["status"] == "pending"}
@@ -1094,7 +1094,7 @@ class DataHandler(object):
             self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
+            endpoints = map(lambda job: self.load_json(job[0]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
             ret = {k: v for d in endpoints for k, v in d.items()}
@@ -1147,7 +1147,7 @@ class DataHandler(object):
             cursor = conn.cursor()
             
             sql = "UPDATE jobs SET endpoints=%s where jobId=%s"
-            cursor.execute(sql, (json.dumps(job_endpoints), job_id))
+            cursor.execute(sql, (json.dumps(job_endpoints), endpoint["jobId"]))
             conn.commit()
             ret = True
         except Exception as e:

--- a/src/utils/MySQLPoolDataHandler.py
+++ b/src/utils/MySQLPoolDataHandler.py
@@ -798,11 +798,9 @@ class DataHandler(object):
             conn = self.pool.get_connection()
             cursor = conn.cursor()
 
-            query = ""
-            if userName == "all":
-                query = "SELECT {}.jobId, jobName, userName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams, priority FROM {} left join {} on {}.jobId = {}.jobId where 1".format(self.jobtablename, self.jobtablename, self.jobprioritytablename, self.jobtablename, self.jobprioritytablename)
-            else:
-                query = "SELECT jobId, jobName, userName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams FROM {} where userName = '{}'".format(self.jobtablename, userName)
+            query = "SELECT {}.jobId, jobName, userName, vcName, jobStatus, jobStatusDetail, jobType, jobTime, jobParams, priority FROM {} left join {} on {}.jobId = {}.jobId where 1".format(self.jobtablename, self.jobtablename, self.jobprioritytablename, self.jobtablename, self.jobprioritytablename)
+            if userName != "all":
+                query += " and userName = '%s'" % userName
 
             if vcName != "all":
                 query += " and vcName = '%s'" % vcName

--- a/src/utils/MySQLPoolDataHandler.py
+++ b/src/utils/MySQLPoolDataHandler.py
@@ -531,12 +531,8 @@ class DataHandler(object):
             if (isinstance(groups, list)):
                 groups = json.dumps(groups)
 
-            if len(self.GetIdentityInfo(identityName)) == 0:
-                sql = "INSERT INTO `"+self.identitytablename+"` (identityName,uid,gid,groups) VALUES (%s,%s,%s,%s)"
-                cursor.execute(sql, (identityName, uid, gid, groups))
-            else:
-                sql = """update `%s` set uid = '%s', gid = '%s', groups = '%s' where `identityName` = '%s' """ % (self.identitytablename, uid, gid, groups, identityName)
-                cursor.execute(sql)
+            sql = "insert into {0} (identityName, uid, gid, groups) values ('{1}', '{2}', '{3}', '{4}') on duplicate key update uid='{2}', gid='{3}', groups='{4}'".format(self.identitytablename, identityName, uid, gid, groups)
+            cursor.execute(sql)
 
             conn.commit()
             ret = True
@@ -551,47 +547,16 @@ class DataHandler(object):
 
 
     @record
-    def GetAceCount(self, identityName, resource):
-        ret = 0
-        conn = None
-        cursor = None
-        try:
-            conn = self.pool.get_connection()
-            cursor = conn.cursor()
-            
-            query = "SELECT count(ALL id) as c FROM `%s` where `identityName` = '%s' and `resource` = '%s'" % (self.acltablename,identityName, resource)
-            cursor.execute(query)
-            for c in cursor:
-                ret = c[0]
-            conn.commit()
-        except Exception as e:
-            logger.error('GetAceCount Exception: %s', str(e))
-        finally:
-            if cursor is not None:
-                cursor.close()
-            if conn is not None:
-                conn.close()
-        return ret    
-
-
-    @record
     def UpdateAce(self, identityName, identityId, resource, permissions, isDeny):
         ret = False
         conn = None
         cursor = None
         try:
-            existingAceCount = self.GetAceCount(identityName, resource)
-            logger.info(existingAceCount)
-
             conn = self.pool.get_connection()
             cursor = conn.cursor()
             
-            if existingAceCount == 0:
-                sql = "INSERT INTO `"+self.acltablename+"` (identityName,identityId,resource,permissions,isDeny) VALUES (%s,%s,%s,%s,%s)"
-                cursor.execute(sql, (identityName, identityId, resource, permissions, isDeny))
-            else:
-                sql = """update `%s` set permissions = '%s' where `identityName` = '%s' and `resource` = '%s' """ % (self.acltablename, permissions, identityName, resource)
-                cursor.execute(sql)
+            sql = "insert into {0} (identityName, identityId, resource, permissions, isDeny) values ('{1}', '{2}', '{3}', '{4}', '{5}') on duplicate key update permissions='{4}'".format(self.acltablename, identityName, identityId, resource, permissions, isDeny)
+            cursor.execute(sql)
 
             conn.commit()
             ret = True
@@ -948,6 +913,36 @@ class DataHandler(object):
         return ret
 
     @record
+    def GetJobV2(self, jobId):
+        ret = []
+        conn = None
+        cursor = None
+        try:
+            conn = self.pool.get_connection()
+            cursor = conn.cursor()
+            query = "SELECT `jobId`, `jobName`, `userName`, `vcName`, `jobStatus`, `jobStatusDetail`, `jobType`, `jobTime`, `jobParams`  FROM `%s` where `jobId` = '%s' " % (self.jobtablename, jobId)
+            cursor.execute(query)
+
+            columns = [column[0] for column in cursor.description]
+            data = cursor.fetchall()
+            for item in data:
+                record = dict(zip(columns, item))
+                if record["jobStatusDetail"] is not None:
+                    record["jobStatusDetail"] = self.load_json(base64.b64decode(record["jobStatusDetail"]))
+                if record["jobParams"] is not None:
+                    record["jobParams"] = self.load_json(base64.b64decode(record["jobParams"]))
+                ret.append(record)
+            conn.commit()
+        except Exception as e:
+            logger.error('GetJobV2 Exception: %s', str(e))
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+        return ret
+
+    @record
     def AddCommand(self, jobId, command):
         ret = False
         conn = None
@@ -1072,7 +1067,7 @@ class DataHandler(object):
             self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job[0]), jobs)
+            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
             ret = {k: v for d in endpoints for k, v in d.items() if v["status"] == "pending"}
@@ -1099,7 +1094,7 @@ class DataHandler(object):
             self.conn.commit()
 
             # [ {endpoint1:{},endpoint2:{}}, {endpoint3:{}, ... }, ... ]
-            endpoints = map(lambda job: self.load_json(job[0]), jobs)
+            endpoints = map(lambda job: self.load_json(job["endpoints"]), jobs)
             # {endpoint1: {}, endpoint2: {}, ... }
             # endpoint["status"] == "pending"
             ret = {k: v for d in endpoints for k, v in d.items()}
@@ -1249,19 +1244,15 @@ class DataHandler(object):
         return ret
 
     @record
-    def UpdateJobTextFields(self, jobId, fields):
+    def UpdateJobTextFields(self, conditionFields, dataFields):
         conn = None
         cursor = None
         ret = False
-        if not isinstance(fields, dict) or not fields:
+        if not isinstance(conditionFields, dict) or not conditionFields or not isinstance(dataFields, dict) or not dataFields:
             return ret
 
         try:
-            sql = "update `%s` set" % (self.jobtablename)
-            for field, value in fields.items():
-                sql += " `%s` = '%s'," % (field, value)
-            sql = sql[:-1]
-            sql += " where `jobId` = '%s'" % (jobId)
+            sql = "update `%s` set" % (self.jobtablename) + ",".join([" `%s` = '%s'" % (field, value) for field, value in dataFields.items()]) + " where" + "and".join([" `%s` = '%s'" % (field, value) for field, value in conditionFields.items()])
 
             conn = self.pool.get_connection()
             cursor = conn.cursor()
@@ -1293,6 +1284,34 @@ class DataHandler(object):
             conn.commit()
         except Exception as e:
             logger.error('GetJobTextField Exception: %s', str(e))
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if conn is not None:
+                conn.close()
+        return ret
+
+    @record
+    def GetJobTextFields(self, jobId, fields):
+        conn = None
+        cursor = None
+        ret = None
+        if not isinstance(fields, list) or not fields:
+            return ret
+
+        try:
+            sql = "select " + ",".join(fields) + " from " + self.jobtablename + " where jobId='%s'" % (jobId)
+
+            conn = self.pool.get_connection()
+            cursor = conn.cursor()
+            cursor.execute(sql)
+
+            columns = [column[0] for column in cursor.description]
+            for item in cursor.fetchall():
+                ret = dict(zip(columns, item))
+            self.conn.commit()
+        except Exception as e:
+            logger.error('GetJobTextFields Exception: %s', str(e))
         finally:
             if cursor is not None:
                 cursor.close()

--- a/src/utils/authorization.py
+++ b/src/utils/authorization.py
@@ -6,6 +6,7 @@ import random
 from config import config
 import time
 import threading
+from cachetools import cached, TTLCache
 
 logger = logging.getLogger(__name__)
 
@@ -30,47 +31,14 @@ INVALID_INFO = {
 
 
 DEFAULT_EXPIRATION = 30 * 60
-
-
-# TODO: Replace with TTLCache in cachetools after refactoring
-class SimpleCache(object):
-    def __init__(self, expiration=DEFAULT_EXPIRATION):
-        self.expiration = expiration
-        self.lock = threading.Lock()
-        self.cache = dict()
-
-    def get(self, key):
-        with self.lock:
-            if key in self.cache:
-                value, timestamp = self.cache[key]
-                if time.time() - timestamp <= self.expiration:
-                    return value
-            return None
-
-    def add(self, key, value):
-        with self.lock:
-            self.cache[key] = (value, time.time())
-
-
-resource_acl_cache = SimpleCache()
-
-
-def get_identity_info_from_db(data_handler, identity_name):
-    try:
-        info_list = data_handler.GetIdentityInfo(identity_name)
-        if len(info_list) > 0:
-            return info_list[0]
-        else:
-            logger.warn("Identity name %s not found in DB" % identity_name)
-            return INVALID_INFO
-    except Exception as e:
-        logger.error("Failed to get identity info for %s from DB: %s" % (identity_name, e))
-
-    return INVALID_INFO
-
+acl_cache = TTLCache(maxsize=10240, ttl=DEFAULT_EXPIRATION)
+acl_cache_lock = threading.Lock()
+resourceKeyPrefix = "r/"
+identityKeyPrefix = "i/"
+identity_cache = TTLCache(maxsize=10240, ttl=DEFAULT_EXPIRATION)
+identity_cache_lock = threading.Lock()
 
 class AuthorizationManager:
-    #TODO : Add Cache to aovid frequent DB calls
 
     CLUSTER_ACL_PATH = "Cluster"
     ACL_DELIMITER = "/"
@@ -81,53 +49,36 @@ class AuthorizationManager:
     def _HasAccess(identity_name, resource_acl_path, permissions):
         start_time = time.time()
         requested_access = "%s;%s;%s" % (str(identity_name), resource_acl_path, str(permissions))
-
-        value = resource_acl_cache.get(requested_access)
-        if value is not None:
-            logger.info('[cached] Yes for %s in time %s' % (requested_access, time.time() - start_time))
-            return value
-
-        data_handler = None
         try:
-            data_handler = DataHandler()
-
-            identities = []
+            identities = set([])
             try:
-                identities = get_identity_info_from_db(data_handler, identity_name)["groups"]
-                identities = map(lambda x: int(x), identities)
+                identities = IdentityManager.GetIdentityInfoFromDB(identity_name)["groups"]
+                identities = set(map(lambda x: int(x), identities))
             except Exception as e:
                 logger.warn("Failed to get identities list: %s" % e)
-                identities = []
 
             #TODO: handle isDeny
             while resource_acl_path:
-                acl = data_handler.GetResourceAcl(resource_acl_path)
+                acl = ACLManager.GetResourceAcl(resource_acl_path)
 
                 for ace in acl:
                     ace_id = int(ace["identityId"])
                     id_in_identities = ace_id in identities
                     id_in_range = ace_id < INVALID_RANGE_START or ace_id > INVALID_RANGE_END
                     if ace["identityName"] == identity_name or (id_in_identities and id_in_range):
-                        permissions = permissions & (~ace["permissions"])
-                        if not permissions:
-                            logger.info('Yes for %s in time %s' % (requested_access, time.time() - start_time))
-                            resource_acl_cache.add(requested_access, True)
+                        permission = permissions & (~ace["permissions"])
+                        if not permission:
+                            logger.info('Yes for %s in time %f' % (requested_access, time.time() - start_time))
                             return True
 
                 resource_acl_path = AuthorizationManager.__GetParentPath(resource_acl_path)
 
             logger.info("No for %s in time %s" % (requested_access, time.time() - start_time))
-            resource_acl_cache.add(requested_access, False)
             return False
 
         except Exception as e:
-            logger.error("Exception: %s" % e)
-            logger.warn("No (exception) for %s in time %s" % (requested_access, time.time() - start_time))
+            logger.error("No (exception) for %s in time %s, ex: %s" % (requested_access, time.time() - start_time), str(e))
             return False
-
-        finally:
-            if data_handler is not None:
-                data_handler.Close()
 
 
     @staticmethod
@@ -136,69 +87,12 @@ class AuthorizationManager:
         return AuthorizationManager._HasAccess(identityName, resourceAclPath, permissions)
 
 
-    # Add/Update a specific access control entry. 
-    @staticmethod
-    def UpdateAce(identityName, resourceAclPath, permissions, isDeny):
-        dataHandler = DataHandler() 
-        try:
-            identityId = 0
-            if identityName.isdigit():
-                identityId = int(identityName)
-            else:               
-                identityId = IdentityManager.GetIdentityInfoFromDB(identityName)["uid"]
-                if identityId == INVALID_ID:
-                    info = IdentityManager.GetIdentityInfoFromAD(identityName)
-                    dataHandler.UpdateIdentityInfo(identityName, info["uid"], info["gid"], info["groups"])
-                    identityId = info["uid"]
-            return dataHandler.UpdateAce(identityName, identityId, resourceAclPath, permissions, isDeny)
-
-        except Exception as e:
-            logger.error('Exception: '+ str(e))
-            logger.warn("Fail to Update Ace for user %s" % identityName)
-            return False
-
-        finally:
-            dataHandler.Close()
-
-
-    @staticmethod
-    def DeleteAce(identityName, resourceAclPath):
-        dataHandler = DataHandler() 
-        try:                  
-            return dataHandler.DeleteAce(identityName, resourceAclPath)
-
-        except Exception as e:
-            logger.error('Exception: '+ str(e))
-            logger.warn("Fail to Delete Ace for user %s" % identityName)
-            return False
-
-        finally:
-            dataHandler.Close()
-
-
-    @staticmethod
-    def DeleteResourceAcl(resourceAclPath):
-        dataHandler = DataHandler()
-        try:           
-            return dataHandler.DeleteResourceAcl(resourceAclPath)    
-
-        except Exception as e:
-            logger.error('Exception: '+ str(e))
-            logger.warn("DeleteResourceAcl failed for %s" % resourceAclPath)
-            return False
-
-        finally:
-            dataHandler.Close()
-
-
     # Return all access control entries (for resources on which user has read access).
     @staticmethod
     def __GetAccessibleAcl(userName, permissions):
-        dataHandler = DataHandler()
-        try:           
-            acl = dataHandler.GetAcl()
-            ret = []
-
+        ret = []
+        try:
+            acl = ACLManager.GetAllAcl()
             for ace in acl:
                 if AuthorizationManager._HasAccess(userName, ace["resource"], permissions): #resource
                     ret.append(ace)
@@ -206,34 +100,12 @@ class AuthorizationManager:
             return ret
 
         except Exception as e:
-            logger.error('Exception: '+ str(e))
-            logger.warn("Fail to get ACL for user %s, return empty list" % userName)
-            return []
-
-        finally:
-            dataHandler.Close()
-
+            logger.error("Fail to get ACL for user %s, ex: %s", userName, str(e))
+        return ret
 
     @staticmethod
     def GetAcl(username):
         return AuthorizationManager.__GetAccessibleAcl(username, Permission.User)
-
-
-    @staticmethod
-    def GetAllAcl():
-        dataHandler = DataHandler()
-        try:           
-            acl = dataHandler.GetAcl()
-            return acl
-
-        except Exception as e:
-            logger.error('Exception: '+ str(e))
-            logger.warn("Fail to get ACL for user %s, return empty list" % userName)
-            return []
-
-        finally:
-            dataHandler.Close()
-
 
     @staticmethod
     def IsClusterAdmin(userName):
@@ -247,7 +119,6 @@ class AuthorizationManager:
         else:
             return ""
 
-
     @staticmethod
     def GetResourceAclPath(resourceIdentifier, resourceType):
         if (resourceType == ResourceType.VC):
@@ -255,9 +126,161 @@ class AuthorizationManager:
         elif resourceType == ResourceType.Cluster:
             return AuthorizationManager.CLUSTER_ACL_PATH
 
-    
 
-class IdentityManager:  
+class ACLManager:
+    # Add/Update a specific access control entry. 
+    @staticmethod
+    def UpdateAce(identityName, resource, permissions, isDeny):
+        dataHandler = DataHandler()
+        ret = False
+        try:
+            identityId = 0
+            if identityName.isdigit():
+                identityId = int(identityName)
+            else:               
+                identityId = IdentityManager.GetIdentityInfoFromDB(identityName)["uid"]
+                if identityId == INVALID_ID:
+                    info = IdentityManager.GetIdentityInfoFromAD(identityName)
+                    IdentityManager.UpdateIdentityInfo(identityName, info["uid"], info["gid"], info["groups"])
+                    identityId = info["uid"]
+            ret = dataHandler.UpdateAce(identityName, identityId, resource, permissions, isDeny)
+
+            with acl_cache_lock:
+                acl_cache.pop(resourceKeyPrefix + resource, None)
+                acl_cache.pop(identityKeyPrefix + identityName, None)
+        except Exception as e:
+            logger.warn("Fail to Update Ace for user %s, ex: %s" , identityName, str(e))
+        finally:
+            dataHandler.Close()
+        return ret
+
+    @staticmethod
+    def DeleteAce(identityName, resource):
+        dataHandler = DataHandler()
+        ret = False
+        try:                  
+            ret = dataHandler.DeleteAce(identityName, resource)
+
+            with acl_cache_lock:
+                acl_cache.pop(resourceKeyPrefix + resource, None)
+                acl_cache.pop(identityKeyPrefix + identityName, None)
+
+        except Exception as e:
+            logger.warn("Fail to Delete Ace for user %s, ex: %s" , identityName, str(e))
+        finally:
+            dataHandler.Close()
+        return ret
+
+    @staticmethod
+    def DeleteResourceAcl(resource):
+        dataHandler = DataHandler()
+        ret = False
+        try:           
+            ret = dataHandler.DeleteResourceAcl(resource)
+
+            with acl_cache_lock:
+                items = acl_cache.pop(resourceKeyPrefix + resource, None)
+                if items is not None:
+                    for ace in items:
+                        acl_cache.pop(identityKeyPrefix + ace["identityName"], None)
+        except Exception as e:
+            logger.error("DeleteResourceAcl failed for %s, ex: %s" , resourceAclPath, str(e))
+        finally:
+            dataHandler.Close()
+        return ret
+
+    @staticmethod
+    def GetAllAcl():
+        acl = []
+        try:
+            with acl_cache_lock:
+                for item in acl_cache.keys():
+                    if item.startswith(resourceKeyPrefix):
+                        acl.append(acl_cache[item])
+        except KeyError:
+            pass
+
+        if acl:
+            return acl
+
+        dataHandler = DataHandler()
+        try:           
+            acl = dataHandler.GetAcl()
+
+            resources = {}
+            identities = {}
+            for ace in acl:
+                resourceKey = resourceKeyPrefix + ace["resource"]
+                if resourceKey not in resources:
+                    resources[resourceKey] = []
+                resources[resourceKey].append(ace)
+
+                identityKey = identityKeyPrefix + ace["identityName"]
+                if identityKey not in identities:
+                    identities[identityKey] = []
+                identities[identityKey].append(ace)
+
+            with acl_cache_lock:
+                acl_cache.update((resources))
+                acl_cache.update((identities))
+
+        except Exception as e:
+            logger.warn("Fail to get ACL for user %s, ex: %s" , userName, str(e))
+
+        finally:
+            dataHandler.Close()
+        return acl
+
+    @staticmethod
+    def GetResourceAcl(resource):
+        try:
+            with acl_cache_lock:
+                return acl_cache[resourceKeyPrefix + resource]
+        except KeyError:
+            pass
+
+        dataHandler = DataHandler()
+        ret = []
+        try:
+            ret = dataHandler.GetResourceAcl(resource)
+
+            identities = {}
+            for ace in ret:
+                identityKey = identityKeyPrefix + ace["identityName"]
+                if identityKey not in identities:
+                    identities[identityKey] = []
+                identities[identityKey].append(ace)
+
+            with acl_cache_lock:
+                acl_cache[resourceKeyPrefix + resource] = ret
+                acl_cache.update((identities))
+        except Exception as e:
+            logger.error("Get resoure acl error for resource: %s, ex: %s", resource, str(e))
+        finally:
+            dataHandler.Close()
+        return ret
+
+    @staticmethod
+    def UpdateAclIdentityId(identityName, identityId):
+        dataHandler = DataHandler()
+        ret = False
+        try:
+            ret = dataHandler.UpdateAclIdentityId(identityName, identityId)
+
+            with acl_cache_lock:
+                items = acl_cache.pop(identityKeyPrefix + identityName, None)
+                if items is not None:
+                    for ace in items:
+                        acl_cache.pop(resourceKeyPrefix + ace["resource"], None)
+        except Exception as e:
+            logger.error("UpdateAclIdentityId failed for %s, ex: %s" , resourceAclPath, str(e))
+        finally:
+            dataHandler.Close()
+        return ret
+
+
+class IdentityManager:
+
 
     @staticmethod
     def GetIdentityInfoFromAD(identityName):
@@ -285,8 +308,8 @@ class IdentityManager:
 
             return info
 
-
     @staticmethod
+    @cached(cache=identity_cache, key=lambda identityName: identityName, lock=identity_cache_lock)
     def GetIdentityInfoFromDB(identityName):
         lst = DataManager.GetIdentityInfo(identityName)
         if lst:
@@ -297,7 +320,18 @@ class IdentityManager:
             info["uid"] = INVALID_ID
             info["gid"] = INVALID_ID
             info["groups"] = [INVALID_ID]
-            
-            
-            
             return info
+
+    @staticmethod
+    def UpdateIdentityInfo(identityName, uid, gid, groups):
+        dataHandler = DataHandler()
+        ret = False
+        try:
+            ret = dataHandler.UpdateIdentityInfo(identityName, uid, gid, groups)
+            with identity_cache_lock:
+                identity_cache.pop(identityName, None)
+        except Exception as e:
+                logger.error("update identity info error for identity: %s, ex: %s", identityName, str(e))
+        finally:
+            dataHandler.Close()
+        return ret

--- a/src/utils/authorization.py
+++ b/src/utils/authorization.py
@@ -77,7 +77,7 @@ class AuthorizationManager:
             return False
 
         except Exception as e:
-            logger.error("No (exception) for %s in time %s, ex: %s" % (requested_access, time.time() - start_time), str(e))
+            logger.error("No (exception) for %s in time %f, ex: %s", requested_access, time.time() - start_time, str(e))
             return False
 
 


### PR DESCRIPTION
1. Add ListJobsV2 API: merge 2 DB requests into 1 by simplifying code logic; cut useless fields; add job priority when getting all jobs.
2. Add GetJobDetailV2 API: cut useless fields; separate endpoints acquisition.
3. Add UpdateJobTextFields in DataHandler: job manager could update multiple fields of a job in one request
4. Optimize authorization cache: use fine-grained key (eg. identityName, resource), so that cache could be updated when DB updates, and do not have to wait until TTL expired
5. Optimize VC list cache: use vcName as key, instead of userName. Update cache timely after DB is successfully updated
6. Improve Enpoint API: Move DB related logic into JobRestAPIUtils, to prevent restAPI from depending on DataHandler directly. Simplify DB operation to reduce latency