### PR TITLE
longer wait time

### DIFF
--- a/src/docker-images/init-container/runtime/sync.py
+++ b/src/docker-images/init-container/runtime/sync.py
@@ -132,7 +132,7 @@ def main(args):
     labels = "run=%s" % (job_name)
 
     items = []
-    for i in range(600): # wait at most 10 minutes
+    for i in range(3600): # wait at most 1 hour
         resp = k8s_core_api.list_namespaced_config_map(
             namespace=job_namespace,
             label_selector=labels,

--- a/src/init-scripts/setup_ssh_config.sh
+++ b/src/init-scripts/setup_ssh_config.sh
@@ -86,7 +86,7 @@ then
     for host in ${host_list}
     do
         succ=false
-        for i in `seq 1 100` ; do
+        for i in `seq 1 3600` ; do
             echo "testing $host"
             ssh $host "echo 1"
             # do not add code here


### PR DESCRIPTION
wait time in sync.py can be used to wait other worker waiting for resource.
wait time in setup_ssh_config can be used to wait pulling container image.