### PR TITLE
Dashboard: Clarify password and token.

### DIFF
--- a/src/dashboard/server/api/controllers/authenticate/index.js
+++ b/src/dashboard/server/api/controllers/authenticate/index.js
@@ -46,13 +46,13 @@ const getDecodedIdToken = async context => {
     grant_type: 'authorization_code',
     client_secret: activeDirectoryConfig.clientSecret
   })
-  context.log.info({ body: params.toString() }, 'Token request')
+  context.log.info({ body: params.toString() }, 'Id Token request')
   const response = await fetch(OAUTH2_URL + '/token', {
     method: 'POST',
     body: params
   })
   const data = await response.json()
-  context.log.info({ data }, 'Token response')
+  context.log.info({ data }, 'Id Token response')
 
   context.assert(data['error'] == null, 502, data['error'])
 
@@ -70,7 +70,7 @@ module.exports = async context => {
     const data = await user.fillIdFromWinbind()
     user.addUserToCluster(data)
 
-    context.cookies.set('token', user.toCookie())
+    context.cookies.set('token', user.toCookieToken())
 
     return context.redirect('/')
   } else if (context.query.error != null) {

--- a/src/dashboard/server/api/controllers/user.js
+++ b/src/dashboard/server/api/controllers/user.js
@@ -6,5 +6,5 @@
 /** @type {import('koa').Middleware<State>} */
 module.exports = context => {
   const { user } = context.state
-  context.body = { token: user.token.toString('hex') }
+  context.body = user
 }

--- a/src/dashboard/server/api/middlewares/user.js
+++ b/src/dashboard/server/api/middlewares/user.js
@@ -4,21 +4,21 @@ const User = require('../services/user')
  * @return {import('koa').Middleware}
  */
 module.exports = (forceAuthenticated = true) => async (context, next) => {
-  if ('email' in context.query && 'token' in context.query) {
-    const { email, token } = context.query
-    const user = context.state.user = User.fromToken(context, email, token)
-    await user.fillIdFromWinbind()
-    await user.password
-    await user.addGroupLink
-    await user.WikiLink
-    context.log.debug(user, 'Authenticated by token')
+  if ('email' in context.query) {
+    let { email, password } = context.query
+
+    // Backward compatibility
+    if (password === undefined) { password = context.query.token }
+
+    if (password) {
+      const user = context.state.user = User.fromPassword(context, email, password)
+      await user.fillIdFromWinbind()
+      context.log.debug(user, 'Authenticated by password')
+    }
   } else if (context.cookies.get('token')) {
     try {
-      const token = context.cookies.get('token')
-      const user = context.state.user = User.fromCookie(context, token)
-      await user.password
-      await user.addGroupLink
-      await user.WikiLink
+      const cookieToken = context.cookies.get('token')
+      const user = context.state.user = User.fromCookieToken(context, cookieToken)
       context.log.debug(user, 'Authenticated by cookie')
     } catch (error) {
       context.log.error(error, 'Error in cookie authentication')

--- a/src/dashboard/server/test/controllers/bootstrap.js
+++ b/src/dashboard/server/test/controllers/bootstrap.js
@@ -1,6 +1,5 @@
 const axiosist = require('axiosist')
 const jwt = require('jsonwebtoken')
-const should = require('should')
 const touge = require('tough-cookie')
 
 const api = require('../../api').callback()
@@ -17,8 +16,8 @@ const getBootstrapArgument = (code) => {
 describe('GET /bootstrap.js', () => {
   it('should response user info as JavaScript type', async () => {
     const user = { email: 'dlts@example.com' }
-    const token = jwt.sign(user, 'DashboardSign')
-    const cookie = new touge.Cookie({ key: 'token', value: token })
+    const cookieToken = jwt.sign(user, 'DashboardSign')
+    const cookie = new touge.Cookie({ key: 'token', value: cookieToken })
     const response = await axiosist(api).get('/bootstrap.js', {
       headers: { 'Cookie': cookie.cookieString() }
     })
@@ -26,6 +25,7 @@ describe('GET /bootstrap.js', () => {
     const arg = getBootstrapArgument(response.data)
     arg.config.should.have.property('key', 'value')
     arg.user.should.have.properties(user)
+    arg.user.should.have.property('password')
   })
 
   it('should response undefined if unauthenticated', async () => {
@@ -38,8 +38,8 @@ describe('GET /bootstrap.js', () => {
 
   it('should response undefined if token is invalid', async () => {
     const user = { email: 'dlts@example.com' }
-    const token = jwt.sign(user, 'BadSign')
-    const cookie = new touge.Cookie({ key: 'token', value: token })
+    const cookieToken = jwt.sign(user, 'BadSign')
+    const cookie = new touge.Cookie({ key: 'token', value: cookieToken })
     const response = await axiosist(api).get('/bootstrap.js', {
       headers: { 'Cookie': cookie.cookieString() }
     })

--- a/src/dashboard/server/test/controllers/cluster/index.js
+++ b/src/dashboard/server/test/controllers/cluster/index.js
@@ -5,7 +5,7 @@ const api = require('../../../api').callback()
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex')
+  password: User.generateToken('dlts@example.com').toString('hex')
 }
 
 describe('GET /clusters/:clusterId', () => {

--- a/src/dashboard/server/test/controllers/cluster/job/getJobDetail.js
+++ b/src/dashboard/server/test/controllers/cluster/job/getJobDetail.js
@@ -6,7 +6,7 @@ const api = require('../../../../api').callback()
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex')
+  password: User.generateToken('dlts@example.com').toString('hex')
 }
 
 // search params for getJob, getCommands and getEndpoints

--- a/src/dashboard/server/test/controllers/cluster/job/postJob.js
+++ b/src/dashboard/server/test/controllers/cluster/job/postJob.js
@@ -7,7 +7,7 @@ const api = require('../../../../api').callback()
 const userParams = {
   jobId: 'testjob',
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex')
+  password: User.generateToken('dlts@example.com').toString('hex')
 }
 
 const addCommandParams = new URLSearchParams({

--- a/src/dashboard/server/test/controllers/cluster/job/putJobPriority.js
+++ b/src/dashboard/server/test/controllers/cluster/job/putJobPriority.js
@@ -6,7 +6,7 @@ const api = require('../../../../api').callback()
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex')
+  password: User.generateToken('dlts@example.com').toString('hex')
 }
 
 const setPriorityParams = new URLSearchParams({

--- a/src/dashboard/server/test/controllers/cluster/job/putJobStatus.js
+++ b/src/dashboard/server/test/controllers/cluster/job/putJobStatus.js
@@ -6,7 +6,7 @@ const api = require('../../../../api').callback()
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex')
+  password: User.generateToken('dlts@example.com').toString('hex')
 }
 
 const setStatusParams = new URLSearchParams({

--- a/src/dashboard/server/test/controllers/cluster/jobs.post.js
+++ b/src/dashboard/server/test/controllers/cluster/jobs.post.js
@@ -8,7 +8,7 @@ const api = require('../../../api').callback()
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex')
+  password: User.generateToken('dlts@example.com').toString('hex')
 }
 
 describe('POST /clusters/:clusterid/jobs', () => {

--- a/src/dashboard/server/test/controllers/team/cluster.js
+++ b/src/dashboard/server/test/controllers/team/cluster.js
@@ -6,7 +6,7 @@ const User = require('../../../api/services/user')
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex'),
+  password: User.generateToken('dlts@example.com').toString('hex'),
   teamId: 'testteam'
 }
 

--- a/src/dashboard/server/test/controllers/team/jobs.js
+++ b/src/dashboard/server/test/controllers/team/jobs.js
@@ -9,7 +9,7 @@ const clusterConfig = config.get('clusters')
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex'),
+  password: User.generateToken('dlts@example.com').toString('hex'),
   teamId: 'testteam'
 }
 

--- a/src/dashboard/server/test/controllers/team/template.delete.js
+++ b/src/dashboard/server/test/controllers/team/template.delete.js
@@ -9,7 +9,7 @@ const clusterConfig = config.get('clusters')
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex'),
+  password: User.generateToken('dlts@example.com').toString('hex'),
   teamId: 'testteam',
   templateName: 'newtemplate'
 }

--- a/src/dashboard/server/test/controllers/team/template.js
+++ b/src/dashboard/server/test/controllers/team/template.js
@@ -9,7 +9,7 @@ const clusterConfig = config.get('clusters')
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex'),
+  password: User.generateToken('dlts@example.com').toString('hex'),
   teamId: 'testteam',
   templateName: 'newtemplate'
 }

--- a/src/dashboard/server/test/controllers/team/template.put.js
+++ b/src/dashboard/server/test/controllers/team/template.put.js
@@ -9,7 +9,7 @@ const clusterConfig = config.get('clusters')
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex'),
+  password: User.generateToken('dlts@example.com').toString('hex'),
   teamId: 'testteam',
   templateName: 'newtemplate'
 }

--- a/src/dashboard/server/test/controllers/teams.js
+++ b/src/dashboard/server/test/controllers/teams.js
@@ -30,7 +30,7 @@ posTeamData['Targaryen'] = {
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex')
+  password: User.generateToken('dlts@example.com').toString('hex')
 }
 
 const fetchParams = new URLSearchParams({

--- a/src/dashboard/server/test/controllers/user.js
+++ b/src/dashboard/server/test/controllers/user.js
@@ -5,16 +5,16 @@ const api = require('../../api').callback()
 
 const userParams = {
   email: 'dlts@example.com',
-  token: User.generateToken('dlts@example.com').toString('hex')
+  password: User.generateToken('dlts@example.com').toString('hex')
 }
 
 describe('GET /user', () => {
-  it('should response user token', async () => {
+  it('should response user password', async () => {
     sinon.stub(User.prototype, 'fillIdFromWinbind').resolves();
 
     const response = await axiosist(api).get('/user', {
       params: userParams
     })
-    response.data.should.have.property('token', `${userParams.token}`)
+    response.data.should.have.property('password', `${userParams.password}`)
   })
 })

--- a/src/dashboard/src/contexts/User.tsx
+++ b/src/dashboard/src/contexts/User.tsx
@@ -5,7 +5,7 @@ interface Context {
   uid?: string;
   familyName?: string;
   givenName?: string;
-  token?: any;
+  password?: string;
 }
 
 const Context = React.createContext<Context>({});
@@ -17,16 +17,13 @@ interface ProviderProps {
   uid?: string;
   familyName?: string;
   givenName?: string;
-  token?: any;
+  password?: string;
 }
 
-export const Provider: React.FC<ProviderProps> = ({ email, uid,familyName, givenName,token,children }) => {
-  if (token) {
-    token = new Buffer(token.data).toString('hex');
-  }
+export const Provider: React.FC<ProviderProps> = ({ email, uid, familyName, givenName, password, children }) => {
   return (
     <Context.Provider
-      value={{ email,uid,familyName,givenName,token }}
+      value={{ email,uid, familyName, givenName, password }}
       children={children}
     />
   );

--- a/src/dashboard/src/layout/AppBar.tsx
+++ b/src/dashboard/src/layout/AppBar.tsx
@@ -137,7 +137,7 @@ TeamMenu = () => {
 const UserButton: React.FC = () => {
   const [openUserProfile, setOpenUserProfile] = React.useState(false);
   const [openCopyWarn, setOpenCopyWarn] = React.useState(false);
-  const { givenName, familyName,email,token } = React.useContext(UserContext);
+  const { givenName, familyName, email, password } = React.useContext(UserContext);
   const styles = useStyles();
   const name = typeof email === 'string' ?  email.split('@', 1)[0] : email;
   const handleClose = () => {
@@ -183,7 +183,7 @@ const UserButton: React.FC = () => {
             </ListItem>
             <Divider />
             <ListItem button >
-              <ListItemText primary="Password" secondary={token} onClick={()=>handleCopy(token)}/>
+              <ListItemText primary="Password" secondary={password} onClick={()=>handleCopy(password)}/>
             </ListItem>
           </List>
         </Box>


### PR DESCRIPTION

Password: The only term user should use, which is the string-typed user
credential for dashboard API use. User should pass `email` as well as
`password` as queries in API call to get access of the dashboard
resource. For backward compatibility, `token` is also available in
query, which is deprecated.

Token: Internal used in dashboard **backend**, which stands for the
Buffer-typed password. Backend always does not store the string-typed
password for security reasons.

IdToken: jwt typed token from Azure Active Directory

CookieToken: `token` field value in cookie, jwt typed. Should be plain
since koa already provided a signed cookie approach.