### PR TITLE
Support deployment of Elasticsearch on infra node

### DIFF
--- a/src/ClusterBootstrap/services/logging/elasticsearch.yaml
+++ b/src/ClusterBootstrap/services/logging/elasticsearch.yaml
@@ -64,6 +64,13 @@ spec:
           value: '{{cnf["elasticsearch"]["port"]["http"]}}'
         - name: "transport.port"
           value: '{{cnf["elasticsearch"]["port"]["transport"]}}'
+        resources:
+          requests:
+            cpu: 100m
+        {% if cnf["elasticsearch"]["cpu_limit"] %}
+          limits:
+            cpu: {{cnf["elasticsearch"]["cpu_limit"]}}
+        {% endif %}
         ports:
         - containerPort: {{cnf["elasticsearch"]["port"]["http"]}}
           name: http


### PR DESCRIPTION
An example of overriding config for deploying ES on infra node
```
elasticsearch:
   cpu_limit: 2500m
   port:
     http: 9400
     transport: 9401

kubelabels:
   elasticsearch: etcd_node_1

 cloud_config_nsg_rules:
   inter_connect:
     tcp_port_ranges: "22 1443 2379 3306 5000 8086 9114 9400 9401 10250"
```