### PR TITLE
Dashboard: add eslint-plugin-mocha to lint all unit tests.

### DIFF
--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -71,6 +71,7 @@
     "eslint": "^6.6.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-mocha": "^6.3.0",
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.0",

--- a/src/dashboard/server/test/.eslintrc.yaml
+++ b/src/dashboard/server/test/.eslintrc.yaml
@@ -1,2 +1,3 @@
 env:
   mocha: true
+extends: plugin:mocha/recommended

--- a/src/dashboard/server/test/authenticate.js
+++ b/src/dashboard/server/test/authenticate.js
@@ -5,8 +5,8 @@ const touge = require('tough-cookie')
 
 const api = require('../api').callback()
 
-describe('GET /authenticate', () => {
-  it('should redirect the user to login page.', async () => {
+describe('GET /authenticate', function () {
+  it('should redirect the user to login page.', async function () {
     const response = await axiosist(api).get('/authenticate', {
       maxRedirects: 0
     })
@@ -17,7 +17,7 @@ describe('GET /authenticate', () => {
       .and.match(/\b11111111-1111-1111-1111-111111111111\b/)
   })
 
-  it('should sign the user in with code from active directory', async () => {
+  it('should sign the user in with code from active directory', async function () {
     const email = 'dlts@example.com'
     nock('https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2')
       .filteringRequestBody(/\bclient_id=11111111-1111-1111-1111-111111111111\b/)
@@ -44,7 +44,7 @@ describe('GET /authenticate', () => {
     payload.email.should.be.equal(email)
   })
 
-  it('should bring ths user back when authentication failed', async () => {
+  it('should bring ths user back when authentication failed', async function () {
     const response = await axiosist(api).get('/authenticate', {
       params: {
         error: 'Invalid code'
@@ -55,8 +55,8 @@ describe('GET /authenticate', () => {
   })
 })
 
-describe('GET /authenticate/logout', () => {
-  it('should bring user to log out page in active directory', async () => {
+describe('GET /authenticate/logout', function () {
+  it('should bring user to log out page in active directory', async function () {
     const response = await axiosist(api).get('/authenticate/logout', {
       maxRedirects: 0
     })

--- a/src/dashboard/server/test/controllers/bootstrap.js
+++ b/src/dashboard/server/test/controllers/bootstrap.js
@@ -14,8 +14,8 @@ const getBootstrapArgument = (code) => {
   return new Function('bootstrap', `return ${code}`)(bootstrap)
 }
 
-describe('GET /bootstrap.js', () => {
-  it('should response user info as JavaScript type', async () => {
+describe('GET /bootstrap.js', function () {
+  it('should response user info as JavaScript type', async function () {
     const user = { email: 'dlts@example.com' }
     const cookieToken = jwt.sign(user, 'DashboardSign')
     const cookie = new touge.Cookie({ key: 'token', value: cookieToken })
@@ -29,7 +29,7 @@ describe('GET /bootstrap.js', () => {
     arg.user.should.have.property('password')
   })
 
-  it('should response undefined if unauthenticated', async () => {
+  it('should response undefined if unauthenticated', async function () {
     const response = await axiosist(api).get('/bootstrap.js')
     response.headers['content-type'].should.startWith('application/javascript')
     const arg = getBootstrapArgument(response.data)
@@ -37,7 +37,7 @@ describe('GET /bootstrap.js', () => {
     arg.should.not.have.property('user')
   })
 
-  it('should response undefined if token is invalid', async () => {
+  it('should response undefined if token is invalid', async function () {
     const user = { email: 'dlts@example.com' }
     const cookieToken = jwt.sign(user, 'BadSign')
     const cookie = new touge.Cookie({ key: 'token', value: cookieToken })

--- a/src/dashboard/server/test/controllers/cluster/index.js
+++ b/src/dashboard/server/test/controllers/cluster/index.js
@@ -7,15 +7,15 @@ const userParams = {
   password: User.generateToken('dlts@example.com').toString('hex')
 }
 
-describe('GET /clusters/:clusterId', () => {
-  it('should response cluster config', async () => {
+describe('GET /clusters/:clusterId', function () {
+  it('should response cluster config', async function () {
     const response = await axiosist(api).get('/clusters/Universe', {
       params: userParams
     })
     response.data.should.have.property('restfulapi', 'http://universe')
   })
 
-  it('should response 404 when cluster not exist', async () => {
+  it('should response 404 when cluster not exist', async function () {
     const response = await axiosist(api).get('/clusters/NewCluster', {
       params: userParams
     })

--- a/src/dashboard/server/test/controllers/cluster/job/getJobDetail.js
+++ b/src/dashboard/server/test/controllers/cluster/job/getJobDetail.js
@@ -19,8 +19,8 @@ const getJobStatusParams = new URLSearchParams({
   jobId: 'testjob'
 })
 
-describe('GET /clusters/:clusterId/jobs/:jobId', () => {
-  it('should return job detail', async () => {
+describe('GET /clusters/:clusterId/jobs/:jobId', function () {
+  it('should return job detail', async function () {
     nock('http://universe')
       .get('/GetJobDetail?' + getJobParams)
       .reply(200, {
@@ -35,7 +35,7 @@ describe('GET /clusters/:clusterId/jobs/:jobId', () => {
     response.data.should.have.property('message', 'job detail retrieved')
   })
 
-  it('should return 502 Bad Gateway Error when the job does not exist', async () => {
+  it('should return 502 Bad Gateway Error when the job does not exist', async function () {
     nock('http://universe')
       .get('/GetJobDetail?' + getJobParams)
       .reply(500)
@@ -48,8 +48,8 @@ describe('GET /clusters/:clusterId/jobs/:jobId', () => {
   })
 })
 
-describe('GET /clusters/:clusterId/jobs/:jobId/status', () => {
-  it('[P-01] should return job status', async () => {
+describe('GET /clusters/:clusterId/jobs/:jobId/status', function () {
+  it('[P-01] should return job status', async function () {
     nock('http://universe')
       .get('/GetJobStatus?' + getJobStatusParams)
       .reply(200, {
@@ -65,7 +65,7 @@ describe('GET /clusters/:clusterId/jobs/:jobId/status', () => {
     response.data.should.have.property('status', 'OK')
   })
 
-  it('[N-01] should return 502 Bad Gateway Error when the job does not exist', async () => {
+  it('[N-01] should return 502 Bad Gateway Error when the job does not exist', async function () {
     nock('http://universe')
       .get('/GetJobStatus?' + getJobStatusParams)
       .reply(500)
@@ -77,7 +77,7 @@ describe('GET /clusters/:clusterId/jobs/:jobId/status', () => {
     response.status.should.equal(502)
   })
 
-  it('[N-02] should return 404 Not Found when there is an error message', async () => {
+  it('[N-02] should return 404 Not Found when there is an error message', async function () {
     nock('http://universe')
       .get('/GetJobStatus?' + getJobStatusParams)
       .reply(200, {
@@ -94,8 +94,8 @@ describe('GET /clusters/:clusterId/jobs/:jobId/status', () => {
   })
 })
 
-describe('GET /clusters/:clusterId/jobs/:jobId/commands', () => {
-  it('should return job commands', async () => {
+describe('GET /clusters/:clusterId/jobs/:jobId/commands', function () {
+  it('should return job commands', async function () {
     nock('http://universe')
       .get('/GetCommands?' + getJobParams)
       .reply(200, {
@@ -110,7 +110,7 @@ describe('GET /clusters/:clusterId/jobs/:jobId/commands', () => {
     response.data.should.have.property('commands', 'test job commands')
   })
 
-  it('should return 502 Bad Gateway Error when the job does not exist', async () => {
+  it('should return 502 Bad Gateway Error when the job does not exist', async function () {
     nock('http://universe')
       .get('/GetCommands?' + getJobParams)
       .reply(500)
@@ -123,8 +123,8 @@ describe('GET /clusters/:clusterId/jobs/:jobId/commands', () => {
   })
 })
 
-describe('GET /clusters/:clusterId/jobs/:jobId/endpoints', () => {
-  it('should return job endpoints', async () => {
+describe('GET /clusters/:clusterId/jobs/:jobId/endpoints', function () {
+  it('should return job endpoints', async function () {
     nock('http://universe')
       .get('/endpoints?' + getJobParams)
       .reply(200, {
@@ -139,7 +139,7 @@ describe('GET /clusters/:clusterId/jobs/:jobId/endpoints', () => {
     response.data.should.have.property('endpoints', 'test job endpoints')
   })
 
-  it('should return 502 Bad Gateway Error when the job does not exist', async () => {
+  it('should return 502 Bad Gateway Error when the job does not exist', async function () {
     nock('http://universe')
       .get('/endpoints?' + getJobParams)
       .reply(500)

--- a/src/dashboard/server/test/controllers/cluster/job/getJobLog.js
+++ b/src/dashboard/server/test/controllers/cluster/job/getJobLog.js
@@ -8,8 +8,8 @@ const userParams = {
   token: User.generateToken('dlts@example.com').toString('hex')
 }
 
-describe('GET /clusters/:clusterId/jobs/:jobId/log', () => {
-  it('should return job log', async () => {
+describe('GET /clusters/:clusterId/jobs/:jobId/log', function () {
+  it('should return job log', async function () {
     nock('http://universe')
       .get('/GetJobLog')
       .query({ jobId: 'testjob', userName: 'dlts@example.com' })
@@ -29,7 +29,7 @@ describe('GET /clusters/:clusterId/jobs/:jobId/log', () => {
     })
   })
 
-  it('should return job log with cursor', async () => {
+  it('should return job log with cursor', async function () {
     nock('http://universe')
       .get('/GetJobLog')
       .query({ jobId: 'testjob', cursor: '1234567890', userName: 'dlts@example.com' })
@@ -51,7 +51,7 @@ describe('GET /clusters/:clusterId/jobs/:jobId/log', () => {
     })
   })
 
-  it('should return 404 when there is no (more) log', async () => {
+  it('should return 404 when there is no (more) log', async function () {
     nock('http://universe')
       .get('/GetJobLog')
       .query({ jobId: 'testjob', userName: 'dlts@example.com' })

--- a/src/dashboard/server/test/controllers/cluster/job/postJob.js
+++ b/src/dashboard/server/test/controllers/cluster/job/postJob.js
@@ -29,8 +29,8 @@ const testEndpoints = {
   }]
 }
 
-describe('POST /clusters/:clusterId/jobs/:jobId/commands', () => {
-  it('should return 201 when command is added successfully', async () => {
+describe('POST /clusters/:clusterId/jobs/:jobId/commands', function () {
+  it('should return 201 when command is added successfully', async function () {
     nock('http://universe')
       .get('/AddCommand?' + addCommandParams)
       .reply(200, {
@@ -44,7 +44,7 @@ describe('POST /clusters/:clusterId/jobs/:jobId/commands', () => {
     response.data.should.have.property('message', 'command adding succeeded')
   })
 
-  it('should return 502 Bad Gateway Error if command adding failed', async () => {
+  it('should return 502 Bad Gateway Error if command adding failed', async function () {
     nock('http://universe')
       .get('/AddCommand?' + addCommandParams)
       .reply(500)
@@ -56,8 +56,8 @@ describe('POST /clusters/:clusterId/jobs/:jobId/commands', () => {
   })
 })
 
-describe('POST /clusters/:clusterId/jobs/:jobId/endpoints', () => {
-  it('should return 200 when endpoints are added successfully', async () => {
+describe('POST /clusters/:clusterId/jobs/:jobId/endpoints', function () {
+  it('should return 200 when endpoints are added successfully', async function () {
     nock('http://universe')
       .post('/endpoints?' + addEndpointsParams)
       .reply(200, {
@@ -71,7 +71,7 @@ describe('POST /clusters/:clusterId/jobs/:jobId/endpoints', () => {
     response.data.should.have.property('message', 'endpoints adding succeeded')
   })
 
-  it('should return 502 Bad Gateway Error if endpoints adding failed', async () => {
+  it('should return 502 Bad Gateway Error if endpoints adding failed', async function () {
     nock('http://universe')
       .post('/endpoints?' + addEndpointsParams)
       .reply(500)

--- a/src/dashboard/server/test/controllers/cluster/job/putJobPriority.js
+++ b/src/dashboard/server/test/controllers/cluster/job/putJobPriority.js
@@ -12,8 +12,8 @@ const setPriorityParams = new URLSearchParams({
   userName: userParams.email
 })
 
-describe('PUT /clusters/:clusterId/jobs/:jobId/priority', () => {
-  it('should return OK if priority set successfully', async () => {
+describe('PUT /clusters/:clusterId/jobs/:jobId/priority', function () {
+  it('should return OK if priority set successfully', async function () {
     nock('http://universe')
       .post('/jobs/priorities?' + setPriorityParams, { 'testjob': /[0-9]+/ })
       .reply(200, {
@@ -27,7 +27,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/priority', () => {
     response.data.should.have.property('message', 'priority set successfully')
   })
 
-  it('should return 502 Bad Gateway error if priority setting failed', async () => {
+  it('should return 502 Bad Gateway error if priority setting failed', async function () {
     nock('http://universe')
       .post('/jobs/priorities?' + setPriorityParams, { 'testjob': /[0-9]+/ })
       .reply(500)

--- a/src/dashboard/server/test/controllers/cluster/job/putJobStatus.js
+++ b/src/dashboard/server/test/controllers/cluster/job/putJobStatus.js
@@ -13,8 +13,8 @@ const setStatusParams = new URLSearchParams({
   userName: userParams.email
 })
 
-describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
-  it('[P-01] should return OK if status approved set successfully', async () => {
+describe('PUT /clusters/:clusterId/jobs/:jobId/status', function () {
+  it('[P-01] should return OK if status approved set successfully', async function () {
     nock('http://universe')
       .get('/ApproveJob?' + setStatusParams)
       .reply(200, {
@@ -28,7 +28,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     response.data.should.have.property('message', 'status approved set successfully')
   })
 
-  it('[P-02] should return OK if status killing set successfully', async () => {
+  it('[P-02] should return OK if status killing set successfully', async function () {
     nock('http://universe')
       .get('/KillJob?' + setStatusParams)
       .reply(200, {
@@ -42,7 +42,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     response.data.should.have.property('message', 'status killing set successfully')
   })
 
-  it('[P-03] should return OK if status pausing set successfully', async () => {
+  it('[P-03] should return OK if status pausing set successfully', async function () {
     nock('http://universe')
       .get('/PauseJob?' + setStatusParams)
       .reply(200, {
@@ -57,7 +57,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
   })
 
   // resume job
-  it('[P-04] should return OK if status queued set successfully', async () => {
+  it('[P-04] should return OK if status queued set successfully', async function () {
     nock('http://universe')
       .get('/ResumeJob?' + setStatusParams)
       .reply(200, {
@@ -71,7 +71,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     response.data.should.have.property('message', 'status queued set successfully')
   })
 
-  it('[N-01] should return response status if approved set failed', async () => {
+  it('[N-01] should return response status if approved set failed', async function () {
     nock('http://universe')
       .get('/ApproveJob?' + setStatusParams)
       .reply(500)
@@ -82,7 +82,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     response.status.should.equal(500)
   })
 
-  it('[N-02] should return response status if killing set failed', async () => {
+  it('[N-02] should return response status if killing set failed', async function () {
     nock('http://universe')
       .get('/KillJob?' + setStatusParams)
       .reply(500)
@@ -93,7 +93,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     response.status.should.equal(500)
   })
 
-  it('[N-03] should return response status if pausing set failed', async () => {
+  it('[N-03] should return response status if pausing set failed', async function () {
     nock('http://universe')
       .get('/PauseJob?' + setStatusParams)
       .reply(500)
@@ -104,7 +104,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     response.status.should.equal(500)
   })
 
-  it('[N-04] should return response status if queued set failed', async () => {
+  it('[N-04] should return response status if queued set failed', async function () {
     nock('http://universe')
       .get('/ResumeJob?' + setStatusParams)
       .reply(500)
@@ -115,7 +115,7 @@ describe('PUT /clusters/:clusterId/jobs/:jobId/status', () => {
     response.status.should.equal(500)
   })
 
-  it('[N-05] should return 400 Invalid status when status is invalid', async () => {
+  it('[N-05] should return 400 Invalid status when status is invalid', async function () {
     const response = await axiosist(api).put('/clusters/Universe/jobs/testjob/status',
       { status: 'invalid' }, { params: userParams })
 

--- a/src/dashboard/server/test/controllers/cluster/jobs.post.js
+++ b/src/dashboard/server/test/controllers/cluster/jobs.post.js
@@ -10,8 +10,8 @@ const userParams = {
   password: User.generateToken('dlts@example.com').toString('hex')
 }
 
-describe('POST /clusters/:clusterid/jobs', () => {
-  it('should response returning messages if job POST succeeded', async () => {
+describe('POST /clusters/:clusterid/jobs', function () {
+  it('should response returning messages if job POST succeeded', async function () {
     nock('http://universe')
       .post('/PostJob')
       .reply(200, {
@@ -24,7 +24,7 @@ describe('POST /clusters/:clusterid/jobs', () => {
     response.status.should.equal(200)
     response.data.should.have.property('message', 'job adding succeeded')
   })
-  it('should response returning messages if job POST succeeded even if team is null', async () => {
+  it('should response returning messages if job POST succeeded even if team is null', async function () {
     nock('http://universe')
       .post('/PostJob')
       .reply(200, {
@@ -37,13 +37,13 @@ describe('POST /clusters/:clusterid/jobs', () => {
     response.status.should.equal(200)
     response.data.should.have.property('message', 'job adding succeeded')
   })
-  it('should response 400 Bad Request if job schema is invalid', async () => {
+  it('should response 400 Bad Request if job schema is invalid', async function () {
     const response = await axiosist(api).post('/clusters/Universe/jobs',
       {}, { params: userParams })
     response.status.should.equal(400)
   })
 
-  it('should forcely set userName as current user in the submitted job', async () => {
+  it('should forcely set userName as current user in the submitted job', async function () {
     nock('http://universe')
       .post('/PostJob', _.matches({ userName: 'dlts@example.com' }))
       .reply(200, {

--- a/src/dashboard/server/test/controllers/cluster/jobs.post.js
+++ b/src/dashboard/server/test/controllers/cluster/jobs.post.js
@@ -24,7 +24,7 @@ describe('POST /clusters/:clusterid/jobs', () => {
     response.status.should.equal(200)
     response.data.should.have.property('message', 'job adding succeeded')
   })
-  it('should response returning messages if job POST succeeded', async () => {
+  it('should response returning messages if job POST succeeded even if team is null', async () => {
     nock('http://universe')
       .post('/PostJob')
       .reply(200, {

--- a/src/dashboard/server/test/controllers/cluster/jobs/status.post.js
+++ b/src/dashboard/server/test/controllers/cluster/jobs/status.post.js
@@ -9,8 +9,8 @@ const userParams = {
   password: User.generateToken('dlts@example.com').toString('hex')
 }
 
-describe('POST /clusters/:clusterid/jobs/status', () => {
-  it('should response successful message of each type of status', async () => {
+describe('POST /clusters/:clusterid/jobs/status', function () {
+  it('should response successful message of each type of status', async function () {
     nock('http://universe')
       .get('/ApproveJobs')
       .query({ jobIds: 'approve1,approve2', userName: userParams.email })

--- a/src/dashboard/server/test/controllers/index.js
+++ b/src/dashboard/server/test/controllers/index.js
@@ -2,8 +2,8 @@ const axiosist = require('axiosist')
 
 const api = require('../../api').callback()
 
-describe('GET /', () => {
-  it('should returns version of the API', async () => {
+describe('GET /', function () {
+  it('should returns version of the API', async function () {
     const response = await axiosist(api).get('/')
     response.data.should.be.an.Object()
       .and.have.property('version')

--- a/src/dashboard/server/test/controllers/team/cluster.js
+++ b/src/dashboard/server/test/controllers/team/cluster.js
@@ -14,8 +14,8 @@ const getTeamParams = new URLSearchParams({
   vcName: userParams.teamId
 })
 
-describe('GET /teams/:teamId/clusters/:clusterId', () => {
-  it('[P-01] should return team info', async () => {
+describe('GET /teams/:teamId/clusters/:clusterId', function () {
+  it('[P-01] should return team info', async function () {
     nock('http://Universe')
       .get('/GetVC?' + getTeamParams)
       .reply(200, {
@@ -30,7 +30,7 @@ describe('GET /teams/:teamId/clusters/:clusterId', () => {
     response.data.should.have.property('message', 'test team info')
   })
 
-  it('[N-01] should return 502 Bad Gateway error if team info getting failed', async () => {
+  it('[N-01] should return 502 Bad Gateway error if team info getting failed', async function () {
     nock('http://Universe')
       .get('/GetVC?' + getTeamParams)
       .reply(500)
@@ -42,7 +42,7 @@ describe('GET /teams/:teamId/clusters/:clusterId', () => {
     response.status.should.equal(502)
   })
 
-  it('[N-02] should return 404 Team is not found if returned team info is empty', async () => {
+  it('[N-02] should return 404 Team is not found if returned team info is empty', async function () {
     nock('http://Universe')
       .get('/GetVC?' + getTeamParams)
       .reply(200, null)

--- a/src/dashboard/server/test/controllers/team/jobs.js
+++ b/src/dashboard/server/test/controllers/team/jobs.js
@@ -42,8 +42,8 @@ const testJobs = {
   }
 }
 
-describe('GET /teams/:teamId/jobs', () => {
-  it('[P-01] should return jobs info in the team with user as all', async () => {
+describe('GET /teams/:teamId/jobs', function () {
+  it('[P-01] should return jobs info in the team with user as all', async function () {
     for (let key in clusterConfig) {
       // nock for getJobs()
       nock(clusterConfig[key]['restfulapi'])
@@ -71,7 +71,7 @@ describe('GET /teams/:teamId/jobs', () => {
     response.data.length.should.equal(8)
   })
 
-  it('[P-02] should return jobs info in the team with specific user', async () => {
+  it('[P-02] should return jobs info in the team with specific user', async function () {
     for (let key in clusterConfig) {
       // change the jobOwner in getJobs params
       getJobsParams.set('jobOwner', userParams.email)
@@ -102,7 +102,7 @@ describe('GET /teams/:teamId/jobs', () => {
     response.data.length.should.equal(8)
   })
 
-  it('[N-01] should return empty data if getJobs failed', async () => {
+  it('[N-01] should return empty data if getJobs failed', async function () {
     // change back the jobOwner in getJobs params
     getJobsParams.set('jobOwner', 'all')
 
@@ -128,7 +128,7 @@ describe('GET /teams/:teamId/jobs', () => {
     response.data.should.be.empty()
   })
 
-  it('[N-02] should ignore errors if getJobsPriority failed', async () => {
+  it('[N-02] should ignore errors if getJobsPriority failed', async function () {
     for (let key in clusterConfig) {
       // nock for getJobs()
       nock(clusterConfig[key]['restfulapi'])

--- a/src/dashboard/server/test/controllers/team/template.delete.js
+++ b/src/dashboard/server/test/controllers/team/template.delete.js
@@ -20,8 +20,8 @@ const deleteTemplateParams = new URLSearchParams({
   templateName: userParams.templateName
 })
 
-describe('DELETE /teams/:teamId/templates/:templateName', () => {
-  it('should return 204 if template deleted successfully', async () => {
+describe('DELETE /teams/:teamId/templates/:templateName', function () {
+  it('should return 204 if template deleted successfully', async function () {
     for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .delete('/templates?' + deleteTemplateParams)
@@ -37,7 +37,7 @@ describe('DELETE /teams/:teamId/templates/:templateName', () => {
     response.status.should.equal(204)
   })
 
-  it('should return 502 if template deleting failed', async () => {
+  it('should return 502 if template deleting failed', async function () {
     for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .delete('/templates?' + deleteTemplateParams)

--- a/src/dashboard/server/test/controllers/team/template.js
+++ b/src/dashboard/server/test/controllers/team/template.js
@@ -18,8 +18,8 @@ const getTemplatesParams = new URLSearchParams({
   vcName: userParams.teamId
 })
 
-describe('GET /teams/:teamId/templates', () => {
-  it('should return template info', async () => {
+describe('GET /teams/:teamId/templates', function () {
+  it('should return template info', async function () {
     for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .get('/templates?' + getTemplatesParams)
@@ -37,7 +37,7 @@ describe('GET /teams/:teamId/templates', () => {
     response.data[1].should.have.property('name', 'Targaryen')
   })
 
-  it('response should be empty if templates getting failed', async () => {
+  it('response should be empty if templates getting failed', async function () {
     for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .get('/templates?' + getTemplatesParams)

--- a/src/dashboard/server/test/controllers/team/template.put.js
+++ b/src/dashboard/server/test/controllers/team/template.put.js
@@ -20,8 +20,8 @@ const updateTemplateParams = new URLSearchParams({
   templateName: userParams.templateName
 })
 
-describe('PUT /teams/:teamId/templates/:templateName', () => {
-  it('should return 204 if template updated successfully', async () => {
+describe('PUT /teams/:teamId/templates/:templateName', function () {
+  it('should return 204 if template updated successfully', async function () {
     for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .post('/templates?' + updateTemplateParams)
@@ -38,7 +38,7 @@ describe('PUT /teams/:teamId/templates/:templateName', () => {
     response.status.should.equal(204)
   })
 
-  it('should return 502 if template updating failed', async () => {
+  it('should return 502 if template updating failed', async function () {
     for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .post('/templates?' + updateTemplateParams)

--- a/src/dashboard/server/test/controllers/teams.js
+++ b/src/dashboard/server/test/controllers/teams.js
@@ -36,8 +36,8 @@ const fetchParams = new URLSearchParams({
   userName: 'dlts@example.com'
 })
 
-describe('GET /teams', () => {
-  it('[P-01] should return the teams info of cluster', async () => {
+describe('GET /teams', function () {
+  it('[P-01] should return the teams info of cluster', async function () {
     for (let key in clusterConfig) {
       nock(clusterConfig[key]['restfulapi'])
         .get('/ListVCs?' + fetchParams)
@@ -54,7 +54,7 @@ describe('GET /teams', () => {
     response.data[1].clusters[0].gpus.should.ownProperty('testmodel')
   })
 
-  it('[N-01] should return empty gpus info with incorrect metadata or quota format', async () => {
+  it('[N-01] should return empty gpus info with incorrect metadata or quota format', async function () {
     for (let key in clusterConfig) {
       // team data for the wrong format negative case
       const negTeamData = {
@@ -81,7 +81,7 @@ describe('GET /teams', () => {
     response.data[1].clusters[0].gpus.should.be.empty()
   })
 
-  it('[N-02] response data should be empty when there is a server error', async () => {
+  it('[N-02] response data should be empty when there is a server error', async function () {
     for (let key in clusterConfig) {
       // team data for the empty data case
       const negTeamData = {

--- a/src/dashboard/server/test/controllers/user.js
+++ b/src/dashboard/server/test/controllers/user.js
@@ -7,8 +7,8 @@ const userParams = {
   password: User.generateToken('dlts@example.com').toString('hex')
 }
 
-describe('GET /user', () => {
-  it('should response user password', async () => {
+describe('GET /user', function () {
+  it('should response user password', async function () {
     const response = await axiosist(api).get('/user', {
       params: userParams
     })

--- a/src/dashboard/yarn.lock
+++ b/src/dashboard/yarn.lock
@@ -4768,6 +4768,14 @@ eslint-plugin-jsx-a11y@6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
+eslint-plugin-mocha@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-6.3.0.tgz#72bfd06a5c4323e17e30ef41cd726030e8cdb8fd"
+  integrity sha512-Cd2roo8caAyG21oKaaNTj7cqeYRWW1I2B5SfpKRp0Ip1gkfwoR1Ow0IGlPWnNjzywdF4n+kHL8/9vM6zCJUxdg==
+  dependencies:
+    eslint-utils "^2.0.0"
+    ramda "^0.27.0"
+
 eslint-plugin-node@^9.1.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-9.2.0.tgz#b1911f111002d366c5954a6d96d3cd5bf2a3036a"
@@ -4830,6 +4838,13 @@ eslint-utils@^1.4.2, eslint-utils@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
   integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
@@ -10178,6 +10193,11 @@ raf@^3.4.0, raf@^3.4.1:
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
   dependencies:
     performance-now "^2.1.0"
+
+ramda@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.0.tgz#915dc29865c0800bf3f69b8fd6c279898b59de43"
+  integrity sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"


### PR DESCRIPTION
This will prevent debug codes like `describe.only` or `it.only` (skip all other cases except this one) to commit to codebase by mistake, which could pass the CI but cause code coverage decreased a lot.

Since mocha [discourage](https://mochajs.org/#arrow-functions) using arrow functions to write unit test cases and it causes lint failed, changed all of them into traditional function declarations.