### PR TITLE
repairmanager - do not resend email when all nodes are already cordoned

### DIFF
--- a/src/RepairManager/Rules/ecc_rule.py
+++ b/src/RepairManager/Rules/ecc_rule.py
@@ -101,7 +101,7 @@ class ECCRule(Rule):
     def take_action(self):
         status = []
         for node_name in self.ecc_hostnames:
-            output = k8s_util.cordon_node(node_name, dry_run=True)
+            output = k8s_util.cordon_node(node_name, dry_run=self.config['rules']['ecc_rule']['dry_run'])
             status.append([node_name, output])
 
         subject = f'Repair Manager Alert [ECC ERROR] [{self.config["cluster_name"]}]'

--- a/src/RepairManager/config/rule-config.yaml
+++ b/src/RepairManager/config/rule-config.yaml
@@ -5,7 +5,7 @@ rules:
     class_name : ECCRule
     ecc_error_url: '/api/v1/query?query=nvidiasmi_ecc_error_count%7Btype%3D%22volatile_double%22%7D%3E0'
     alert_job_owners: False # alert all impacted job owners
-    dry_run: True
+    dry_run: {{cnf['repair-manager']['ecc_rule']['dry_run']}}
 
 # time to sleep between rule execution (seconds)
 rule_wait_time: 10

--- a/src/RepairManager/config/rule-config.yaml
+++ b/src/RepairManager/config/rule-config.yaml
@@ -5,6 +5,7 @@ rules:
     class_name : ECCRule
     ecc_error_url: '/api/v1/query?query=nvidiasmi_ecc_error_count%7Btype%3D%22volatile_double%22%7D%3E0'
     alert_job_owners: False # alert all impacted job owners
+    dry_run: True
 
 # time to sleep between rule execution (seconds)
 rule_wait_time: 10

--- a/src/RepairManager/utils/k8s_util.py
+++ b/src/RepairManager/utils/k8s_util.py
@@ -17,7 +17,7 @@ def cordon_node(node_name, dry_run=True):
         return e.output.decode()
 
 
-def is_node_unschedulable(node_info, node_name):
+def is_node_cordoned(node_info, node_name):
     for node in node_info.items:
         for address in node.status.addresses:
             if address.type == 'Hostname' and address.address == node_name:


### PR DESCRIPTION
When turning off dry-run, two emails are sent. This is because after nodes are cordoned, their status changes to "already cordoned." Since this is a status change, an additional email is sent.

This update
- checks if nodes are already cordoned before attempting to cordon
- does not send emails if all nodes listed have already been cordoned in the past.

Note: this update interferes with the "reminder" functionality... will make a fix in future PR.