### PR TITLE
also report nonidle_util in gpu-reporter

### DIFF
--- a/src/docker-images/gpu-reporter/reporter.py
+++ b/src/docker-images/gpu-reporter/reporter.py
@@ -24,15 +24,18 @@ from prometheus_client import Histogram
 
 logger = logging.getLogger(__name__)
 
-prometheus_request_histogram = Histogram("reporter_req_latency_seconds",
-        "latency for reporter requesting prometheus (seconds)",
-        buckets=(.05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0,
-            7.5, 10.0, 12.5, 15.0, 17.5, 20.0, float("inf")))
+prometheus_request_histogram = Histogram(
+    "reporter_req_latency_seconds",
+    "latency for reporter requesting prometheus (seconds)",
+    buckets=(.05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0, 12.5, 15.0,
+             17.5, 20.0, float("inf")))
 
-reporter_iteration_histogram = Histogram("reporter_iteration_seconds",
-        "latency for reporter to iterate one pass (seconds)",
-        buckets=(.05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0,
-            7.5, 10.0, 12.5, 15.0, 17.5, 20.0, float("inf")))
+reporter_iteration_histogram = Histogram(
+    "reporter_iteration_seconds",
+    "latency for reporter to iterate one pass (seconds)",
+    buckets=(.05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0, 12.5, 15.0,
+             17.5, 20.0, float("inf")))
+
 
 class AtomicRef(object):
     """ a thread safe way to store and get object,
@@ -49,6 +52,7 @@ class AtomicRef(object):
     def get(self):
         with self.lock:
             return self.data
+
 
 def walk_json_field_safe(obj, *fields):
     """ for example a=[{"a": {"b": 2}}]
@@ -89,10 +93,10 @@ def get_monthly_idleness(prometheus_url):
         "start": str(one_month_ago),
         "end": str(now),
         "step": str(STEP_MINUTE) + "m",
-        })
+    })
 
     url = urllib.parse.urljoin(prometheus_url,
-            "/prometheus/api/v1/query_range") + "?" + args
+                               "/prometheus/api/v1/query_range") + "?" + args
 
     start = timeit.default_timer()
     obj = request_with_error_handling(url)
@@ -106,17 +110,17 @@ def get_monthly_idleness(prometheus_url):
 
     metrics = walk_json_field_safe(obj, "data", "result")
 
-    default = lambda : {"booked": 0, "idle": 0}
+    default = lambda: {"booked": 0, "idle": 0, "nonidle_util_sum": 0.0}
 
     # the first level is vc, the second level is user
-    result = collections.defaultdict(lambda : collections.defaultdict(default))
+    result = collections.defaultdict(lambda: collections.defaultdict(default))
 
     for metric in metrics:
         username = walk_json_field_safe(metric, "metric", "username")
         vc_name = walk_json_field_safe(metric, "metric", "vc_name")
         if username is None or vc_name is None:
             logger.warning("username or vc_name is missing for metric %s",
-                    walk_json_field_safe(metric, "metric"))
+                           walk_json_field_safe(metric, "metric"))
             continue
 
         values = walk_json_field_safe(metric, "values")
@@ -125,14 +129,29 @@ def get_monthly_idleness(prometheus_url):
 
         booked_seconds = values[-1][0] - values[0][0] + step_seconds
         idleness_seconds = 0
+        nonidle_util_sum = 0.0
 
         for time, utils in values:
             utils = float(utils)
             if utils <= IDLENESS_THRESHOLD:
                 idleness_seconds += step_seconds
+            else:
+                nonidle_util_sum += utils * step_seconds
 
         result[vc_name][username]["booked"] += booked_seconds
         result[vc_name][username]["idle"] += idleness_seconds
+        result[vc_name][username]["nonidle_util_sum"] += nonidle_util_sum
+
+    for vc_name, vc_values in result.items():
+        for username, user_val in vc_values.items():
+            nonidle_time = user_val["booked"] - user_val["idle"]
+            nonidle_util_sum = user_val["nonidle_util_sum"]
+
+            if nonidle_time == 0:
+                user_val["nonidle_util"] = 0.0
+            else:
+                user_val["nonidle_util"] = nonidle_util_sum / nonidle_time
+            user_val.pop("nonidle_util_sum")
 
     return result
 
@@ -155,11 +174,10 @@ def serve(prometheus_url, port):
 
     atomic_ref = AtomicRef()
 
-    t = threading.Thread(
-            target=refresher,
-            name="refresher",
-            args=(prometheus_url, atomic_ref),
-            daemon=True)
+    t = threading.Thread(target=refresher,
+                         name="refresher",
+                         args=(prometheus_url, atomic_ref),
+                         daemon=True)
     t.start()
 
     @app.route("/gpu_idle", methods=["GET"])
@@ -177,27 +195,36 @@ def serve(prometheus_url, port):
     @app.route("/metrics")
     def metrics():
         return Response(prometheus_client.generate_latest(),
-                mimetype="text/plain; version=0.0.4; charset=utf-8")
+                        mimetype="text/plain; version=0.0.4; charset=utf-8")
 
     app.run(host="0.0.0.0", port=port, debug=False, use_reloader=False)
 
+
 def register_stack_trace_dump():
     faulthandler.register(signal.SIGTRAP, all_threads=True, chain=False)
+
 
 def main(args):
     register_stack_trace_dump()
     serve(args.prometheus_url, args.port)
 
+
 if __name__ == "__main__":
-    logging.basicConfig(format="%(asctime)s - %(levelname)s - %(filename)s:%(lineno)s - %(message)s",
-            level=logging.INFO)
+    logging.basicConfig(
+        format=
+        "%(asctime)s - %(levelname)s - %(filename)s:%(lineno)s - %(message)s",
+        level=logging.INFO)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--prometheus_url", "-p", required=True,
-            help="Prometheus url, eg: http://127.0.0.1:9091")
+    parser.add_argument("--prometheus_url",
+                        "-p",
+                        required=True,
+                        help="Prometheus url, eg: http://127.0.0.1:9091")
 
-    parser.add_argument("--port", type=int, default=9092,
-            help="port to listen")
+    parser.add_argument("--port",
+                        type=int,
+                        default=9092,
+                        help="port to listen")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Added one more field in result `nonidle_util` represents average gpu utilization when gpu utilization is not 0.

for example:

```
{
  "zhzha": {
    "booked": 40800,
    "idle": 300,
    "nonidle_util": 99.07407407407408
  }
}
```