### PR TITLE
support inference job in launcher

### DIFF
--- a/src/ClusterManager/framework.py
+++ b/src/ClusterManager/framework.py
@@ -41,7 +41,7 @@ class Framework(object):
                  home_folder_host_path, is_fragment_gpu_job,
                  is_preemption_allowed, is_host_network, is_host_ipc,
                  is_privileged, is_nccl_ib_disabled):
-        self.init_image = init_image  # str
+        self.init_image = init_image  # str, maybe None
         self.labels = labels  # map
         self.annotations = annotations  # map
         self.roles = roles  # a map, key is role name, value is Role object
@@ -276,11 +276,16 @@ def gen_containers(job, role):
 
     volume_mounts.extend(transform_mount_points(job.mount_points, job.plugins))
 
+    if job.init_image is None:
+        cmd = ["sh", "-c", "printenv DLWS_LAUNCH_CMD > /job_command.sh ; mkdir -p /dlts-runtime/status ; touch /dlts-runtime/status/READY ; sh /job_command.sh"]
+    else:
+        cmd = ["bash", "/dlws-scripts/bootstrap.sh"]
+
     spec = [{
         "name": job.job_id,
         "image": role.image,
         "imagePullPolicy": "Always",
-        "command": ["bash", "/dlws-scripts/bootstrap.sh"],
+        "command": cmd,
         "readinessProbe": {
             "exec": {
                 "command": ["ls", "/dlts-runtime/status/READY"]
@@ -500,10 +505,12 @@ def gen_task_role(job, role):
         "hostIPC": job.is_host_ipc,
         "imagePullSecrets": image_pull_secrets,
         "affinity": gen_affinity(job, role),
-        "initContainers": gen_init_container(job, role),
         "containers": gen_containers(job, role),
         "volumes": volumes,
     }
+
+    if job.init_image is not None:
+        pod_spec["initContainers"] = gen_init_container(job, role)
 
     if job.dns_policy is not None:
         pod_spec["dnsPolicy"] = job.dns_policy
@@ -727,6 +734,80 @@ def transform_distributed_job(params, cluster_config):
 
     return gen_framework_spec(framework)
 
+
+def transform_inference_job(params, cluster_config):
+    master_resource = transform_resource(
+        params,
+        cluster_config.get("default_cpurequest", "500m"),
+        cluster_config.get("default_cpulimit", "500m"),
+        cluster_config.get("default_memoryrequest", "2048M"),
+        cluster_config.get("default_memorylimit", "2560M"),
+    )
+    worker_resource = transform_resource(
+        params,
+        cluster_config.get("default_cpurequest", "500m"),
+        cluster_config.get("default_cpulimit", "500m"),
+        cluster_config.get("default_memoryrequest", "2048M"),
+        cluster_config.get("default_memorylimit", "2560M"),
+    )
+    master_resource.gpu_limit = 0
+    worker_resource.gpu_limit = 0
+
+    image = params["image"]
+
+    envs = params.get("envs", [])
+
+    roles = {
+        "master":
+        Role("master", 1, image, envs, master_resource, 1, 1),
+        "worker":
+        Role("worker", int(params["resourcegpu"]), image, envs,
+             worker_resource, 1, 1),
+    }
+
+    labels = params.get("label", {})
+    annotations = params.get("annotations", {})
+
+    framework = Framework(
+        None, # init container
+        labels,
+        annotations,
+        roles,
+        params["jobId"],
+        params[
+            "jobId"],  # pod_name here, should fix this before using blobfuse
+        params["cmd"],
+        params["user"],
+        params["user_email"],
+        params["gid"],
+        params["uid"],
+        params["mountpoints"],
+        params["plugins"],
+        params["familyToken"],
+        params["vcName"],
+        params.get("dnsPolicy"),
+        params.get("nodeSelector", {}),
+        params["homeFolderHostpath"],
+        params.get("fragmentGpuJob", False),
+        params.get("preemptionAllowed", False),
+        params.get("hostNetwork", False),
+        params.get("hostIPC", False),
+        params.get("isPrivileged", False),
+        params.get("nccl_ib_disable", False),
+    )
+
+    return gen_framework_spec(framework)
+
+def transform_job(job_type, params, cluster_config):
+    if job_type == "RegularJob":
+        return transform_regular_job(params, cluster_config)
+    elif job_type == "PSDistJob":
+        return transform_distributed_job(params, cluster_config)
+    elif job_type == "InferenceJob":
+        return transform_inference_job(params, cluster_config)
+    else:
+        logger.error("Unknown job type %s, params is %s", job_type, params)
+        raise RuntimeError("Unknown job type %s" % (job_type))
 
 if __name__ == '__main__':
     pass

--- a/src/ClusterManager/framework.py
+++ b/src/ClusterManager/framework.py
@@ -277,7 +277,10 @@ def gen_containers(job, role):
     volume_mounts.extend(transform_mount_points(job.mount_points, job.plugins))
 
     if job.init_image is None:
-        cmd = ["sh", "-c", "printenv DLWS_LAUNCH_CMD > /job_command.sh ; mkdir -p /dlts-runtime/status ; touch /dlts-runtime/status/READY ; sh /job_command.sh"]
+        cmd = [
+            "sh", "-c",
+            "printenv DLWS_LAUNCH_CMD > /job_command.sh ; mkdir -p /dlts-runtime/status ; touch /dlts-runtime/status/READY ; sh /job_command.sh"
+        ]
     else:
         cmd = ["bash", "/dlws-scripts/bootstrap.sh"]
 
@@ -751,7 +754,7 @@ def transform_inference_job(params, cluster_config):
         cluster_config.get("default_memorylimit", "2560M"),
     )
     master_resource.gpu_limit = 0
-    worker_resource.gpu_limit = 0
+    worker_resource.gpu_limit = 1
 
     image = params["image"]
 
@@ -769,7 +772,7 @@ def transform_inference_job(params, cluster_config):
     annotations = params.get("annotations", {})
 
     framework = Framework(
-        None, # init container
+        None,  # init container
         labels,
         annotations,
         roles,
@@ -798,6 +801,7 @@ def transform_inference_job(params, cluster_config):
 
     return gen_framework_spec(framework)
 
+
 def transform_job(job_type, params, cluster_config):
     if job_type == "RegularJob":
         return transform_regular_job(params, cluster_config)
@@ -808,6 +812,7 @@ def transform_job(job_type, params, cluster_config):
     else:
         logger.error("Unknown job type %s, params is %s", job_type, params)
         raise RuntimeError("Unknown job type %s" % (job_type))
+
 
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
All work for introduce frameworker are done. But when switching to new launcher, we can not simply change it, because old running jobs can not use new one to manage.

Here are choices we can make:

1. write some auto detection so new job will use new launcher to manage, old ones will be managed by old launcher
2. use one launcher per cluster, and only enable this new launcher in new cluster, and migrate old cluster when we can

The first will need to write some code, it's not trivial. The second only need to add a switcher, is much easier to implement. @hongzhili @Anbang-Hu what's your opinion?