### PR TITLE
support user pass in public key as authorized

### DIFF
--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -129,6 +129,12 @@ class JobTemplate(object):
         if nccl_ib_disable is not None and nccl_ib_disable is True:
             params["nccl_ib_disable"] = True
 
+        public_key_path = job.get_hostpath(job.get_alias(), ".ssh", "id_rsa.pub")
+        if os.path.isfile(public_key_path):
+            with open(public_key_path) as f:
+                params["ssh_public_keys"] = params.get("ssh_public_keys", [])
+                params["ssh_public_keys"].append(f.read())
+
         return params, None
 
     def generate_secrets(self, job):

--- a/src/ClusterManager/test/test_regular_job.py
+++ b/src/ClusterManager/test/test_regular_job.py
@@ -377,7 +377,11 @@ def test_blobfuse(args):
             {"unapproved", "queued", "scheduling", "running"})
         assert state == "finished", "state is not finished, but %s" % state
 
-        log = utils.get_job_log(args.rest, args.email, job.jid)
+        for _ in range(5):
+            log = utils.get_job_log(args.rest, args.email, job.jid)
+            if log.find("dummy") != -1:
+                break
+            time.sleep(0.5)
 
         assert log.find("dummy") != -1, "could not find dummy in log %s" % (
             log)

--- a/src/Jobs_Templete/deployment.yaml.template
+++ b/src/Jobs_Templete/deployment.yaml.template
@@ -130,6 +130,10 @@ spec:
         - name: {{env.name}}
           value: "{{env.value}}"
         {% endfor %}
+        {% for key_value in job["ssh_public_keys"] %}
+        - name: DLTS_PUBLIC_SSH_KEY_{{loop.index}}
+          value: "{{key_value}}"
+        {% endfor %}
 
       imagePullSecrets:
       - name: regcred

--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -181,12 +181,6 @@ spec:
     - name: id-rsa-volume
       mountPath: /home/{{ job["user"] }}/.ssh/id_rsa
       readOnly: true
-    - name: id-rsa-pub-volume
-      mountPath: /home/{{ job["user"] }}/.ssh/id_rsa.pub
-      readOnly: true
-    - name: authorized-keys-volume
-      mountPath: /home/{{ job["user"] }}/.ssh/authorized_keys
-      readOnly: true
     {% if not job["dnsPolicy"] %}
     - mountPath: /etc/resolv.conf
       name: resolv
@@ -283,6 +277,10 @@ spec:
     - name: {{env.name}}
       value: "{{env.value}}"
     {% endfor %}
+    {% for key_value in job["ssh_public_keys"] %}
+    - name: DLTS_PUBLIC_SSH_KEY_{{loop.index}}
+      value: "{{key_value}}"
+    {% endfor %}
     {% if job["nccl_ib_disable"] %}
     - name: NCCL_IB_DISABLE
       value: "1"
@@ -310,12 +308,6 @@ spec:
   - name: id-rsa-volume
     hostPath:
       path: {{ job["homeFolderHostpath"] }}/.ssh/id_rsa
-  - name: id-rsa-pub-volume
-    hostPath:
-      path: {{ job["homeFolderHostpath"] }}/.ssh/id_rsa.pub
-  - name: authorized-keys-volume
-    hostPath:
-      path: {{ job["homeFolderHostpath"] }}/.ssh/authorized_keys
   - name: dlts-runtime
     emptyDir: {}
   {% if not job["dnsPolicy"] %}

--- a/src/init-scripts/init_user.sh
+++ b/src/init-scripts/init_user.sh
@@ -15,9 +15,22 @@ chmod 700 /home/${DLTS_USER_NAME}/.ssh || /bin/true
 adduser $DLTS_USER_NAME sudo
 echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-ENV_FILE=/home/${DLTS_USER_NAME}/.ssh/environment
+ENV_FILE=/dlts-runtime/env/pod.env
 
-grep -qx "^\s*. ${ENV_FILE}" /home/${DLTS_USER_NAME}/.profile || cat << SCRIPT >> /home/${DLTS_USER_NAME}/.profile
+set +x
+compgen -e | while read line; do
+        if [[ $line != HOME* ]] && [[ $line != INTERACTIVE* ]] && [[ $line != LS_COLORS* ]]  && [[ $line != PATH* ]] && [[ $line != PWD* ]]; then
+            # Since bash >= 4.4 we could use
+            # echo "export ${line}=${!line@Q}" >> "${ENV_FILE}" ;
+            # For compatible with bash < 4.4
+            printf "export ${line}=%q\n" "${!line}" >> "${ENV_FILE}" ;
+        fi; done
+echo "export PATH=$PATH:\${PATH}" >> "${ENV_FILE}"
+echo "export LD_LIBRARY_PATH=/usr/local/nvidia/lib64/:\${LD_LIBRARY_PATH}" >> "${ENV_FILE}"
+set -x
+
+# source the envs
+grep -qx "^\s*. ${ENV_FILE}" /home/${DLTS_USER_NAME}/.profile || cat << SCRIPT >> "/home/${DLTS_USER_NAME}/.profile"
 if [ -f ${ENV_FILE} ]; then
     . ${ENV_FILE}
 fi

--- a/src/init-scripts/init_user.sh
+++ b/src/init-scripts/init_user.sh
@@ -1,8 +1,6 @@
 #/bin/bash
 set -ex
 
-export ENV_FILE=/pod.env
-
 # install required pkgs
 export DEBIAN_FRONTEND=noninteractive
 
@@ -17,19 +15,9 @@ chmod 700 /home/${DLTS_USER_NAME}/.ssh || /bin/true
 adduser $DLTS_USER_NAME sudo
 echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# export envs
-# options '-e' for exported ENVs only
-compgen -e | while read line; do
-        if [[ $line != HOME* ]] && [[ $line != INTERACTIVE* ]] && [[ $line != LS_COLORS* ]]  && [[ $line != PATH* ]] && [[ $line != PWD* ]]; then
-            # Since bash >= 4.4 we could use
-            # echo "export ${line}=${!line@Q}" >> "${ENV_FILE}" ;
-            # For compatible with bash < 4.4
-            printf "export ${line}=%q\n" "${!line}" >> "${ENV_FILE}" ;
-        fi; done
-echo "export PATH=$PATH:\${PATH}" >> "${ENV_FILE}"
-echo "export LD_LIBRARY_PATH=/usr/local/nvidia/lib64/:\${LD_LIBRARY_PATH}" >> "${ENV_FILE}"
-# source the envs
-grep -qx "^\s*. ${ENV_FILE}" /home/${DLTS_USER_NAME}/.profile || cat << SCRIPT >> "/home/${DLTS_USER_NAME}/.profile"
+ENV_FILE=/home/${DLTS_USER_NAME}/.ssh/environment
+
+grep -qx "^\s*. ${ENV_FILE}" /home/${DLTS_USER_NAME}/.profile || cat << SCRIPT >> /home/${DLTS_USER_NAME}/.profile
 if [ -f ${ENV_FILE} ]; then
     . ${ENV_FILE}
 fi

--- a/src/init-scripts/setup_ssh_config.sh
+++ b/src/init-scripts/setup_ssh_config.sh
@@ -105,6 +105,13 @@ done
 chown ${DLTS_USER_NAME} ${SSH_ENVIRONMENT_FILE}
 chmod 600 ${SSH_ENVIRONMENT_FILE}
 
+AUTHORIZED_FILE=/home/${DLTS_USER_NAME}/.ssh/authorized_keys
+for env_key in `env | grep DLTS_PUBLIC_SSH_KEY_| cut -d = -f 1` ; do
+    printenv $env_key >> $AUTHORIZED_FILE
+done
+chown ${DLTS_USER_NAME} ${AUTHORIZED_FILE}
+chmod 600 ${AUTHORIZED_FILE}
+
 mkdir -p /root/.ssh && cp /home/${DLTS_USER_NAME}/.ssh/* /root/.ssh/ && chown root /root/.ssh/* && chmod 600 /root/.ssh/*
 
 # generate /job/hostfile


### PR DESCRIPTION
Allow user of Restfulapi pass in `ssh_public_keys` as an array of string to pass in public keys to be added to /home/alias/.ssh/authorized_keys.

Do not mount `authorized_keys` and `id_rsa.pub` from NFS anymore. The content of `id_rsa.pub` will be added to this `ssh_public_keys` before submission.

I have checked p40 cluster, no user modified authorized_keys themselves, it should be safe to generate  it ourselves.