### PR TITLE
exit on failed to get enough configmap

### DIFF
--- a/src/docker-images/init-container/runtime/sync.py
+++ b/src/docker-images/init-container/runtime/sync.py
@@ -24,6 +24,7 @@ ERROR_EXIT_CODE = {
         "network": 2,
         "k8s_api": 3,
         "port": 4,
+        "wait_sync_fail": 5,
         }
 
 def find_free_port(min=40000, max=49999):
@@ -138,11 +139,15 @@ def main(args):
             label_selector=labels,
         )
 
-        logging.debug("Got %d config maps, expected %d", len(resp.items), expected_num)
+        logger.debug("Got %d config maps, expected %d", len(resp.items), expected_num)
         if len(resp.items) == expected_num:
             items = resp.items
             break
         time.sleep(1)
+
+    if len(items) != expected_num:
+        logger.error("timeout in waiting other's configmap, maybe because resource not enough")
+        sys.exit(ERROR_EXIT_CODE["wait_sync_fail"])
 
     # SD stands for service discovery
     envs = {


### PR DESCRIPTION
Without this, the job will wait until timeout and bootstrap log will show:

```
testing ps-0
+ ssh ps-0 'echo 1'
/root/.ssh/config line 3: Missing argument.
+ rtn=255
+ echo 'done testing ps-0'
done testing ps-0
```