### PR TITLE
Skip default VC if there is data in VC table

### DIFF
--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -363,6 +363,10 @@ class DataHandler(object):
         quota, metadata, res_quota, res_meta = vc_value_str(config, ratio_dict)
         if quota == "":
             return
+
+        if len(self.ListVCs()) != 0:
+            return
+
         for vc, vc_res_quota in res_quota.items():
             self.AddVC(vc, quota, metadata, vc_res_quota, res_meta)
 


### PR DESCRIPTION
We should not add default vc every time restful is restarted.

@YinYangOfDao It's better to separate VC quota assignment in a separate step outside MySQLDataHandler.

Currently all services that calls MySQLDataHandler will try to create the default vc.