### PR TITLE
Do not kill job using deprecated family token

### DIFF
--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -332,8 +332,6 @@ def KillJob(userName, jobId):
         if job["userName"] == userName or AuthorizationManager.HasAccess(userName, ResourceType.VC, job["vcName"], Permission.Admin):
             dataFields = {"jobStatus": "killing"}
             conditionFields = {"jobId": jobId}
-            if job["isParent"] == 1:
-                conditionFields = {"familyToken": job["familyToken"]}
             ret = dataHandler.UpdateJobTextFields(conditionFields, dataFields)
     dataHandler.Close()
     return ret


### PR DESCRIPTION
`familyToken` is deprecated and to be removed. It is not indexed in `jobs` table, causing KillJob perf to hurt a lot - single request takes 24 - 30s.

It drops to milliseconds when using indexed `jobId` to locate the job. 

This is already present in dltsdev branch.