### PR TITLE
update public/private key when empty

### DIFF
--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -312,7 +312,7 @@ class DistributeJobTemplate(JobTemplate):
             "name":
             "DLTS_SSH_PRIVATE_KEY",
             "value":
-            params["private_key"]
+            pod["private_key"]
         })
         return pod_obj
 

--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -472,10 +472,17 @@ class DataHandler(object):
             ON DUPLICATE KEY UPDATE
             uid=%s, gid=%s, groups=%s""".format(self.identitytablename)
 
+            cursor.execute(sql, (identityName, uid, gid, groups, public_key,
+                private_key, uid, gid, groups))
+
             # do not update public_key and private_key if already exist, maybe
             # this key is currently in use
-            cursor.execute(sql, (identityName, uid, gid, groups, public_key,
-                           private_key, uid, gid, groups))
+            sql = """UPDATE {0}
+            SET public_key = %s, private_key = %s
+            WHERE identityName=%s AND public_key="" AND private_key=""
+            """.format(self.identitytablename)
+
+            cursor.execute(sql, (public_key, private_key, identityName))
             self.conn.commit()
             cursor.close()
             return True


### PR DESCRIPTION
cloud init will need this, because cloud init will insert a init value for identity value. We do not want cloud init to generate public/private key for this first user.