### PR TITLE
use environment variable to pass user's command

### DIFF
--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -140,7 +140,7 @@ spec:
   - name: {{ job["podName"] }}
     image: {{ job["image"] }}
     imagePullPolicy: Always
-    command: {{ job["LaunchCMD"] }}
+    command: ["bash", "/pod/scripts/bootstrap.sh"]
     readinessProbe:
       exec:
         command: ["ls", "/pod/running/ROLE_READY"]

--- a/src/init-scripts/bootstrap.sh
+++ b/src/init-scripts/bootstrap.sh
@@ -54,6 +54,7 @@ if [ "$DLWS_ROLE_NAME" = "worker" ];
 then
     runuser -l ${DLWS_USER_NAME} -c "sleep infinity"
 else
+    printenv DLWS_LAUNCH_CMD > /pod/job_command.sh
     chmod +x /pod/job_command.sh
     runuser -l ${DLWS_USER_NAME} -c /pod/job_command.sh
     # Save exit code


### PR DESCRIPTION
So that the jobmanager do not have to do that dirty work. This will make it easier to adopt framework launcher.