### PR TITLE
Configurable default job resource

### DIFF
--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -261,7 +261,6 @@ default_config_parameters = {
     "default_kube_labels_by_node_role": {
         'infra': {
             "infrastructure": "active",
-            "alert-manager": "active",
             "jobmanager": "active",
             "watchdog": "active",
             "mysql": "active",
@@ -728,7 +727,6 @@ default_config_parameters = {
     # 2. enable_cpuworker is set to True
     # 3. default_cpu_sku is set to a valid value that exists in sku_meta
     "enable_cpuworker": False,
-    "enable_blobfuse": False,
     "enable_custom_registry_secrets": False,
     "default_cpu_sku": "Standard_D2s_v3",
 
@@ -745,7 +743,7 @@ default_config_parameters = {
             "memory": 8,
             "memory_ratio": 0.9
         }
-    }
+    },
 }
 
 # These are super scripts

--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -86,4 +86,3 @@ elasticsearch:
   {% endfor %}
 
 job_mountpoints: {{cnf["job_mountpoints"]}}
-enable_job_resource_limit: {{cnf["enable_job_resource_limit"]}}

--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -61,11 +61,8 @@ job-manager:
 infiniband_mounts: {{cnf["infiniband_mounts"]}}
 custom_mounts: {{cnf["custom_mounts"]}}
 
+# TODO: Remove special cpuworker configuration
 enable_cpuworker: {{cnf["enable_cpuworker"]}}
-default_cpurequest: {{cnf["default_cpurequest"]}}
-default_cpulimit: {{cnf["default_cpulimit"]}}
-default_memoryrequest: {{cnf["default_memoryrequest"]}}
-default_memorylimit: {{cnf["default_memorylimit"]}}
 default_cpu_sku: {{cnf["default_cpu_sku"]}}
 sku_meta: {{cnf["sku_meta"]}}
 
@@ -86,3 +83,19 @@ elasticsearch:
   {% endfor %}
 
 job_mountpoints: {{cnf["job_mountpoints"]}}
+
+{% if cnf["job_resource_policy"] %}
+job_resource_policy: {{cnf["job_resource_policy"]}}
+{% endif %}
+{% if cnf["default_cpurequest"] %}
+default_cpurequest: {{cnf["default_cpurequest"]}}
+{% endif %}
+{% if cnf["default_cpulimit"] %}
+default_cpulimit: {{cnf["default_cpulimit"]}}
+{% endif %}
+{% if cnf["default_memoryrequest"] %}
+default_memoryrequest: {{cnf["default_memoryrequest"]}}
+{% endif %}
+{% if cnf["default_memorylimit"] %}
+default_memorylimit: {{cnf["default_memorylimit"]}}
+{% endif %}

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -143,17 +143,15 @@ def populate_job_resource(params):
             logger.exception("Failed to parse resource quota and metadata")
             return
 
-        job_params = make_job_params(params, quota, metadata)
+        job_params = make_job_params(params, quota, metadata, config)
         if job_params.is_valid():
             logger.info("job_params %s is valid. Populating.", job_params)
             params["sku"] = job_params.sku
-            if config.get("enable_job_resource_limit", False) is True:
-                logger.info("Job resource is enabled. Populating resource.")
-                params["resourcegpu"] = job_params.gpu_limit
-                params["cpurequest"] = job_params.cpu_request
-                params["cpulimit"] = job_params.cpu_limit
-                params["memoryrequest"] = job_params.memory_request
-                params["memorylimit"] = job_params.memory_limit
+            params["resourcegpu"] = job_params.gpu_limit
+            params["cpurequest"] = job_params.cpu_request
+            params["cpulimit"] = job_params.cpu_limit
+            params["memoryrequest"] = job_params.memory_request
+            params["memorylimit"] = job_params.memory_limit
         else:
             logger.warning("job_params %s is invalid. Not populating.",
                            job_params)

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -9,3 +9,7 @@ def base64encode(str_val):
 
 def base64decode(str_val):
     return base64.b64decode(str_val.encode("utf-8")).decode("utf-8")
+
+
+def override(func):
+    return func

--- a/src/utils/job_params_util.py
+++ b/src/utils/job_params_util.py
@@ -3,6 +3,7 @@
 import logging
 
 from resource_stat import make_resource
+from job_resource_policy import make_job_resource_policy
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,7 @@ def get_resource_params_from_job_params(params):
 
 
 class JobParams(object):
-    def __init__(self, params, quota, metadata):
+    def __init__(self, params, quota, metadata, config):
         """Constructor for JobParams.
 
         Args:
@@ -94,6 +95,9 @@ class JobParams(object):
         self.params = params
         self.quota = quota
         self.metadata = metadata
+        self.config = config
+
+        self.policy = None
 
         self.sku = None
         self.gpu_limit = None
@@ -107,6 +111,8 @@ class JobParams(object):
     def generate(self):
         self.gen_sku()
         self.gen_gpu()
+        # Job resource policy is dependent on sku and gpu
+        self.gen_policy()
         self.gen_cpu()
         self.gen_memory()
 
@@ -145,6 +151,11 @@ class JobParams(object):
             self.gpu_limit = gpu_limit
         if self.gpu_limit is not None:
             self.gpu_limit = int(self.gpu_limit)
+
+    def gen_policy(self):
+        self.policy = make_job_resource_policy(self.sku, self.gpu_limit,
+                                               self.config, self.quota,
+                                               self.metadata)
 
     def gen_cpu(self):
         self.cpu_request = self.params.get("cpurequest")
@@ -191,32 +202,14 @@ class JobParams(object):
 
     @override
     def get_cpu_request_and_limit(self):
-        if self.gpu_limit > 0:
-            # For a gpu job, proportionally assign cpu according to gpu.
-            request, limit = self.get_cpu_proportional()
-        else:
-            # For a cpu job, assign system default.
-            request, limit = self.get_default_cpu_request_and_limit()
+        request = self.policy.default_cpu_request
+        limit = self.policy.default_cpu_limit
         return request, limit
 
     @override
     def get_memory_request_and_limit(self):
-        if self.gpu_limit > 0:
-            # For a gpu job, proportionally assign memory according to gpu.
-            request, limit = self.get_memory_proportional()
-        else:
-            # For a cpu job, assign system default.
-            request, limit = self.get_default_memory_request_and_limit()
-        return request, limit
-
-    def get_default_cpu_request_and_limit(self):
-        request = self.params.get("cpurequest", DEFAULT_CPU_REQUEST)
-        limit = self.params.get("cpulimit", DEFAULT_CPU_LIMIT)
-        return request, limit
-
-    def get_default_memory_request_and_limit(self):
-        request = self.params.get("memoryrequest", DEFAULT_MEMORY_REQUEST)
-        limit = self.params.get("memorylimit", DEFAULT_MEMORY_LIMIT)
+        request = self.policy.default_memory_request
+        limit = self.policy.default_memory_limit
         return request, limit
 
     def __repr__(self):
@@ -230,97 +223,52 @@ class JobParams(object):
             "memory_limit": self.memory_limit,
         }
 
-    def get_sku_resource_info(self, r_type):
-        """Returns resource per node and the corresponding schedulable ratio.
-
-        Args:
-            r_type: "gpu", "cpu", or "memory".
-
-        Returns:
-            per_node resource, schedulable_ratio
-        """
-        info = self.metadata.get(r_type, {}).get(self.sku, {})
-        per_node = make_resource(r_type, {self.sku: info.get("per_node", 0)})
-        schedulable_ratio = float(info.get("schedulable_ratio", 1))
-        return per_node, schedulable_ratio
-
-    def get_resource_proportional(self, r_type):
-        """Returns request and limit value for resource proportional to GPU.
-
-        Args:
-            r_type: "gpu", "cpu", or "memory".
-
-        Returns:
-            request, limit for resource
-        """
-        gpu_per_node, _ = self.get_sku_resource_info("gpu")
-        gpu_per_node = gpu_per_node.scalar(self.sku)
-
-        per_node, schedulable_ratio = self.get_sku_resource_info(r_type)
-        schedulable_per_node = per_node * schedulable_ratio
-
-        request = schedulable_per_node * self.gpu_limit / gpu_per_node
-        limit = per_node * self.gpu_limit / gpu_per_node
-        return request.scalar(self.sku), limit.scalar(self.sku)
-
-    def get_cpu_proportional(self):
-        """Returns request and limit value for cpu proportional to GPU.
-        """
-        return self.get_resource_proportional("cpu")
-
-    def get_memory_proportional(self):
-        """Returns request and limit value for memory proportional to GPU.
-        """
-        return self.get_resource_proportional("memory")
-
 
 class RegularJobParams(JobParams):
-    def __init__(self, params, quota, metadata):
-        super(RegularJobParams, self).__init__(params, quota, metadata)
+    def __init__(self, params, quota, metadata, config):
+        super(RegularJobParams, self).__init__(params, quota, metadata, config)
 
 
 class PSDistJobParams(JobParams):
     """Always allocate entire nodes for workers if no resource request.
     """
-    def __init__(self, params, quota, metadata):
-        super(PSDistJobParams, self).__init__(params, quota, metadata)
+    def __init__(self, params, quota, metadata, config):
+        super(PSDistJobParams, self).__init__(params, quota, metadata, config)
 
     def get_cpu_request_and_limit(self):
-        if self.gpu_limit > 0:
-            # For a gpu job, proportionally assign cpu according to gpu
-            request, limit = self.get_cpu_proportional()
+        if self.cpu_job_on_cpu_node:
+            policy = self.policy
+            per_node, schedulable_ratio = policy.get_sku_resource_info("cpu")
+            request = (per_node * schedulable_ratio).scalar(self.sku)
+            limit = per_node.scalar(self.sku)
         else:
-            # For a cpu job, if it's running on cpu nodes, assign whole nodes;
-            # if it's running on gpu nodes, assign system default.
-            if self.metadata.get("gpu", {}).get(self.sku) is None:
-                per_node, schedulable_ratio = self.get_sku_resource_info("cpu")
-                request = (per_node * schedulable_ratio).scalar(self.sku)
-                limit = per_node.scalar(self.sku)
-            else:
-                request, limit = self.get_default_cpu_request_and_limit()
+            request, limit = super(PSDistJobParams, self).\
+                get_cpu_request_and_limit()
         return request, limit
 
     def get_memory_request_and_limit(self):
-        if self.gpu_limit > 0:
-            # For a gpu job, proportionally assign memory according to gpu
-            request, limit = self.get_memory_proportional()
+        if self.cpu_job_on_cpu_node:
+            policy = self.policy
+            per_node, schedulable_ratio = policy.get_sku_resource_info("memory")
+            request = (per_node * schedulable_ratio).scalar(self.sku)
+            limit = per_node.scalar(self.sku)
         else:
-            # For a cpu job, if it's running on cpu nodes, assign whole nodes;
-            # if it's running on gpu nodes, assign system default.
-            if self.metadata.get("gpu", {}).get(self.sku) is None:
-                per_node, schedulable_ratio = \
-                    self.get_sku_resource_info("memory")
-                request = (per_node * schedulable_ratio).scalar(self.sku)
-                limit = per_node.scalar(self.sku)
-            else:
-                request, limit = self.get_default_memory_request_and_limit()
+            request, limit = super(PSDistJobParams, self).\
+                get_memory_request_and_limit()
         return request, limit
+
+    @property
+    def cpu_job_on_cpu_node(self):
+        is_cpu_job = self.gpu_limit == 0
+        on_cpu_node = self.metadata.get("gpu", {}).get(self.sku) is None
+        return is_cpu_job and on_cpu_node
 
 
 class InferenceJobParams(JobParams):
     """Always allocate 1 GPU for each worker if any."""
-    def __init__(self, params, quota, metadata):
-        super(InferenceJobParams, self).__init__(params, quota, metadata)
+    def __init__(self, params, quota, metadata, config):
+        super(InferenceJobParams, self).__init__(params, quota, metadata,
+                                                 config)
 
 
 JOB_PARAMS_MAPPING = {
@@ -330,11 +278,12 @@ JOB_PARAMS_MAPPING = {
 }
 
 
-def make_job_params(params, quota, metadata):
+def make_job_params(params, quota, metadata, config):
     job_params = None
     try:
         job_type = params.get("jobtrainingtype")
-        job_params = JOB_PARAMS_MAPPING[job_type](params, quota, metadata)
+        job_params = JOB_PARAMS_MAPPING[job_type](params, quota, metadata,
+                                                  config)
     except ValueError:
         logger.exception("Bad job type in params %s", params)
     except Exception:

--- a/src/utils/job_resource_policy.py
+++ b/src/utils/job_resource_policy.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+import logging
+
+from common import override
+from resource_stat import make_resource
+
+
+logger = logging.getLogger(__name__)
+
+
+class JobResourcePolicy(object):
+    def __init__(self, sku=None, gpu_limit=0, config=None, quota=None,
+                 metadata=None):
+        self.sku = sku
+        self.gpu_limit = int(gpu_limit)
+        self.config = config
+        self.quota = quota
+        self.metadata = metadata
+
+        # Backward compatible: use 1 core to reserve
+        self.sys_cpu_request = "1000m"
+
+        # Backward compatible: allow using up cpu on node
+        cpu_per_node, _ = self.get_sku_resource_info("cpu")
+        self.sys_cpu_limit = cpu_per_node.scalar(self.sku)
+
+        # Backward compatible: use 0 memory to reserve
+        self.sys_memory_request = "0Mi"
+
+        # Backward compatible: allow using up memory on node
+        memory_per_node, _ = self.get_sku_resource_info("memory")
+        self.sys_memory_limit = memory_per_node.scalar(self.sku)
+
+    @override
+    @property
+    def default_cpu_request(self):
+        return self.config.get("default_cpurequest", self.sys_cpu_request)
+
+    @override
+    @property
+    def default_cpu_limit(self):
+        return self.config.get("default_cpulimit", self.sys_cpu_limit)
+
+    @override
+    @property
+    def default_memory_request(self):
+        return self.config.get("default_memoryrequest", self.sys_memory_request)
+
+    @override
+    @property
+    def default_memory_limit(self):
+        return self.config.get("default_memorylimit", self.sys_memory_limit)
+
+    def get_sku_resource_info(self, r_type):
+        info = self.metadata.get(r_type, {}).get(self.sku, {})
+        per_node = make_resource(r_type, {self.sku: info.get("per_node", 0)})
+        schedulable_ratio = float(info.get("schedulable_ratio", 1))
+        return per_node, schedulable_ratio
+
+
+class GpuProportionalPolicy(JobResourcePolicy):
+    @property
+    def default_cpu_request(self):
+        if self.gpu_limit == 0:
+            return super(GpuProportionalPolicy, self).default_cpu_request
+        else:
+            return self.get_request_proportional("cpu")
+
+    @property
+    def default_cpu_limit(self):
+        if self.gpu_limit == 0:
+            return super(GpuProportionalPolicy, self).default_cpu_limit
+        else:
+            return self.get_limit_proportional("cpu")
+
+    @property
+    def default_memory_request(self):
+        if self.gpu_limit == 0:
+            return super(GpuProportionalPolicy, self).default_memory_request
+        else:
+            return self.get_request_proportional("memory")
+
+    @property
+    def default_memory_limit(self):
+        if self.gpu_limit == 0:
+            return super(GpuProportionalPolicy, self).default_memory_limit
+        else:
+            return self.get_limit_proportional("memory")
+
+    def get_request_proportional(self, r_type):
+        gpu_per_node, _ = self.get_sku_resource_info("gpu")
+        gpu_per_node = gpu_per_node.scalar(self.sku)
+
+        per_node, schedulable_ratio = self.get_sku_resource_info(r_type)
+        schedulable_per_node = per_node * schedulable_ratio
+
+        request = schedulable_per_node * self.gpu_limit / gpu_per_node
+        return request.scalar(self.sku)
+
+    def get_limit_proportional(self, r_type):
+        gpu_per_node, _ = self.get_sku_resource_info("gpu")
+        gpu_per_node = gpu_per_node.scalar(self.sku)
+
+        per_node, _ = self.get_sku_resource_info(r_type)
+
+        limit = per_node * self.gpu_limit / gpu_per_node
+        return limit.scalar(self.sku)
+
+
+JOB_RESOURCE_POLICY_MAPPING = {
+    "default": JobResourcePolicy,
+    "gpu_proportional": GpuProportionalPolicy,
+}
+
+
+def make_job_resource_policy(sku, gpu_limit, config, quota, metadata):
+    policy = None
+    try:
+        policy_type = config.get("job_resource_policy", "default")
+        policy = JOB_RESOURCE_POLICY_MAPPING[policy_type](sku, gpu_limit,
+                                                          config, quota,
+                                                          metadata)
+    except:
+        logger.exception("Failed to make job resource policy with sku %s, "
+                         "gpu_limit %s, config %s, quota %s, metadata %s",
+                         sku, gpu_limit, config, quota, metadata)
+    return policy

--- a/src/utils/test_job_params_util.py
+++ b/src/utils/test_job_params_util.py
@@ -59,6 +59,8 @@ class TestJobParams(TestCase):
             "vcName": "platform",
         }
 
+        self.config = {}
+
 
 class TestRegularJobParams(TestJobParams):
     def setUp(self):
@@ -70,7 +72,8 @@ class TestRegularJobParams(TestJobParams):
     def test_backward_compatibility_cpu_job(self):
         # Cpu job on cpu node
         self.params["resourcegpu"] = 0
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -82,7 +85,8 @@ class TestRegularJobParams(TestJobParams):
 
         # Cpu job on gpu node
         self.quota["cpu"].pop("Standard_D2s_v3", None)
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -95,7 +99,8 @@ class TestRegularJobParams(TestJobParams):
     def test_backward_compatibility_gpu_job(self):
         # Gpu job with proportionally assigned cpu and memory
         self.params["resourcegpu"] = 3
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -107,7 +112,8 @@ class TestRegularJobParams(TestJobParams):
 
     def test_cpu_job_on_cpu_node(self):
         self.params["gpu_limit"] = 0
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -122,7 +128,8 @@ class TestRegularJobParams(TestJobParams):
             "cpurequest": "1200m",
             "memoryrequest": "4096Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -137,7 +144,8 @@ class TestRegularJobParams(TestJobParams):
             "cpulimit": "1500m",
             "memorylimit": "4608Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -153,7 +161,8 @@ class TestRegularJobParams(TestJobParams):
             "gpu_limit": 0,
             "sku": "Standard_ND24rs",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -167,7 +176,8 @@ class TestRegularJobParams(TestJobParams):
         # gpu_limit precedes resourcegpu
         self.params["resourcegpu"] = 0
         self.params["gpu_limit"] = 3
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -182,7 +192,8 @@ class TestRegularJobParams(TestJobParams):
             "cpurequest": "1200m",
             "memoryrequest": "4096Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -197,7 +208,8 @@ class TestRegularJobParams(TestJobParams):
             "cpulimit": "1500m",
             "memorylimit": "4608Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -218,7 +230,8 @@ class TestPSDistJobParams(TestJobParams):
     def test_backward_compatibility_cpu_job(self):
         # Cpu job running on cpu nodes occupy entire nodes
         self.params["resourcegpu"] = 0
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -231,7 +244,8 @@ class TestPSDistJobParams(TestJobParams):
     def test_backward_compatibility_gpu_job(self):
         # Gpu jobs asking for all gpus on nodes
         self.params["resourcegpu"] = 4
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -243,7 +257,8 @@ class TestPSDistJobParams(TestJobParams):
 
     def test_cpu_job_on_cpu_node(self):
         self.params["gpu_limit"] = 0
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -258,7 +273,8 @@ class TestPSDistJobParams(TestJobParams):
             "cpurequest": "1200m",
             "memoryrequest": "4096Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -273,7 +289,8 @@ class TestPSDistJobParams(TestJobParams):
             "cpulimit": "1500m",
             "memorylimit": "4608Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -288,7 +305,8 @@ class TestPSDistJobParams(TestJobParams):
             "gpu_limit": 0,
             "sku": "Standard_ND24rs",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -302,7 +320,8 @@ class TestPSDistJobParams(TestJobParams):
         # gpu_limit precedes resourcegpu
         self.params["resourcegpu"] = 0
         self.params["gpu_limit"] = 3
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -317,7 +336,8 @@ class TestPSDistJobParams(TestJobParams):
             "cpurequest": "1200m",
             "memoryrequest": "4096Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -332,7 +352,8 @@ class TestPSDistJobParams(TestJobParams):
             "cpulimit": "1500m",
             "memorylimit": "4608Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -353,7 +374,8 @@ class TestInferenceJobParams(TestJobParams):
     def test_backward_compatibility_gpu_job(self):
         # 1 gpu per pod for workers on gpu nodes
         self.params["resourcegpu"] = 1
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -365,7 +387,8 @@ class TestInferenceJobParams(TestJobParams):
 
     def test_cpu_job_on_cpu_node(self):
         self.params["gpu_limit"] = 0
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -380,7 +403,8 @@ class TestInferenceJobParams(TestJobParams):
             "cpurequest": "1200m",
             "memoryrequest": "4096Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -395,7 +419,8 @@ class TestInferenceJobParams(TestJobParams):
             "cpulimit": "1500m",
             "memorylimit": "4608Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_D2s_v3", job_params.sku)
@@ -411,7 +436,8 @@ class TestInferenceJobParams(TestJobParams):
             "gpu_limit": 0,
             "sku": "Standard_ND24rs",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -425,7 +451,8 @@ class TestInferenceJobParams(TestJobParams):
         # gpu_limit precedes resourcegpu
         self.params["resourcegpu"] = 0
         self.params["gpu_limit"] = 3
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -440,7 +467,8 @@ class TestInferenceJobParams(TestJobParams):
             "cpurequest": "1200m",
             "memoryrequest": "4096Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)
@@ -455,7 +483,8 @@ class TestInferenceJobParams(TestJobParams):
             "cpulimit": "1500m",
             "memorylimit": "4608Mi",
         })
-        job_params = make_job_params(self.params, self.quota, self.metadata)
+        job_params = make_job_params(self.params, self.quota, self.metadata,
+                                     self.config)
         self.assertIsNotNone(job_params)
         self.assertTrue(job_params.is_valid())
         self.assertEqual("Standard_ND24rs", job_params.sku)

--- a/src/utils/test_job_resource_policy.py
+++ b/src/utils/test_job_resource_policy.py
@@ -1,55 +1,14 @@
 #!/usr/bin/env python3
 
 from unittest import TestCase
+from utils_for_test import get_test_quota, get_test_metadata
 from job_resource_policy import make_job_resource_policy
 
 
 class TestJobResourcePolicy(TestCase):
     def setUp(self):
-        self.quota = {
-            "cpu": {
-                "Standard_D2s_v3": 4,
-                "Standard_ND24rs": 72,
-            },
-            "memory": {
-                "Standard_D2s_v3": "16Gi",
-                "Standard_ND24rs": "1344Gi",
-            },
-            "gpu": {
-                "Standard_ND24rs": 12,
-            },
-        }
-
-        self.metadata = {
-            "cpu": {
-                "Standard_D2s_v3": {
-                    "per_node": 2,
-                    "schedulable_ratio": 0.9,
-                },
-                "Standard_ND24rs": {
-                    "per_node": 24,
-                    "schedulable_ratio": 0.9,
-                },
-            },
-            "memory": {
-                "Standard_D2s_v3": {
-                    "per_node": "8Gi",
-                    "schedulable_ratio": 0.9,
-                },
-                "Standard_ND24rs": {
-                    "per_node": "448Gi",
-                    "schedulable_ratio": 0.9,
-                },
-            },
-            "gpu": {
-                "Standard_ND24rs": {
-                    "per_node": 4,
-                    "gpu_type": "P40",
-                    "schedulable_ratio": 1,
-                },
-            },
-        }
-
+        self.quota = get_test_quota()
+        self.metadata = get_test_metadata()
         self.config = {
             "job_resource_policy": "default",
         }

--- a/src/utils/test_job_resource_policy.py
+++ b/src/utils/test_job_resource_policy.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+from unittest import TestCase
+from job_resource_policy import make_job_resource_policy
+
+
+class TestJobResourcePolicy(TestCase):
+    def setUp(self):
+        self.quota = {
+            "cpu": {
+                "Standard_D2s_v3": 4,
+                "Standard_ND24rs": 72,
+            },
+            "memory": {
+                "Standard_D2s_v3": "16Gi",
+                "Standard_ND24rs": "1344Gi",
+            },
+            "gpu": {
+                "Standard_ND24rs": 12,
+            },
+        }
+
+        self.metadata = {
+            "cpu": {
+                "Standard_D2s_v3": {
+                    "per_node": 2,
+                    "schedulable_ratio": 0.9,
+                },
+                "Standard_ND24rs": {
+                    "per_node": 24,
+                    "schedulable_ratio": 0.9,
+                },
+            },
+            "memory": {
+                "Standard_D2s_v3": {
+                    "per_node": "8Gi",
+                    "schedulable_ratio": 0.9,
+                },
+                "Standard_ND24rs": {
+                    "per_node": "448Gi",
+                    "schedulable_ratio": 0.9,
+                },
+            },
+            "gpu": {
+                "Standard_ND24rs": {
+                    "per_node": 4,
+                    "gpu_type": "P40",
+                    "schedulable_ratio": 1,
+                },
+            },
+        }
+
+        self.config = {
+            "job_resource_policy": "default",
+        }
+
+    def test_override(self):
+        self.config.update({
+            "default_cpurequest": "12000m",
+            "default_cpulimit": "14000m",
+            "default_memoryrequest": "102400Mi",
+            "default_memorylimit": "409600Mi",
+        })
+        policy = make_job_resource_policy("Standard_ND24rs", 0, self.config,
+                                          self.quota, self.metadata)
+        self.assertIsNotNone(policy)
+        self.assertEqual("12000m", policy.default_cpu_request)
+        self.assertEqual("14000m", policy.default_cpu_limit)
+        self.assertEqual("102400Mi", policy.default_memory_request)
+        self.assertEqual("409600Mi", policy.default_memory_limit)
+
+    def test_cpu_job(self):
+        policy = make_job_resource_policy("Standard_ND24rs", 0, self.config,
+                                          self.quota, self.metadata)
+        self.assertIsNotNone(policy)
+        self.assertEqual("1000m", policy.default_cpu_request)
+        self.assertEqual("24000m", policy.default_cpu_limit)
+        self.assertEqual("0Mi", policy.default_memory_request)
+        self.assertEqual("458752Mi", policy.default_memory_limit)
+
+    def test_gpu_job(self):
+        policy = make_job_resource_policy("Standard_ND24rs", 3, self.config,
+                                          self.quota, self.metadata)
+        self.assertIsNotNone(policy)
+        self.assertEqual("1000m", policy.default_cpu_request)
+        self.assertEqual("24000m", policy.default_cpu_limit)
+        self.assertEqual("0Mi", policy.default_memory_request)
+        self.assertEqual("458752Mi", policy.default_memory_limit)
+
+
+class TestGpuProportionalPolicy(TestJobResourcePolicy):
+    def setUp(self):
+        super(TestGpuProportionalPolicy, self).setUp()
+        self.config["job_resource_policy"] = "gpu_proportional"
+
+    def test_gpu_job(self):
+        policy = make_job_resource_policy("Standard_ND24rs", 3, self.config,
+                                          self.quota, self.metadata)
+        self.assertIsNotNone(policy)
+        self.assertEqual("16000m", policy.default_cpu_request)
+        self.assertEqual("18000m", policy.default_cpu_limit)
+        self.assertEqual("309657Mi", policy.default_memory_request)
+        self.assertEqual("344064Mi", policy.default_memory_limit)

--- a/src/utils/utils_for_test.py
+++ b/src/utils/utils_for_test.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+
+def get_test_quota():
+    quota = {
+        "cpu": {
+            "Standard_D2s_v3": 4,
+            "Standard_ND24rs": 72,
+        },
+        "memory": {
+            "Standard_D2s_v3": "16Gi",
+            "Standard_ND24rs": "1344Gi",
+        },
+        "gpu": {
+            "Standard_ND24rs": 12,
+        },
+    }
+    return quota
+
+
+def get_test_metadata():
+    metadata = {
+        "cpu": {
+            "Standard_D2s_v3": {
+                "per_node": 2,
+                "schedulable_ratio": 0.9,
+            },
+            "Standard_ND24rs": {
+                "per_node": 24,
+                "schedulable_ratio": 0.9,
+            },
+        },
+        "memory": {
+            "Standard_D2s_v3": {
+                "per_node": "8Gi",
+                "schedulable_ratio": 0.9,
+            },
+            "Standard_ND24rs": {
+                "per_node": "448Gi",
+                "schedulable_ratio": 0.9,
+            },
+        },
+        "gpu": {
+            "Standard_ND24rs": {
+                "per_node": 4,
+                "gpu_type": "P40",
+                "schedulable_ratio": 1,
+            },
+        },
+    }
+    return metadata


### PR DESCRIPTION
Add `JobResourcePolicy` and `GpuProportionalPolicy`. They can be specified in `confg.yaml`:
```
job_resource_policy: "default"
```
or
```
job_resource_policy: "gpu_proportional"
```

Values for the following fields can be overriden in `config.yaml` to control the default values of cpu and memory:
```
default_cpurequest
default_cpulimit
default_memoryrequest
default_memorylimit
```

For backward compatibility, `JobResourcePolicy` is the default policy that
- for both CPU and GPU `RegularJob`, as well as `InferenceJob`:
```
default_cpurequest: 1000m
default_cpulimit: <total number of cpu on the node, depending on sku>
default_memoryrequest: 0Mi
default_memorylimit: <total amount of memory on the node, depending on sku>
```
- for CPU `PSDistJob` on GPU node and GPU `PSDistJob`:
```
default_cpurequest: 1000m
default_cpulimit: <total number of cpu on the node, depending on sku>
default_memoryrequest: 0Mi
default_memorylimit: <total amount of memory on the node, depending on sku>
```
- for CPU `PSDistJob` on CPU node:
```
default_cpurequest: <total number of cpu on the node, depending on sku> * <schedulable ratio>
default_cpulimit: <total number of cpu on the node, depending on sku>
default_memoryrequest: <total amount of memory on the node, depending on sku> * <schedulable ratio>
default_memorylimit: <total amount of memory on the node, depending on sku>
```