### PR TITLE
repair manager - fix email alerting bugs

### DIFF
--- a/src/RepairManager/Rules/ecc_rule.py
+++ b/src/RepairManager/Rules/ecc_rule.py
@@ -101,7 +101,7 @@ class ECCRule(Rule):
     def take_action(self):
         status = []
         for node_name in self.ecc_hostnames:
-            output = k8s_util.cordon_node(node_name, dry_run=True)
+            output = k8s_util.cordon_node(node_name, dry_run=self.config['rules']['ecc_rule']['dry_run'])
             status.append([node_name, output])
 
         subject = f'Repair Manager Alert [ECC ERROR] [{self.config["cluster_name"]}]'

--- a/src/RepairManager/config/rule-config.yaml
+++ b/src/RepairManager/config/rule-config.yaml
@@ -5,7 +5,7 @@ rules:
     class_name : ECCRule
     ecc_error_url: '/api/v1/query?query=nvidiasmi_ecc_error_count%7Btype%3D%22volatile_double%22%7D%3E0'
     alert_job_owners: False # alert all impacted job owners
-    dry_run: True
+    dry_run: {{cnf['repair-manager']['ecc_rule']['dry_run']}}
 
 # time to sleep between rule execution (seconds)
 rule_wait_time: 10

--- a/src/RepairManager/config/rule-config.yaml
+++ b/src/RepairManager/config/rule-config.yaml
@@ -5,6 +5,7 @@ rules:
     class_name : ECCRule
     ecc_error_url: '/api/v1/query?query=nvidiasmi_ecc_error_count%7Btype%3D%22volatile_double%22%7D%3E0'
     alert_job_owners: False # alert all impacted job owners
+    dry_run: True
 
 # time to sleep between rule execution (seconds)
 rule_wait_time: 10

--- a/src/RepairManager/main.py
+++ b/src/RepairManager/main.py
@@ -55,15 +55,9 @@ def Run():
 
                 except Exception as e:
                     logger.exception(f'Error executing {class_name} from module {module_name}\n')
-                    subject = f'Repair Manager Alert [Rule Error] [{class_name}] [{config["cluster_name"]}]'
-                    body = ''.join(traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__))
-                    alert.handle_email_alert(subject, body)
 
     except Exception as e:
-         logger.exception('Repair manager has stopped due to an unhandled exception:')
-         subject = f'Repair Manager Alert [Repair Manager Crashed] [{config["cluster_name"]}]'
-         body = ''.join(traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__))
-         alert.send(subject, body)
+         logger.exception('Repair manager has stopped due to an unhandled exception.')
 
 if __name__ == '__main__':
     Run()

--- a/src/RepairManager/utils/email.py
+++ b/src/RepairManager/utils/email.py
@@ -52,8 +52,7 @@ class EmailHandler():
 
         # if ecc errors remain on nodes after configured alert wait time, resend email 
         # or if any action is taken on a node
-        elif self.ecc_alert_reminder < datetime.datetime.now() \
-        or action_taken:
+        elif action taken or self.ecc_alert_reminder < datetime.datetime.now():
             self.ecc_alert_reminder = datetime.datetime.now() + datetime.timedelta(seconds=self.config['alert_wait_seconds'])
             self.send(subject, body, additional_recipients)
 
@@ -61,3 +60,4 @@ class EmailHandler():
 
     def clear_ecc_alert_cache(self):
         self.ecc_alert_cache = []
+        self.ecc_alert_reminder = None

--- a/src/RepairManager/utils/email.py
+++ b/src/RepairManager/utils/email.py
@@ -52,7 +52,7 @@ class EmailHandler():
 
         # if ecc errors remain on nodes after configured alert wait time, resend email 
         # or if any action is taken on a node
-        elif action taken or self.ecc_alert_reminder < datetime.datetime.now():
+        elif action_taken or self.ecc_alert_reminder < datetime.datetime.now():
             self.ecc_alert_reminder = datetime.datetime.now() + datetime.timedelta(seconds=self.config['alert_wait_seconds'])
             self.send(subject, body, additional_recipients)
 

--- a/src/RepairManager/utils/email.py
+++ b/src/RepairManager/utils/email.py
@@ -2,13 +2,13 @@ import smtplib
 import logging
 import yaml
 import datetime
-from cachetools import TTLCache
 
 class EmailHandler():
 
     def __init__(self):
         self.config=self.load_config()
-        self.alert_cache=TTLCache(maxsize=1000, ttl=self.config['alert_wait_seconds'])
+        self.ecc_alert_cache=[]
+        self.ecc_alert_reminder = None
 
     def load_config(self):
         with open('./config/email-config.yaml', 'r') as file:
@@ -40,8 +40,24 @@ class EmailHandler():
         except smtplib.SMTPException as e:
             logging.exception('SMTP error occurred: ' + str(e))
 
-    def handle_email_alert(self, subject, body, additional_recipients=None):
-        # to avoid email spam, send email based on configured alert wait time
-        if body not in self.alert_cache:
+    def handle_ecc_email_alert(self, subject, body, ecc_nodes, action_taken, additional_recipients=None):
+        if ecc_nodes is None:
+            ecc_nodes = []
+
+        # if a new node found to have ecc error, send email
+        if not set(ecc_nodes).issubset(self.ecc_alert_cache):
+            self.ecc_alert_reminder = datetime.datetime.now() + datetime.timedelta(seconds=self.config['alert_wait_seconds'])
             self.send(subject, body, additional_recipients)
-            self.alert_cache[body] = 1  
+            # TODO: send email to individual job owners on each new node
+
+        # if ecc errors remain on nodes after configured alert wait time, resend email 
+        # or if any action is taken on a node
+        elif self.ecc_alert_reminder < datetime.datetime.now() \
+        or action_taken:
+            self.ecc_alert_reminder = datetime.datetime.now() + datetime.timedelta(seconds=self.config['alert_wait_seconds'])
+            self.send(subject, body, additional_recipients)
+
+        self.ecc_alert_cache = ecc_nodes
+
+    def clear_ecc_alert_cache(self):
+        self.ecc_alert_cache = []

--- a/src/RepairManager/utils/k8s_util.py
+++ b/src/RepairManager/utils/k8s_util.py
@@ -17,7 +17,7 @@ def cordon_node(node_name, dry_run=True):
         return e.output.decode()
 
 
-def is_node_unschedulable(node_info, node_name):
+def is_node_cordoned(node_info, node_name):
     for node in node_info.items:
         for address in node.status.addresses:
             if address.type == 'Hostname' and address.address == node_name:


### PR DESCRIPTION
better handling of ecc error email alerting on several edge cases. 

Previously, I cached the body of each email sent in order to compare emails and avoid sending the same email twice (and avoid spamming DRIs). However, since the email body included information such as node status and jobs/job owners, any changes to the body would result in another (sometimes unnecessary) email. I changed email alerting so that it uses a cache of ecc error nodes instead of email body content.

an email alert is sent to DLTSDRI only if any of the below are TRUE:
 - Any new nodes are shown to have ecc error (in comparison to the last email sent).
---> ex: **nodes a and b** were originally found to have ecc error and an email was sent. some time later, **nodes a and b** still have ecc error, but also **node c**. An email will be sent with an update of all nodes (a, b, c) with ecc error and any actions taken.
- If any action has been taken on any node.
---> ex: Let's say **node a** was shown to have an ecc error, cordoned by repair manager, and an email sent indicating the node error and action taken. Then for some reason **node a** was uncordoned (manually or by some other service). The repair manager will cordon it again on the next ecc error rule check. an email update will be sent indicating the action taken, despite any previous emails sent about node a.
- If ecc error remains on the same nodes after the configured alert wait time.
--> ex. Let's say the configured alert wait time is 24 hours and **nodes a and b** have ecc error. Then 24 hours after the initial email update is sent, if these nodes continue to have ecc error, another reminder email will be sent (no action will be taken on the nodes).

