### PR TITLE
fix scp could not found ssh

### DIFF
--- a/src/docker-images/init-container/build-openssh-static.sh
+++ b/src/docker-images/init-container/build-openssh-static.sh
@@ -21,29 +21,29 @@ top="$(pwd)"
 root="$top/root"
 build="$top/build"
 
-export CFLAGS="-I$root/include -L. -fPIC"
-export CPPFLAGS="-I$root/include -L. -fPIC"
+export CFLAGS="-I$root/usr/include -L. -fPIC"
+export CPPFLAGS="-I$root/usr/include -L. -fPIC"
 
 rm -rf "$root" "$build"
 mkdir -p "$root" "$build"
 
 gzip -dc dist/zlib-*.tar.gz |(cd "$build" && tar xf -)
 cd "$build"/zlib-*
-./configure --prefix="$root" --static
+./configure --prefix="$root/usr" --static
 make -j12
 make install
 cd "$top"
 
 gzip -dc dist/openssl-*.tar.gz |(cd "$build" && tar xf -)
 cd "$build"/openssl-*
-./config --prefix="$root" no-shared
+./config --prefix="/usr" no-shared
 make -j12
-make install
+make INSTALL_PREFIX="$root" install
 cd "$top"
 
 gzip -dc dist/openssh-*.tar.gz |(cd "$build" && tar xf -)
 cd "$build"/openssh-*
-cp -p "$root"/lib/*.a .
+cp -p "$root"/usr/lib/*.a .
 [ -f sshd_config.orig ] || cp -p sshd_config sshd_config.orig
 sed \
   -e 's/^#\(PubkeyAuthentication\) .*/\1 yes/' \
@@ -53,6 +53,6 @@ sed \
   sshd_config.orig \
   >sshd_config \
 ;
-./configure --prefix="$root" --with-privsep-user=nobody --with-privsep-path="/var/run/sshd"
+./configure --prefix="/usr" --with-privsep-user=nobody --with-privsep-path="/var/run/sshd"
 make -j12
-make install
+make DESTDIR="$root" install

--- a/src/docker-images/init-container/install.sh
+++ b/src/docker-images/init-container/install.sh
@@ -1,11 +1,16 @@
 cwd=`dirname $0`
+ssh_root="$cwd/ssh_build/usr"
 
-mkdir -p /etc/ssh
-cp $cwd/ssh_build/etc/* /etc/ssh
-cp $cwd/ssh_config/sshd/sshd_config /etc/ssh/sshd_config
+mkdir -p /usr/etc
+cp $ssh_root/etc/* /usr/etc
+cp $cwd/ssh_config/sshd/sshd_config /usr/etc/sshd_config
 
 cp $cwd/ssh_config/init.d/* /etc/init.d
 cp $cwd/ssh_config/default/* /etc/default
 chmod +x /etc/init.d/ssh
 
-cp -r $cwd/ssh_build/bin $cwd/ssh_build/sbin $cwd/ssh_build/lib $cwd/ssh_build/libexec /usr/
+cp -r $ssh_root/bin $ssh_root/sbin $ssh_root/lib $ssh_root/libexec /usr/
+
+ssh-keygen -t dsa -f /usr/etc/ssh_host_dsa_key -N ""
+ssh-keygen -t rsa -f /usr/etc/ssh_host_rsa_key -N ""
+ssh-keygen -t ecdsa -f /usr/etc/ssh_host_ecdsa_key -N ""

--- a/src/docker-images/init-container/ssh_config/default/ssh
+++ b/src/docker-images/init-container/ssh_config/default/ssh
@@ -1,1 +1,0 @@
-SSHD_OPTS="-f /etc/ssh/sshd_config -h /etc/ssh/ssh_host_rsa_key"

--- a/src/docker-images/init-container/ssh_config/init.d/ssh
+++ b/src/docker-images/init-container/ssh_config/init.d/ssh
@@ -40,13 +40,13 @@ check_for_upstart() {
 }
 
 check_for_no_start() {
-    # forget it if we're trying to start, and /etc/ssh/sshd_not_to_be_run exists
-    if [ -e /etc/ssh/sshd_not_to_be_run ]; then 
+    # forget it if we're trying to start, and /usr/etc/sshd_not_to_be_run exists
+    if [ -e /usr/etc/sshd_not_to_be_run ]; then 
 	if [ "$1" = log_end_msg ]; then
 	    log_end_msg 0 || true
 	fi
 	if ! run_by_init; then
-	    log_action_msg "OpenBSD Secure Shell server not in use (/etc/ssh/sshd_not_to_be_run)" || true
+	    log_action_msg "OpenBSD Secure Shell server not in use (/usr/etc/sshd_not_to_be_run)" || true
 	fi
 	exit 0
     fi
@@ -73,7 +73,7 @@ check_privsep_dir() {
 }
 
 check_config() {
-    if [ ! -e /etc/ssh/sshd_not_to_be_run ]; then
+    if [ ! -e /usr/etc/sshd_not_to_be_run ]; then
 	/usr/sbin/sshd $SSHD_OPTS -t || exit 1
     fi
 }

--- a/src/docker-images/init-container/ssh_config/sshd/sshd_config
+++ b/src/docker-images/init-container/ssh_config/sshd/sshd_config
@@ -15,9 +15,9 @@ Port 22
 #ListenAddress 0.0.0.0
 #ListenAddress ::
 
-#HostKey /etc/ssh/ssh_host_rsa_key
-#HostKey /etc/ssh/ssh_host_ecdsa_key
-#HostKey /etc/ssh/ssh_host_ed25519_key
+#HostKey /usr/etc/ssh_host_rsa_key
+#HostKey /usr/etc/ssh_host_ecdsa_key
+#HostKey /usr/etc/ssh_host_ed25519_key
 
 # Ciphers and keying
 #RekeyLimit default none
@@ -44,7 +44,7 @@ Port 22
 #AuthorizedKeysCommand none
 #AuthorizedKeysCommandUser nobody
 
-# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+# For this to work you will also need host keys in /usr/etc/ssh_known_hosts
 #HostbasedAuthentication no
 # Change to yes if you don't trust ~/.ssh/known_hosts for
 # HostbasedAuthentication

--- a/src/init-scripts/setup_sshd.sh
+++ b/src/init-scripts/setup_sshd.sh
@@ -25,7 +25,7 @@ function retry {
 
 function setup_sshd {
     SSH_PORT=$DLWS_SD_SELF_SSH_PORT
-    sed -i -E "s/^#?Port 22/Port ${SSH_PORT}/" /etc/ssh/sshd_config || exit 1
+    sed -i -E "s/^#?Port 22/Port ${SSH_PORT}/" /usr/etc/sshd_config || exit 1
 
     echo "${SSH_PORT}" > ${PROC_DIR}/SSH_PORT
     echo "${POD_IP}" > ${PROC_DIR}/POD_IP


### PR DESCRIPTION
Because we previous set prefix to /ssh_build/root, and so scp will try to find ssh in that dir. I solve this by treating this as cross platform build, so will set prefix as /usr and change install directory when building the init-container.

ref https://stackoverflow.com/a/21072532/845762