### PR TITLE
Remove default mountOptions for blobfuse

### DIFF
--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -337,8 +337,6 @@ spec:
         {% endif %}
         {% if bf["mountOptions"] %}
         mountoptions: {{ bf["mountOptions"] }}
-        {% else %}
-        mountoptions: "--file-cache-timeout-in-seconds=120"
         {% endif %}
         {% endif %}
       {% endfor %}

--- a/src/dashboard/src/pages/Submission/Training.tsx
+++ b/src/dashboard/src/pages/Submission/Training.tsx
@@ -199,7 +199,7 @@ const Training: React.ComponentClass = withRouter(({ history }) => {
   const [accountKey, setAccountKey] = React.useState("");
   const [containerName, setContainerName] = React.useState("");
   const [mountPath, setMountPath] = React.useState("");
-  const [mountOptions, setMountOptions] = React.useState("--file-cache-timeout-in-seconds=120");
+  const [mountOptions, setMountOptions] = React.useState("");
   const onAccountNameChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setAccountName(event.target.value);
@@ -379,7 +379,7 @@ const Training: React.ComponentClass = withRouter(({ history }) => {
       blobfuseObj['accountKey'] = accountKey || '';
       blobfuseObj['containerName'] = containerName || '';
       blobfuseObj['mountPath'] = mountPath || '';
-      blobfuseObj['mountOptions'] = mountOptions;
+      blobfuseObj['mountOptions'] = mountOptions || '';
       plugins['blobfuse'].push(blobfuseObj);
 
       plugins['imagePull'] = [];
@@ -525,7 +525,7 @@ const Training: React.ComponentClass = withRouter(({ history }) => {
           setAccountKey("");
           setContainerName("");
           setMountPath("");
-          setMountOptions("--file-cache-timeout-in-seconds=120");
+          setMountOptions("");
           setDockerRegistry("")
           setDockerUsername("")
           setDockerPassword("")
@@ -593,7 +593,7 @@ const Training: React.ComponentClass = withRouter(({ history }) => {
     blobfuseObj['accountKey'] = accountKey || '';
     blobfuseObj['containerName'] = containerName || '';
     blobfuseObj['mountPath'] = mountPath || '';
-    blobfuseObj['mountOptions'] = mountOptions;
+    blobfuseObj['mountOptions'] = mountOptions || '';
     plugins['blobfuse'].push(blobfuseObj);
     plugins['imagePull'] = [];
     let imagePullObj: any = {};


### PR DESCRIPTION
If a user does not specify anything in the blobfuse `mountOptions`, we should not add any default value to avoid confusion.