### PR TITLE
change how network metric scrapped

### DIFF
--- a/src/ClusterBootstrap/services/monitor/grafana-config/job-status-dashboard.json
+++ b/src/ClusterBootstrap/services/monitor/grafana-config/job-status-dashboard.json
@@ -382,7 +382,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "task_net_in_byte{job_name=\"$job_name\"}",
+              "expr": "sum(rate(task_net_in_byte{job_name=\"$job_name\"}[5m])) by (instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -390,7 +390,7 @@
               "refId": "A"
             },
             {
-              "expr": "task_net_out_byte{job_name=\"$job_name\"}",
+              "expr": "sum(rate(task_net_out_byte{job_name=\"$job_name\"}[5m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{'{{'}}instance{{'}}'}} Outbound",

--- a/src/docker-images/job-exporter/src/collector.py
+++ b/src/docker-images/job-exporter/src/collector.py
@@ -38,79 +38,91 @@ import ps
 
 logger = logging.getLogger(__name__)
 
-
 ##### collector will generate following metrics
 # Document about these metrics is in `` # TODO
 
-iteration_counter = Counter("collector_iteration_count", "total number of iteration",
-        ["name"])
+iteration_counter = Counter("collector_iteration_count",
+                            "total number of iteration", ["name"])
+
 
 def gen_docker_daemon_counter():
     return GaugeMetricFamily("docker_daemon_count",
-            "count of docker daemon",
-            labels=["error"])
+                             "count of docker daemon",
+                             labels=["error"])
+
 
 def gen_gpu_util_gauge():
     return GaugeMetricFamily("nvidiasmi_utilization_gpu",
-            "gpu core utilization of card",
-            labels=["minor_number"])
+                             "gpu core utilization of card",
+                             labels=["minor_number"])
+
 
 def gen_gpu_mem_util_gauge():
     return GaugeMetricFamily("nvidiasmi_utilization_memory",
-            "gpu memory utilization of card",
-            labels=["minor_number"])
+                             "gpu memory utilization of card",
+                             labels=["minor_number"])
+
 
 def gen_gpu_temperature_gauge():
     return GaugeMetricFamily("nvidiasmi_temperature",
-            "gpu temperature of card",
-            labels=["minor_number"])
+                             "gpu temperature of card",
+                             labels=["minor_number"])
+
 
 def gen_gpu_ecc_counter():
     return GaugeMetricFamily("nvidiasmi_ecc_error_count",
-            "count of nvidia ecc error",
-            labels=["minor_number", "type"])
+                             "count of nvidia ecc error",
+                             labels=["minor_number", "type"])
+
 
 def gen_gpu_retired_page_count():
     return GaugeMetricFamily("nvidiasmi_retired_page_count",
-            "count of nvidia ecc retired page",
-            labels=["minor_number", "type"])
+                             "count of nvidia ecc retired page",
+                             labels=["minor_number", "type"])
+
 
 def gen_gpu_memory_leak_counter():
     return GaugeMetricFamily("nvidiasmi_memory_leak_count",
-            "count of nvidia memory leak",
-            labels=["minor_number"])
+                             "count of nvidia memory leak",
+                             labels=["minor_number"])
+
 
 def gen_zombie_process_counter():
     return GaugeMetricFamily("zombie_process_count",
-            "count of zombie process",
-            labels=["command"])
+                             "count of zombie process",
+                             labels=["command"])
+
 
 def gen_gpu_used_by_external_process_counter():
     return GaugeMetricFamily("gpu_used_by_external_process_count",
-            "count of gpu used by external process",
-            labels=["minor_number", "pid"])
+                             "count of gpu used by external process",
+                             labels=["minor_number", "pid"])
+
 
 def gen_gpu_used_by_zombie_container_counter():
     return GaugeMetricFamily("gpu_used_by_zombie_container_count",
-            "count of gpu used by zombie container",
-            labels=["minor_number", "container_id"])
+                             "count of gpu used by zombie container",
+                             labels=["minor_number", "container_id"])
+
 
 def gen_process_mem_usage_gauge():
-    return GaugeMetricFamily("process_mem_usage_byte",
-            "memory usage of process, to save space in prometheus, we only expose those who consume more than 500Mb of memory",
-            labels=["pid", "cmd"])
+    return GaugeMetricFamily(
+        "process_mem_usage_byte",
+        "memory usage of process, to save space in prometheus, we only expose those who consume more than 500Mb of memory",
+        labels=["pid", "cmd"])
+
 
 class ResourceGauges(object):
     def __init__(self):
         self.task_labels = [
-                "username",
-                "job_name",
-                "role_name",
-                "task_index",
-                "pod_name",
-                "user_email",
-                "vc_name",
-                ]
+            "username",
+            "job_name",
+            "role_name",
+            "task_index",
+            "pod_name",
+            "user_email",
+            "vc_name",
+        ]
         self.service_labels = ["name"]
 
         self.task_labels_gpu = copy.deepcopy(self.task_labels)
@@ -118,40 +130,38 @@ class ResourceGauges(object):
 
         self.gauges = {}
 
-        self.add_task_and_service_gauge("{0}_cpu_percent",
-                "how much percent of cpu this {0} used")
+        self.add_task_and_service_gauge(
+            "{0}_cpu_percent", "how much percent of cpu this {0} used")
         self.add_task_and_service_gauge("{0}_mem_usage_byte",
-                "how much memory this {0} used")
-        self.add_task_and_service_gauge("{0}_mem_usage_percent",
-                "how much percent of memory this {0} used")
-        self.add_task_and_service_gauge("{0}_mem_limit_byte",
-                "how much memory this {0} are constrained to")
-        self.add_task_and_service_gauge("{0}_net_in_byte",
-                "how much network inbound this task used")
-        self.add_task_and_service_gauge("{0}_net_out_byte",
-                "how much network outbound this {0} used")
-        self.add_task_and_service_gauge("{0}_block_in_byte",
-                "how much block inbound this {0} used")
-        self.add_task_and_service_gauge("{0}_block_out_byte",
-                "how much block outbound this {0} used")
+                                        "how much memory this {0} used")
+        self.add_task_and_service_gauge(
+            "{0}_mem_usage_percent",
+            "how much percent of memory this {0} used")
+        self.add_task_and_service_gauge(
+            "{0}_mem_limit_byte",
+            "how much memory this {0} are constrained to")
+        self.add_task_and_service_gauge(
+            "{0}_net_in_byte", "how much network inbound this task used")
+        self.add_task_and_service_gauge(
+            "{0}_net_out_byte", "how much network outbound this {0} used")
+        self.add_task_and_service_gauge(
+            "{0}_block_in_byte", "how much block inbound this {0} used")
+        self.add_task_and_service_gauge(
+            "{0}_block_out_byte", "how much block outbound this {0} used")
 
         self.add_gauge("task_gpu_percent",
-                "how much percent of gpu core this task used",
-                self.task_labels_gpu)
+                       "how much percent of gpu core this task used",
+                       self.task_labels_gpu)
         self.add_gauge("task_gpu_mem_percent",
-                "how much percent of gpu memory this task used",
-                self.task_labels_gpu)
+                       "how much percent of gpu memory this task used",
+                       self.task_labels_gpu)
 
     def add_task_and_service_gauge(self, name_tmpl, desc_tmpl):
-        self.add_gauge(
-                name_tmpl.format("task"),
-                desc_tmpl.format("task"),
-                self.task_labels)
+        self.add_gauge(name_tmpl.format("task"), desc_tmpl.format("task"),
+                       self.task_labels)
 
-        self.add_gauge(
-                name_tmpl.format("service"),
-                desc_tmpl.format("service"),
-                self.service_labels)
+        self.add_gauge(name_tmpl.format("service"),
+                       desc_tmpl.format("service"), self.service_labels)
 
     def add_gauge(self, name, desc, labels):
         self.gauges[name] = GaugeMetricFamily(name, desc, labels=labels)
@@ -159,8 +169,8 @@ class ResourceGauges(object):
     def add_value(self, metric_name, labels, val):
         if metric_name not in self.gauges:
             raise RuntimeError(
-                    "{0} not found in gauges, all gauge names is {1}".format(
-                        metric_name, ",".join(self.gauges.keys())))
+                "{0} not found in gauges, all gauge names is {1}".format(
+                    metric_name, ",".join(self.gauges.keys())))
 
         gauge = self.gauges[metric_name]
 
@@ -174,14 +184,14 @@ class ResourceGauges(object):
                 label_array[index] = v
             except ValueError:
                 logger.warning("unknown label %s with value %s for metrics %s",
-                        k, v, metric_name)
+                               k, v, metric_name)
                 continue
 
         for i, label_val in enumerate(label_array):
             if label_val is None:
                 logger.error(
-                        "not provided %s as label value for metric %s, ignore this metric",
-                        gauge._labelnames[i], metric_name)
+                    "not provided %s as label value for metric %s, ignore this metric",
+                    gauge._labelnames[i], metric_name)
                 return
 
         gauge.add_metric(label_array, val)
@@ -189,7 +199,9 @@ class ResourceGauges(object):
     def as_array(self):
         return self.gauges.values()
 
+
 #####
+
 
 class AtomicRef(object):
     """ a thread safe way to store and get object,
@@ -229,9 +241,11 @@ class Collector(object):
         histogram_key = "collector_%s_iteration_lantecy_seconds" % self.name
         histogram_desc = "latency for execute one interation of %s collector (seconds)" % \
                 self.name
-        self.collector_histogram = Histogram(histogram_key, histogram_desc,
-                buckets=(.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0,
-                    7.5, 10.0, 12.5, 15.0, 17.5, 20.0, float("inf")))
+        self.collector_histogram = Histogram(
+            histogram_key,
+            histogram_desc,
+            buckets=(.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5,
+                     5.0, 7.5, 10.0, 12.5, 15.0, 17.5, 20.0, float("inf")))
 
         logger.debug("init %s with sleep_time %d", self.name, self.sleep_time)
 
@@ -242,12 +256,15 @@ class Collector(object):
             with self.collector_histogram.time():
                 self.iteration_counter.labels(name=self.name).inc()
                 try:
-                    self.atomic_ref.set(self.collect_impl(), datetime.datetime.now())
+                    self.atomic_ref.set(self.collect_impl(),
+                                        datetime.datetime.now())
                 except Exception as e:
-                    logger.exception("%s collector get an exception", self.name)
+                    logger.exception("%s collector get an exception",
+                                     self.name)
 
-                logger.debug("finished collect metrcis from %s, will sleep for %s",
-                        self.name, self.sleep_time)
+                logger.debug(
+                    "finished collect metrcis from %s, will sleep for %s",
+                    self.name, self.sleep_time)
 
             time.sleep(self.sleep_time)
 
@@ -257,23 +274,25 @@ class Collector(object):
         pass
 
 
-def instantiate_collector(name, sleep_time, decay_time, collector_class, *args):
+def instantiate_collector(name, sleep_time, decay_time, collector_class,
+                          *args):
     """ test cases helper fn to instantiate a collector """
     atomic_ref = AtomicRef(decay_time)
-    return atomic_ref, collector_class(name, sleep_time, atomic_ref, iteration_counter, *args)
+    return atomic_ref, collector_class(name, sleep_time, atomic_ref,
+                                       iteration_counter, *args)
 
 
 def make_collector(name, sleep_time, decay_time, collector_class, *args):
     """ other module should use this fn to init a collector, this fn start a thread
     to run the collector and return an atomic_ref so outside world can get metrics
     collected by this collector """
-    atomic_ref, instance = instantiate_collector(name, sleep_time, decay_time, collector_class, *args)
+    atomic_ref, instance = instantiate_collector(name, sleep_time, decay_time,
+                                                 collector_class, *args)
 
-    t = threading.Thread(
-            target=instance.collect,
-            name=name,
-            args=(),
-            daemon=True)
+    t = threading.Thread(target=instance.collect,
+                         name=name,
+                         args=(),
+                         daemon=True)
 
     t.start()
 
@@ -281,12 +300,13 @@ def make_collector(name, sleep_time, decay_time, collector_class, *args):
 
 
 class DockerCollector(Collector):
-    cmd_histogram = Histogram("cmd_docker_active_latency_seconds",
-            "Command call latency for checking docker daemon activeness (seconds)",
-            buckets=(1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0,
-                float("inf")))
+    cmd_histogram = Histogram(
+        "cmd_docker_active_latency_seconds",
+        "Command call latency for checking docker daemon activeness (seconds)",
+        buckets=(1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0,
+                 1024.0, float("inf")))
 
-    cmd_timeout = 1 # 99th latency is 0.01s
+    cmd_timeout = 1  # 99th latency is 0.01s
 
     def collect_impl(self):
         cmd = ["docker", "info"]
@@ -294,13 +314,13 @@ class DockerCollector(Collector):
 
         try:
             out = utils.exec_cmd(cmd,
-                    histogram=DockerCollector.cmd_histogram,
-                    timeout=DockerCollector.cmd_timeout)
+                                 histogram=DockerCollector.cmd_histogram,
+                                 timeout=DockerCollector.cmd_timeout)
 
             logger.debug("output for docker info is %s", out)
         except subprocess.CalledProcessError as e:
             logger.exception("command '%s' return with error (code %d): %s",
-                    cmd, e.returncode, e.output)
+                             cmd, e.returncode, e.output)
             error = str(e)
         except subprocess.TimeoutExpired as e:
             logger.warning("check docker active timeout")
@@ -316,15 +336,17 @@ class DockerCollector(Collector):
 
 class GpuCollector(Collector):
     cmd_histogram = Histogram("cmd_nvidia_smi_latency_seconds",
-            "Command call latency for nvidia-smi (seconds)",
-            buckets=(1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0,
-                float("inf")))
+                              "Command call latency for nvidia-smi (seconds)",
+                              buckets=(1.0, 2.0, 4.0, 8.0, 16.0, 32.0,
+                                       64.0, 128.0, 256.0, 512.0, 1024.0,
+                                       float("inf")))
 
-    cmd_timeout = 60 # 99th latency is 0.97s
+    cmd_timeout = 60  # 99th latency is 0.97s
 
     def __init__(self, name, sleep_time, atomic_ref, iteration_counter,
-            gpu_info_ref, zombie_info_ref, mem_leak_thrashold):
-        Collector.__init__(self, name, sleep_time, atomic_ref, iteration_counter)
+                 gpu_info_ref, zombie_info_ref, mem_leak_thrashold):
+        Collector.__init__(self, name, sleep_time, atomic_ref,
+                           iteration_counter)
         self.gpu_info_ref = gpu_info_ref
         self.zombie_info_ref = zombie_info_ref
         self.mem_leak_thrashold = mem_leak_thrashold
@@ -349,7 +371,8 @@ class GpuCollector(Collector):
                         return True, parts[1]
                 elif "/kubepods/" in line:
                     parts = line.split("/kubepods/")
-                    if len(parts) == 2 and re.match(u"pod[0-9a-f-]+", parts[1]):
+                    if len(parts) == 2 and re.match(u"pod[0-9a-f-]+",
+                                                    parts[1]):
                         return True, parts[1]
                 else:
                     logger.info("unknown format in pid cgroup %s", line)
@@ -357,7 +380,8 @@ class GpuCollector(Collector):
         return False, ""
 
     @staticmethod
-    def convert_to_metrics(gpu_info, zombie_info, pid_to_cid_fn, mem_leak_thrashold):
+    def convert_to_metrics(gpu_info, zombie_info, pid_to_cid_fn,
+                           mem_leak_thrashold):
         """ This fn used to convert gpu_info & zombie_info into metrics, used to make
         it easier to do unit test """
         core_utils = gen_gpu_util_gauge()
@@ -369,31 +393,38 @@ class GpuCollector(Collector):
         external_process = gen_gpu_used_by_external_process_counter()
         zombie_container = gen_gpu_used_by_zombie_container_counter()
 
-        pids_use_gpu = {} # key is gpu minor, value is an array of pid
+        pids_use_gpu = {}  # key is gpu minor, value is an array of pid
 
         for minor, info in gpu_info.items():
             if not minor.isdigit():
-                continue # ignore UUID
+                continue  # ignore UUID
 
             core_utils.add_metric([minor], info.gpu_util)
             mem_utils.add_metric([minor], info.gpu_mem_util)
             if info.temperature is not None:
                 gpu_temp.add_metric([minor], info.temperature)
-            ecc_errors.add_metric([minor, "volatile_single"], info.ecc_errors.volatile_single)
-            ecc_errors.add_metric([minor, "volatile_double"], info.ecc_errors.volatile_double)
-            ecc_errors.add_metric([minor, "aggregated_single"], info.ecc_errors.aggregated_single)
-            ecc_errors.add_metric([minor, "aggregated_double"], info.ecc_errors.aggregated_double)
+            ecc_errors.add_metric([minor, "volatile_single"],
+                                  info.ecc_errors.volatile_single)
+            ecc_errors.add_metric([minor, "volatile_double"],
+                                  info.ecc_errors.volatile_double)
+            ecc_errors.add_metric([minor, "aggregated_single"],
+                                  info.ecc_errors.aggregated_single)
+            ecc_errors.add_metric([minor, "aggregated_double"],
+                                  info.ecc_errors.aggregated_double)
 
-            retired_page.add_metric([minor, "single"], info.ecc_errors.single_retirement)
-            retired_page.add_metric([minor, "double"], info.ecc_errors.double_retirement)
+            retired_page.add_metric([minor, "single"],
+                                    info.ecc_errors.single_retirement)
+            retired_page.add_metric([minor, "double"],
+                                    info.ecc_errors.double_retirement)
             if info.gpu_mem_util > mem_leak_thrashold and len(info.pids) == 0:
                 # we found memory leak less than 20M can be mitigated automatically
                 mem_leak.add_metric([minor], 1)
 
             if len(info.pids) > 0:
-                pids_use_gpu[minor]= info.pids
+                pids_use_gpu[minor] = info.pids
 
-        logger.debug("pids_use_gpu is %s, zombie_info is %s", pids_use_gpu, zombie_info)
+        logger.debug("pids_use_gpu is %s, zombie_info is %s", pids_use_gpu,
+                     zombie_info)
         if len(pids_use_gpu) > 0:
             if zombie_info is None:
                 zombie_info = []
@@ -401,26 +432,32 @@ class GpuCollector(Collector):
             for minor, pids in pids_use_gpu.items():
                 for pid in pids:
                     found, z_id = pid_to_cid_fn(pid)
-                    logger.debug("pid %s has found %s, z_id %s", pid, found, z_id)
+                    logger.debug("pid %s has found %s, z_id %s", pid, found,
+                                 z_id)
                     if found:
                         # NOTE: zombie_info is a set of short docker container id, but
                         # z_id is full id.
                         for zombie_id in zombie_info:
                             if z_id.startswith(zombie_id):
                                 # found corresponding container
-                                zombie_container.add_metric([minor, zombie_id], 1)
+                                zombie_container.add_metric([minor, zombie_id],
+                                                            1)
                     else:
                         external_process.add_metric([minor, str(pid)], 1)
-            if len(zombie_container.samples) > 0 or len(external_process.samples) > 0:
-                logger.warning("found gpu used by external %s, zombie container %s",
-                        external_process, zombie_container)
+            if len(zombie_container.samples) > 0 or len(
+                    external_process.samples) > 0:
+                logger.warning(
+                    "found gpu used by external %s, zombie container %s",
+                    external_process, zombie_container)
 
-        return [core_utils, mem_utils, ecc_errors, mem_leak,
-            external_process, zombie_container, gpu_temp, retired_page]
+        return [
+            core_utils, mem_utils, ecc_errors, mem_leak, external_process,
+            zombie_container, gpu_temp, retired_page
+        ]
 
     def collect_impl(self):
         gpu_info = nvidia.nvidia_smi(GpuCollector.cmd_histogram,
-                GpuCollector.cmd_timeout)
+                                     GpuCollector.cmd_timeout)
 
         logger.debug("get gpu_info %s", gpu_info)
 
@@ -429,72 +466,82 @@ class GpuCollector(Collector):
         zombie_info = self.zombie_info_ref.get(now)
 
         if gpu_info is not None:
-            return GpuCollector.convert_to_metrics(gpu_info, zombie_info,
-                    GpuCollector.get_container_id, self.mem_leak_thrashold)
+            return GpuCollector.convert_to_metrics(
+                gpu_info, zombie_info, GpuCollector.get_container_id,
+                self.mem_leak_thrashold)
         return None
 
 
 class ContainerCollector(Collector):
-    stats_histogram = Histogram("cmd_docker_stats_latency_seconds",
-            "Command call latency for docker stats (seconds)")
+    stats_histogram = Histogram(
+        "cmd_docker_stats_latency_seconds",
+        "Command call latency for docker stats (seconds)",
+        buckets=(1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0,
+                 1024.0, float("inf")))
     stats_timeout = 20
     # 99th latency may larger than 10s,
     # Because prometheus's largest bucket for recording histogram is 10s,
     # we can not get value higher than 10s.
 
-    inspect_histogram = Histogram("cmd_docker_inspect_latency_seconds",
-            "Command call latency for docker inspect (seconds)")
-    inspect_timeout = 1 # 99th latency is 0.042s
+    inspect_histogram = Histogram(
+        "cmd_docker_inspect_latency_seconds",
+        "Command call latency for docker inspect (seconds)")
+    inspect_timeout = 1  # 99th latency is 0.042s
 
     iftop_histogram = Histogram("cmd_iftop_latency_seconds",
-            "Command call latency for iftop (seconds)")
-    iftop_timeout = 10 # 99th latency is 7.4s
+                                "Command call latency for iftop (seconds)")
+    iftop_timeout = 10  # 99th latency is 7.4s
 
     lsof_histogram = Histogram("cmd_lsof_latency_seconds",
-            "Command call latency for lsof (seconds)")
-    lsof_timeout = 2 # 99th latency is 0.5s
+                               "Command call latency for lsof (seconds)")
+    lsof_timeout = 2  # 99th latency is 0.5s
 
-    pai_services = list(map(lambda s: "k8s_" + s, [
-        "rest-server",
-        "pylon",
-        "webportal",
-        "grafana",
-        "prometheus",
-        "alertmanager",
-        "watchdog",
-        "end-to-end-test",
-        "yarn-frameworklauncher",
-        "hadoop-jobhistory-service",
-        "hadoop-name-node",
-        "hadoop-node-manager",
-        "hadoop-resource-manager",
-        "hadoop-data-node",
-        "zookeeper",
-        "node-exporter",
-        "job-exporter",
-        "yarn-exporter",
-        "nvidia-drivers",
-        "docker-cleaner",
+    pai_services = list(
+        map(
+            lambda s: "k8s_" + s,
+            [
+                "rest-server",
+                "pylon",
+                "webportal",
+                "grafana",
+                "prometheus",
+                "alertmanager",
+                "watchdog",
+                "end-to-end-test",
+                "yarn-frameworklauncher",
+                "hadoop-jobhistory-service",
+                "hadoop-name-node",
+                "hadoop-node-manager",
+                "hadoop-resource-manager",
+                "hadoop-data-node",
+                "zookeeper",
+                "node-exporter",
+                "job-exporter",
+                "yarn-exporter",
+                "nvidia-drivers",
+                "docker-cleaner",
 
-        # Below are DLTS services
-        "nginx",
-        "restfulapi",
-        "weave",
-        "weave-npc",
-        "nvidia-device-plugin-ctr",
-        "mysql",
-        "jobmanager",
-        ]))
+                # Below are DLTS services
+                "nginx",
+                "restfulapi",
+                "weave",
+                "weave-npc",
+                "nvidia-device-plugin-ctr",
+                "mysql",
+                "jobmanager",
+            ]))
 
-    def __init__(self, name, sleep_time, atomic_ref, iteration_counter, gpu_info_ref,
-            stats_info_ref, interface):
-        Collector.__init__(self, name, sleep_time, atomic_ref, iteration_counter)
+    def __init__(self, name, sleep_time, atomic_ref, iteration_counter,
+                 gpu_info_ref, stats_info_ref, interface):
+        Collector.__init__(self, name, sleep_time, atomic_ref,
+                           iteration_counter)
         self.gpu_info_ref = gpu_info_ref
         self.stats_info_ref = stats_info_ref
 
         self.network_interface = network.try_to_get_right_interface(interface)
-        logger.info("found %s as potential network interface to listen network traffic",
-                self.network_interface)
+        logger.info(
+            "found %s as potential network interface to listen network traffic",
+            self.network_interface)
 
         # k8s will prepend "k8s_" to pod name. There will also be a container name
         # prepend with "k8s_POD_" which is a docker container used to construct
@@ -503,11 +550,11 @@ class ContainerCollector(Collector):
 
     def collect_impl(self):
         all_conns = network.iftop(self.network_interface,
-                ContainerCollector.iftop_histogram,
-                ContainerCollector.iftop_timeout)
+                                  ContainerCollector.iftop_histogram,
+                                  ContainerCollector.iftop_timeout)
 
         stats_obj = docker_stats.stats(ContainerCollector.stats_histogram,
-                ContainerCollector.stats_timeout)
+                                       ContainerCollector.stats_timeout)
 
         now = datetime.datetime.now()
         gpu_infos = self.gpu_info_ref.get(now)
@@ -550,11 +597,12 @@ class ContainerCollector(Collector):
                     if gpu_infos.get(id) is not None:
                         gpu_ids.append(gpu_infos[id].minor)
                     else:
-                        logger.warning("gpu uuid %s can not be found in map %s",
-                                id, gpu_infos)
+                        logger.warning(
+                            "gpu uuid %s can not be found in map %s", id,
+                            gpu_infos)
                 else:
-                    logger.warning("unknown gpu id %s, gpu_infos is %s",
-                            id, gpu_infos)
+                    logger.warning("unknown gpu id %s, gpu_infos is %s", id,
+                                   gpu_infos)
 
         return gpu_ids, result_labels
 
@@ -569,47 +617,45 @@ class ContainerCollector(Collector):
         # TODO speed this up, since this is O(n^2)
         for service_name in cls.pai_services:
             if container_name.startswith(service_name):
-                return service_name[4:] # remove "k8s_" prefix
+                return service_name[4:]  # remove "k8s_" prefix
 
         return None
 
-    def process_one_container(self, container_id, stats, gpu_infos, all_conns, gauges):
+    def process_one_container(self, container_id, stats, gpu_infos, all_conns,
+                              gauges):
         container_name = utils.walk_json_field_safe(stats, "name")
-        pai_service_name = ContainerCollector.infer_service_name(container_name)
+        pai_service_name = ContainerCollector.infer_service_name(
+            container_name)
 
-        inspect_info = docker_inspect.inspect(container_id,
-                ContainerCollector.inspect_histogram,
-                ContainerCollector.inspect_timeout)
+        inspect_info = docker_inspect.inspect(
+            container_id, ContainerCollector.inspect_histogram,
+            ContainerCollector.inspect_timeout)
 
         pid = inspect_info.pid
         job_name = inspect_info.job_name
 
         logger.debug("%s has inspect result %s, service_name %s",
-                container_name, inspect_info, pai_service_name)
+                     container_name, inspect_info, pai_service_name)
 
         if job_name is None and pai_service_name is None:
             logger.debug("%s is ignored", container_name)
-            return # other container, maybe kubelet or api-server
+            return  # other container, maybe kubelet or api-server
 
-        # get network consumption, since all our services/jobs running in host
-        # network, and network statistic from docker is not specific to that
-        # container. We have to get network statistic by ourselves.
-        lsof_result = network.lsof(pid,
-                ContainerCollector.lsof_histogram,
-                ContainerCollector.lsof_timeout)
-
-        net_in, net_out = network.get_container_network_metrics(all_conns,
-                lsof_result)
-        if logger.isEnabledFor(logging.DEBUG):
-            debug_info = utils.exec_cmd(
-                    "ps -o cmd fp {0} | tail -n 1".format(pid),
-                    shell=True)
-
-            logger.debug("pid %s with cmd `%s` has lsof result %s, in %d, out %d",
-                    pid, debug_info.strip(), lsof_result, net_in, net_out)
+        # get network consumption, if container is host network, we will treat
+        # node network consumption as container consumption. If not, use data
+        # from docker state.
+        # This will result network consumption of service using host network
+        # equals to node network consumption.
+        is_host_network = inspect_info.is_host_network
+        if is_host_network:
+            net_in, net_out = network.get_network_consumption(
+                self.network_interface)
+        else:
+            net_in, net_out = network.get_non_host_network_consumption(pid)
 
         if pai_service_name is None:
-            gpu_ids, container_labels = ContainerCollector.parse_from_labels(inspect_info, gpu_infos)
+            gpu_ids, container_labels = ContainerCollector.parse_from_labels(
+                inspect_info, gpu_infos)
 
             if gpu_infos:
                 for id in gpu_ids:
@@ -620,29 +666,40 @@ class ContainerCollector(Collector):
                     labels = copy.deepcopy(container_labels)
                     labels["minor_number"] = id
 
-                    gauges.add_value("task_gpu_percent",
-                            labels, nvidia_gpu_status.gpu_util)
-                    gauges.add_value("task_gpu_mem_percent",
-                            labels, nvidia_gpu_status.gpu_mem_util)
+                    gauges.add_value("task_gpu_percent", labels,
+                                     nvidia_gpu_status.gpu_util)
+                    gauges.add_value("task_gpu_mem_percent", labels,
+                                     nvidia_gpu_status.gpu_mem_util)
 
-            gauges.add_value("task_cpu_percent", container_labels, stats["CPUPerc"])
-            gauges.add_value("task_mem_usage_byte", container_labels, stats["MemUsage_Limit"]["usage"])
-            gauges.add_value("task_mem_limit_byte", container_labels, stats["MemUsage_Limit"]["limit"])
+            gauges.add_value("task_cpu_percent", container_labels,
+                             stats["CPUPerc"])
+            gauges.add_value("task_mem_usage_byte", container_labels,
+                             stats["MemUsage_Limit"]["usage"])
+            gauges.add_value("task_mem_limit_byte", container_labels,
+                             stats["MemUsage_Limit"]["limit"])
             gauges.add_value("task_net_in_byte", container_labels, net_in)
             gauges.add_value("task_net_out_byte", container_labels, net_out)
-            gauges.add_value("task_block_in_byte", container_labels, stats["BlockIO"]["in"])
-            gauges.add_value("task_block_out_byte", container_labels, stats["BlockIO"]["out"])
-            gauges.add_value("task_mem_usage_percent", container_labels, stats["MemPerc"])
+            gauges.add_value("task_block_in_byte", container_labels,
+                             stats["BlockIO"]["in"])
+            gauges.add_value("task_block_out_byte", container_labels,
+                             stats["BlockIO"]["out"])
+            gauges.add_value("task_mem_usage_percent", container_labels,
+                             stats["MemPerc"])
         else:
             labels = {"name": pai_service_name}
             gauges.add_value("service_cpu_percent", labels, stats["CPUPerc"])
-            gauges.add_value("service_mem_usage_byte", labels, stats["MemUsage_Limit"]["usage"])
-            gauges.add_value("service_mem_limit_byte", labels, stats["MemUsage_Limit"]["limit"])
-            gauges.add_value("service_mem_usage_percent", labels, stats["MemPerc"])
+            gauges.add_value("service_mem_usage_byte", labels,
+                             stats["MemUsage_Limit"]["usage"])
+            gauges.add_value("service_mem_limit_byte", labels,
+                             stats["MemUsage_Limit"]["limit"])
+            gauges.add_value("service_mem_usage_percent", labels,
+                             stats["MemPerc"])
             gauges.add_value("service_net_in_byte", labels, net_in)
             gauges.add_value("service_net_out_byte", labels, net_out)
-            gauges.add_value("service_block_in_byte", labels, stats["BlockIO"]["in"])
-            gauges.add_value("service_block_out_byte", labels, stats["BlockIO"]["out"])
+            gauges.add_value("service_block_in_byte", labels,
+                             stats["BlockIO"]["in"])
+            gauges.add_value("service_block_out_byte", labels,
+                             stats["BlockIO"]["out"])
 
     def collect_container_metrics(self, stats_obj, gpu_infos, all_conns):
         if stats_obj is None:
@@ -653,29 +710,33 @@ class ContainerCollector(Collector):
 
         for container_id, stats in stats_obj.items():
             try:
-                self.process_one_container(container_id, stats, gpu_infos, all_conns, gauges)
+                self.process_one_container(container_id, stats, gpu_infos,
+                                           all_conns, gauges)
             except Exception:
-                logger.exception("error when trying to process container %s with name %s",
-                        container_id, utils.walk_json_field_safe(stats, "name"))
+                logger.exception(
+                    "error when trying to process container %s with name %s",
+                    container_id, utils.walk_json_field_safe(stats, "name"))
 
         return gauges.as_array()
 
 
 class ZombieCollector(Collector):
-    logs_histogram = Histogram("cmd_docker_logs_latency_seconds",
-            "Command call latency for docker logs (seconds)",
-            buckets=(1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0,
-                float("inf")))
-    logs_timeout = 1 # 99th latency is 0.04s
+    logs_histogram = Histogram(
+        "cmd_docker_logs_latency_seconds",
+        "Command call latency for docker logs (seconds)",
+        buckets=(1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0,
+                 1024.0, float("inf")))
+    logs_timeout = 1  # 99th latency is 0.04s
 
-    zombie_container_count = Gauge("zombie_container_count",
-            "number of zombie container found for this node",
-            ["type"])
+    zombie_container_count = Gauge(
+        "zombie_container_count",
+        "number of zombie container found for this node", ["type"])
 
     class ZombieRecorder(object):
         def __init__(self, type):
             self.type = type
-            self.zombies = {} # key is container id, value is enter zombie time
+            self.zombies = {
+            }  # key is container id, value is enter zombie time
 
             # When we first meet zombie container, we only record time of that meet,
             # we wait extra decay_time to report it as zombie. Because at the time
@@ -701,14 +762,17 @@ class ZombieCollector(Collector):
                     logger.debug("new zombie %s", current)
                     self.zombies[current] = now
 
-            ZombieCollector.zombie_container_count.labels(self.type).set(len(result))
+            ZombieCollector.zombie_container_count.labels(self.type).set(
+                len(result))
             return result
 
         def __len__(self):
             return len(self.zombies)
 
-    def __init__(self, name, sleep_time, atomic_ref, iteration_counter, stats_info_ref, zombie_ids_ref):
-        Collector.__init__(self, name, sleep_time, atomic_ref, iteration_counter)
+    def __init__(self, name, sleep_time, atomic_ref, iteration_counter,
+                 stats_info_ref, zombie_ids_ref):
+        Collector.__init__(self, name, sleep_time, atomic_ref,
+                           iteration_counter)
         self.stats_info_ref = stats_info_ref
         self.zombie_ids_ref = zombie_ids_ref
 
@@ -717,7 +781,8 @@ class ZombieCollector(Collector):
 
         self.yarn_pattern = u"container_\w{3}_[0-9]{13}_[0-9]{4}_[0-9]{2}_[0-9]{6}"
         self.yarn_container_reg = re.compile(u"^" + self.yarn_pattern + "$")
-        self.job_container_reg = re.compile(u"^.+(" + self.yarn_pattern + u")$")
+        self.job_container_reg = re.compile(u"^.+(" + self.yarn_pattern +
+                                            u")$")
 
     def update_zombie_count_type1(self, exited_containers, now):
         """ this fn will generate zombie container count for the first type,
@@ -746,7 +811,7 @@ class ZombieCollector(Collector):
                 value = match.groups()[0]
                 job_containers[name] = (value, id)
             else:
-                pass # ignore
+                pass  # ignore
 
         for job_name, val in job_containers.items():
             yarn_name, job_id = val
@@ -758,14 +823,17 @@ class ZombieCollector(Collector):
     def docker_logs(self, container_id, tail="all"):
         try:
             return utils.exec_cmd(
-                    ["docker", "logs", "--tail", str(tail), str(container_id)],
-                    histogram=ZombieCollector.logs_histogram,
-                    stderr=subprocess.STDOUT, # also capture stderr output
-                    timeout=ZombieCollector.logs_timeout)
+                ["docker", "logs", "--tail",
+                 str(tail),
+                 str(container_id)],
+                histogram=ZombieCollector.logs_histogram,
+                stderr=subprocess.STDOUT,  # also capture stderr output
+                timeout=ZombieCollector.logs_timeout)
         except subprocess.TimeoutExpired as e:
             logger.warning("docker log timeout")
         except subprocess.CalledProcessError as e:
-            logger.warning("docker logs returns %d, output %s", e.returncode, e.output)
+            logger.warning("docker logs returns %d, output %s", e.returncode,
+                           e.output)
         except Exception:
             logger.exception("exec docker logs error")
 
@@ -805,21 +873,25 @@ class ZombieCollector(Collector):
 
 class ProcessCollector(Collector):
     cmd_histogram = Histogram("cmd_ps_latency_seconds",
-            "Command call latency for ps (seconds)")
+                              "Command call latency for ps (seconds)",
+                              buckets=(1.0, 2.0, 4.0, 8.0, 16.0, 32.0,
+                                       64.0, 128.0, 256.0, 512.0, 1024.0,
+                                       float("inf")))
 
-    cmd_timeout = 10 # TODO 99th latency is xxx
+    cmd_timeout = 10  # TODO 99th latency is xxx
 
     def __init__(self, name, sleep_time, atomic_ref, iteration_counter):
-        Collector.__init__(self, name, sleep_time, atomic_ref, iteration_counter)
+        Collector.__init__(self, name, sleep_time, atomic_ref,
+                           iteration_counter)
 
     def collect_impl(self):
         process_info = ps.get_process_info(ProcessCollector.cmd_histogram,
-                ProcessCollector.cmd_timeout)
+                                           ProcessCollector.cmd_timeout)
 
         if len(process_info) > 0:
             zombie_metrics = gen_zombie_process_counter()
             process_mem_metrics = gen_process_mem_usage_gauge()
-            zombie_count = collections.defaultdict(lambda : 0)
+            zombie_count = collections.defaultdict(lambda: 0)
 
             for info in process_info:
                 if info.state == "D":
@@ -827,13 +899,14 @@ class ProcessCollector(Collector):
                         # override command name to make alert rule easier
                         zombie_count["nvidia-smi"] += 1
                     else:
-                        cmd = info.cmd.split()[0] # remove args
+                        cmd = info.cmd.split()[0]  # remove args
                         zombie_count[cmd] += 1
 
                 if info.rss > 500 * 1024 * 1024:
                     # only record large memory consumption to save space in prometheus
-                    cmd = info.cmd.split()[0] # remove args
-                    process_mem_metrics.add_metric([str(info.pid), cmd], info.rss)
+                    cmd = info.cmd.split()[0]  # remove args
+                    process_mem_metrics.add_metric([str(info.pid), cmd],
+                                                   info.rss)
 
             for cmd, count in zombie_count.items():
                 zombie_metrics.add_metric([cmd], count)

--- a/src/docker-images/job-exporter/src/docker_inspect.py
+++ b/src/docker-images/job-exporter/src/docker_inspect.py
@@ -25,19 +25,21 @@ import utils
 
 logger = logging.getLogger(__name__)
 
+
 class InspectResult(object):
     """ Represents a task meta data, parsed from docker inspect result """
     def __init__(self, username, job_name, role_name, task_index, pod_name,
-            gpu_ids, pid, email, vc_name):
+                 gpu_ids, pid, email, vc_name, is_host_network):
         self.username = username
         self.job_name = job_name
         self.role_name = role_name
         self.task_index = task_index
         self.pod_name = pod_name
-        self.gpu_ids = gpu_ids # comma seperated str, str may be minor_number or UUID
+        self.gpu_ids = gpu_ids  # comma seperated str, str may be minor_number or UUID
         self.pid = pid
-        self.email = email # None on no value
-        self.vc_name = vc_name # None on no value
+        self.email = email  # None on no value
+        self.vc_name = vc_name  # None on no value
+        self.is_host_network = is_host_network  # boolean
 
     def __repr__(self):
         return "username %s, job_name %s, role_name %s, task_index %s, pod_name %s, gpu_ids %s, pid %s, email %s, vc %s" % \
@@ -54,12 +56,16 @@ class InspectResult(object):
                 self.gpu_ids == o.gpu_ids and \
                 self.pid == o.pid and \
                 self.email == o.email and \
-                self.vc_name == o.vc_name
+                self.vc_name == o.vc_name and \
+                self.is_host_network == o.is_host_network
 
 
-keys = {"PAI_JOB_NAME", "PAI_USER_NAME", "PAI_CURRENT_TASK_ROLE_NAME", "GPU_ID",
-        "PAI_TASK_INDEX", "DLWS_JOB_ID", "DLWS_USER_NAME", "POD_NAME",
-        "DLWS_USER_EMAIL", "DLWS_VC_NAME", "DLWS_ROLE_NAME", "DLWS_ROLE_IDX"}
+keys = {
+    "PAI_JOB_NAME", "PAI_USER_NAME", "PAI_CURRENT_TASK_ROLE_NAME", "GPU_ID",
+    "PAI_TASK_INDEX", "DLTS_JOB_ID", "DLTS_USER_NAME", "POD_NAME",
+    "DLTS_USER_EMAIL", "DLTS_VC_NAME", "DLTS_ROLE_NAME", "DLTS_ROLE_IDX",
+    "FC_TASK_INDEX", "DLTS_HOST_NETWORK"
+}
 
 
 def parse_docker_inspect(inspect_output):
@@ -89,27 +95,29 @@ def parse_docker_inspect(inspect_output):
     pid = utils.walk_json_field_safe(obj, 0, "State", "Pid")
 
     return InspectResult(
-            m.get("PAI_USER_NAME") or m.get("DLWS_USER_NAME"),
-            m.get("PAI_JOB_NAME") or m.get("DLWS_JOB_ID"),
-            m.get("PAI_CURRENT_TASK_ROLE_NAME") or m.get("DLWS_ROLE_NAME"),
-            m.get("PAI_TASK_INDEX") or m.get("DLWS_ROLE_IDX"),
-            m.get("POD_NAME") or m.get("PAI_JOB_NAME"),
-            m.get("GPU_ID"),
-            pid,
-            m.get("DLWS_USER_EMAIL"),
-            m.get("DLWS_VC_NAME"),
-            )
+        m.get("PAI_USER_NAME") or m.get("DLTS_USER_NAME"),
+        m.get("PAI_JOB_NAME") or m.get("DLTS_JOB_ID"),
+        m.get("PAI_CURRENT_TASK_ROLE_NAME") or m.get("DLTS_ROLE_NAME"),
+        m.get("PAI_TASK_INDEX") or m.get("DLTS_ROLE_IDX")
+        or m.get("FC_TASK_INDEX"),
+        m.get("POD_NAME") or m.get("PAI_JOB_NAME"),
+        m.get("GPU_ID"),
+        pid,
+        m.get("DLTS_USER_EMAIL"),
+        m.get("DLTS_VC_NAME"),
+        m.get("DLTS_HOST_NETWORK") == "enable",
+    )
+
 
 def inspect(container_id, histogram, timeout):
     try:
-        result = utils.exec_cmd(
-                ["docker", "inspect", container_id],
-                histogram=histogram,
-                timeout=timeout)
+        result = utils.exec_cmd(["docker", "inspect", container_id],
+                                histogram=histogram,
+                                timeout=timeout)
         return parse_docker_inspect(result)
     except subprocess.CalledProcessError as e:
-        logger.exception("command '%s' return with error (code %d): %s",
-                e.cmd, e.returncode, e.output)
+        logger.exception("command '%s' return with error (code %d): %s", e.cmd,
+                         e.returncode, e.output)
     except subprocess.TimeoutExpired:
         logger.warning("docker inspect timeout")
     except Exception:

--- a/src/docker-images/job-exporter/test/test_collector.py
+++ b/src/docker-images/job-exporter/test/test_collector.py
@@ -34,81 +34,83 @@ from collector import GpuCollector
 
 logger = logging.getLogger(__name__)
 
+
 class TestContainerCollector(base.TestBase):
     """
     Test ContainerCollector in collecotr.py
     """
-
     def test_parse_from_labels(self):
         inspect_result = docker_inspect.InspectResult(
-                "openmindstudio",
-                "trialslot_nnimain_d65bc5ac",
-                "tuner",
-                "0",
-                "this_is_pod_name_val",
-                "0,1,",
-                12345,
-                "dixu@example.com",
-                "platform",
-                )
+            "openmindstudio",
+            "trialslot_nnimain_d65bc5ac",
+            "tuner",
+            "0",
+            "this_is_pod_name_val",
+            "0,1,",
+            12345,
+            "dixu@example.com",
+            "platform",
+            False,
+        )
 
-        gpu_ids, labels = ContainerCollector.parse_from_labels(inspect_result, None)
+        gpu_ids, labels = ContainerCollector.parse_from_labels(
+            inspect_result, None)
         self.assertEqual(["0", "1"], gpu_ids)
 
         target_labels = {
-                "username": "openmindstudio",
-                "job_name": "trialslot_nnimain_d65bc5ac",
-                "role_name": "tuner",
-                "task_index": "0",
-                "pod_name": "this_is_pod_name_val",
-                "user_email": "dixu@example.com",
-                "vc_name": "platform",
-                }
+            "username": "openmindstudio",
+            "job_name": "trialslot_nnimain_d65bc5ac",
+            "role_name": "tuner",
+            "task_index": "0",
+            "pod_name": "this_is_pod_name_val",
+            "user_email": "dixu@example.com",
+            "vc_name": "platform",
+        }
 
         self.assertEqual(target_labels, labels)
 
     def test_infer_service_name(self):
-        self.assertIsNone(ContainerCollector.infer_service_name(
-            "k8s_POD_alertmanager-7884c59f78-66r86_default_0a32e30a-f6ae-11e8"))
+        self.assertIsNone(
+            ContainerCollector.infer_service_name(
+                "k8s_POD_alertmanager-7884c59f78-66r86_default_0a32e30a-f6ae-11e8"
+            ))
 
         self.assertEqual(
-                "alertmanager",
-                ContainerCollector.infer_service_name(
-                    "k8s_alertmanager_alertmanager-7884c59f78-66r86_default_0a32e30a-f6ae-11e8-a62d-000d3ab25bb6_2"))
+            "alertmanager",
+            ContainerCollector.infer_service_name(
+                "k8s_alertmanager_alertmanager-7884c59f78-66r86_default_0a32e30a-f6ae-11e8-a62d-000d3ab25bb6_2"
+            ))
 
-        self.assertIsNone(ContainerCollector.infer_service_name(
-            "k8s_kube-scheduler_kube-scheduler-10.151.40.4_kube-system_f1164d931979939cf0601155df9c748a_6"))
+        self.assertIsNone(
+            ContainerCollector.infer_service_name(
+                "k8s_kube-scheduler_kube-scheduler-10.151.40.4_kube-system_f1164d931979939cf0601155df9c748a_6"
+            ))
 
 
 class TestDockerCollector(base.TestBase):
     """
     Test DockerCollector in collector.py
     """
-
     def assert_metrics(self, metrics):
         self.assertEqual(1, len(metrics))
         self.assertEqual(1, len(metrics[0].samples))
         sample = metrics[0].samples[0]
-        self.assertEqual(1, len(sample[1])) # label keys
-        self.assertEqual(1, sample[2]) # sample value
+        self.assertEqual(1, len(sample[1]))  # label keys
+        self.assertEqual(1, sample[2])  # sample value
 
     def test_impl(self):
-        _, c = collector.instantiate_collector(
-                "test_docker_collector1",
-                0.5,
-                datetime.timedelta(seconds=1),
-                collector.DockerCollector)
+        _, c = collector.instantiate_collector("test_docker_collector1", 0.5,
+                                               datetime.timedelta(seconds=1),
+                                               collector.DockerCollector)
 
         self.assert_metrics(c.collect_impl())
 
     def test_base_collector(self):
         """ actually setup DockerCollector thread, and test, since this is multi-thread
         test case, maybe sensitive to the system load """
-        ref = collector.make_collector(
-                "test_docker_collector2",
-                0.5,
-                datetime.timedelta(seconds=10),
-                collector.DockerCollector)
+        ref = collector.make_collector("test_docker_collector2", 0.5,
+                                       datetime.timedelta(seconds=10),
+                                       collector.DockerCollector)
 
         metrics = None
         for i in range(20):
@@ -131,12 +133,9 @@ class TestZombieCollector(base.TestBase):
 
         decay_time = datetime.timedelta(seconds=1)
         _, self.collector = collector.instantiate_collector(
-                "test_zombie_collector" + t,
-                0.5,
-                decay_time,
-                collector.ZombieCollector,
-                collector.AtomicRef(decay_time),
-                collector.AtomicRef(decay_time))
+            "test_zombie_collector" + t, 0.5, decay_time,
+            collector.ZombieCollector, collector.AtomicRef(decay_time),
+            collector.AtomicRef(decay_time))
 
     def test_update_zombie_count_type1(self):
         start = datetime.datetime.now()
@@ -145,28 +144,32 @@ class TestZombieCollector(base.TestBase):
 
         type1_recorder = self.collector.type1_zombies
 
-        self.assertEqual(set(),
-                self.collector.update_zombie_count_type1({"a", "b"}, start))
+        self.assertEqual(
+            set(), self.collector.update_zombie_count_type1({"a", "b"}, start))
         self.assertEqual(2, len(type1_recorder))
 
-        self.assertEqual(set(),
-                self.collector.update_zombie_count_type1({"a", "b"},
-                    start + type1_recorder.decay_time - one_sec))
+        self.assertEqual(
+            set(),
+            self.collector.update_zombie_count_type1(
+                {"a", "b"}, start + type1_recorder.decay_time - one_sec))
         self.assertEqual(2, len(type1_recorder))
 
         self.assertEqual({"a", "b"},
-                self.collector.update_zombie_count_type1({"a", "b"},
-                    start + type1_recorder.decay_time + one_sec))
+                         self.collector.update_zombie_count_type1(
+                             {"a", "b"},
+                             start + type1_recorder.decay_time + one_sec))
         self.assertEqual(2, len(type1_recorder))
 
         self.assertEqual({"a"},
-                self.collector.update_zombie_count_type1({"a"},
-                    start + type1_recorder.decay_time + 2 *one_sec))
+                         self.collector.update_zombie_count_type1(
+                             {"a"},
+                             start + type1_recorder.decay_time + 2 * one_sec))
         self.assertEqual(1, len(type1_recorder))
 
-        self.assertEqual(set(),
-                self.collector.update_zombie_count_type1({},
-                    start + type1_recorder.decay_time + 3 * one_sec))
+        self.assertEqual(
+            set(),
+            self.collector.update_zombie_count_type1(
+                {}, start + type1_recorder.decay_time + 3 * one_sec))
         self.assertEqual(0, len(type1_recorder))
 
     def test_update_zombie_count_type2(self):
@@ -174,58 +177,73 @@ class TestZombieCollector(base.TestBase):
 
         one_sec = datetime.timedelta(seconds=1)
 
-        stats = {"43ffe701d883":
-                    {"name": "core-caffe2_resnet50_20181012040921.586-container_e03_1539312078880_0780_01_000002", "id": "43ffe701d883"},
-                "8de2f53e64cb":
-                {"name": "container_e03_1539312078880_0780_01_000002", "id": "8de2f53e64cb"}}
+        stats = {
+            "43ffe701d883": {
+                "name":
+                "core-caffe2_resnet50_20181012040921.586-container_e03_1539312078880_0780_01_000002",
+                "id": "43ffe701d883"
+            },
+            "8de2f53e64cb": {
+                "name": "container_e03_1539312078880_0780_01_000002",
+                "id": "8de2f53e64cb"
+            }
+        }
 
         type2_recorder = self.collector.type2_zombies
 
-        self.assertEqual(set(),
-                self.collector.update_zombie_count_type2(stats, start))
+        self.assertEqual(
+            set(), self.collector.update_zombie_count_type2(stats, start))
 
         stats.pop("8de2f53e64cb")
 
-        self.assertEqual(set(),
-                self.collector.update_zombie_count_type2(stats, start + one_sec))
+        self.assertEqual(
+            set(),
+            self.collector.update_zombie_count_type2(stats, start + one_sec))
 
-        self.assertEqual(set(),
-                self.collector.update_zombie_count_type2(stats,
-                    start + type2_recorder.decay_time))
+        self.assertEqual(
+            set(),
+            self.collector.update_zombie_count_type2(
+                stats, start + type2_recorder.decay_time))
 
         self.assertEqual({"43ffe701d883"},
-                self.collector.update_zombie_count_type2(stats,
-                    start + type2_recorder.decay_time + 2 * one_sec))
+                         self.collector.update_zombie_count_type2(
+                             stats,
+                             start + type2_recorder.decay_time + 2 * one_sec))
 
         stats.pop("43ffe701d883")
 
-        self.assertEqual(set(),
-                self.collector.update_zombie_count_type2(stats,
-                    start + type2_recorder.decay_time + 3 * one_sec))
+        self.assertEqual(
+            set(),
+            self.collector.update_zombie_count_type2(
+                stats, start + type2_recorder.decay_time + 3 * one_sec))
+
 
 class TestGpuCollector(base.TestBase):
     """
     Test GpuCollector in collecotr.py
     """
-
     def make_pid_to_cid_fn(self, mapping):
         def fn(pid):
             if pid in mapping:
                 return True, mapping[pid]
             return False, ""
+
         return fn
 
     def test_convert_to_metrics(self):
         # sample may not ordered, and can not assertEqual directly, so tear them apart
-        gpu_info = nvidia.construct_gpu_info(
-                [nvidia.NvidiaGpuStatus(20, 21, [22, 33, 44], nvidia.EccError(), "0", "GPU-uuid0", 37.0)])
+        gpu_info = nvidia.construct_gpu_info([
+            nvidia.NvidiaGpuStatus(20, 21, [22, 33, 44], nvidia.EccError(),
+                                   "0", "GPU-uuid0", 37.0)
+        ])
 
         zombie_info = {"abc", "def"}
 
-        pid_to_cid_mapping = {33: "def", 22: "ghi"} # only 33 is zombie
+        pid_to_cid_mapping = {33: "def", 22: "ghi"}  # only 33 is zombie
 
-        metrics = GpuCollector.convert_to_metrics(gpu_info, zombie_info,
-                self.make_pid_to_cid_fn(pid_to_cid_mapping), 20 * 1024)
+        metrics = GpuCollector.convert_to_metrics(
+            gpu_info, zombie_info, self.make_pid_to_cid_fn(pid_to_cid_mapping),
+            20 * 1024)
 
         core_utils, mem_utils, ecc_errors, mem_leak, external_process, zombie_container, gpu_temp, gpu_retired = metrics
 
@@ -247,11 +265,13 @@ class TestGpuCollector(base.TestBase):
         target_mem_leak = collector.gen_gpu_memory_leak_counter()
         self.assertEqual(target_mem_leak, mem_leak)
 
-        target_external_process = collector.gen_gpu_used_by_external_process_counter()
+        target_external_process = collector.gen_gpu_used_by_external_process_counter(
+        )
         target_external_process.add_metric(["0", "44"], 1)
         self.assertEqual(target_external_process, external_process)
 
-        target_zombie_container = collector.gen_gpu_used_by_zombie_container_counter()
+        target_zombie_container = collector.gen_gpu_used_by_zombie_container_counter(
+        )
         target_zombie_container.add_metric(["0", "def"], 1)
         self.assertEqual(target_zombie_container, zombie_container)
 
@@ -261,10 +281,17 @@ class TestGpuCollector(base.TestBase):
 
         # test minor 1
         gpu_info = nvidia.construct_gpu_info([
-            nvidia.NvidiaGpuStatus(30, 31, [55, 123], nvidia.EccError(volatile_single=2, volatile_double=3, aggregated_single=4, aggregated_double=5), "1", "GPU-uuid1", 24.0)])
+            nvidia.NvidiaGpuStatus(
+                30, 31, [55, 123],
+                nvidia.EccError(volatile_single=2,
+                                volatile_double=3,
+                                aggregated_single=4,
+                                aggregated_double=5), "1", "GPU-uuid1", 24.0)
+        ])
 
-        metrics = GpuCollector.convert_to_metrics(gpu_info, zombie_info,
-                self.make_pid_to_cid_fn(pid_to_cid_mapping), 20 * 1024)
+        metrics = GpuCollector.convert_to_metrics(
+            gpu_info, zombie_info, self.make_pid_to_cid_fn(pid_to_cid_mapping),
+            20 * 1024)
 
         core_utils, mem_utils, ecc_errors, mem_leak, external_process, zombie_container, gpu_temp, gpu_retired = metrics
 
@@ -286,12 +313,14 @@ class TestGpuCollector(base.TestBase):
         target_mem_leak = collector.gen_gpu_memory_leak_counter()
         self.assertEqual(target_mem_leak, mem_leak)
 
-        target_external_process = collector.gen_gpu_used_by_external_process_counter()
+        target_external_process = collector.gen_gpu_used_by_external_process_counter(
+        )
         target_external_process.add_metric(["1", "55"], 1)
         target_external_process.add_metric(["1", "123"], 1)
         self.assertEqual(target_external_process, external_process)
 
-        target_zombie_container = collector.gen_gpu_used_by_zombie_container_counter()
+        target_zombie_container = collector.gen_gpu_used_by_zombie_container_counter(
+        )
         self.assertEqual(target_zombie_container, zombie_container)
 
         target_gpu_temp = collector.gen_gpu_temperature_gauge()
@@ -300,10 +329,13 @@ class TestGpuCollector(base.TestBase):
 
         # test minor 2
         gpu_info = nvidia.construct_gpu_info([
-            nvidia.NvidiaGpuStatus(40, 20 * 1024 * 1024, [], nvidia.EccError(), "2", "GPU-uuid2", 30.0)])
+            nvidia.NvidiaGpuStatus(40, 20 * 1024 * 1024, [], nvidia.EccError(),
+                                   "2", "GPU-uuid2", 30.0)
+        ])
 
-        metrics = GpuCollector.convert_to_metrics(gpu_info, zombie_info,
-                self.make_pid_to_cid_fn(pid_to_cid_mapping), 20 * 1024 * 1024)
+        metrics = GpuCollector.convert_to_metrics(
+            gpu_info, zombie_info, self.make_pid_to_cid_fn(pid_to_cid_mapping),
+            20 * 1024 * 1024)
 
         core_utils, mem_utils, ecc_errors, mem_leak, external_process, zombie_container, gpu_temp, gpu_retired = metrics
 
@@ -325,10 +357,12 @@ class TestGpuCollector(base.TestBase):
         target_mem_leak = collector.gen_gpu_memory_leak_counter()
         self.assertEqual(target_mem_leak, mem_leak)
 
-        target_external_process = collector.gen_gpu_used_by_external_process_counter()
+        target_external_process = collector.gen_gpu_used_by_external_process_counter(
+        )
         self.assertEqual(target_external_process, external_process)
 
-        target_zombie_container = collector.gen_gpu_used_by_zombie_container_counter()
+        target_zombie_container = collector.gen_gpu_used_by_zombie_container_counter(
+        )
         self.assertEqual(target_zombie_container, zombie_container)
 
         target_gpu_temp = collector.gen_gpu_temperature_gauge()
@@ -337,10 +371,13 @@ class TestGpuCollector(base.TestBase):
 
         # test memory leak
         gpu_info = nvidia.construct_gpu_info([
-            nvidia.NvidiaGpuStatus(40, 20 * 1024 * 1024 + 1, [], nvidia.EccError(), "3", "GPU-uuid3", 30.0)])
+            nvidia.NvidiaGpuStatus(40, 20 * 1024 * 1024 + 1, [],
+                                   nvidia.EccError(), "3", "GPU-uuid3", 30.0)
+        ])
 
-        metrics = GpuCollector.convert_to_metrics(gpu_info, zombie_info,
-                self.make_pid_to_cid_fn(pid_to_cid_mapping), 20 * 1024)
+        metrics = GpuCollector.convert_to_metrics(
+            gpu_info, zombie_info, self.make_pid_to_cid_fn(pid_to_cid_mapping),
+            20 * 1024)
 
         core_utils, mem_utils, ecc_errors, mem_leak, external_process, zombie_container, gpu_temp, gpu_retired = metrics
 
@@ -350,59 +387,76 @@ class TestGpuCollector(base.TestBase):
 
     def test_convert_to_metrics_with_no_zombie_info_BUGFIX(self):
         gpu_info = nvidia.construct_gpu_info([
-            nvidia.NvidiaGpuStatus(20, 21, [22, 33, 44], nvidia.EccError(), "0", "GPU-uuid0", 40.0)])
+            nvidia.NvidiaGpuStatus(20, 21, [22, 33, 44], nvidia.EccError(),
+                                   "0", "GPU-uuid0", 40.0)
+        ])
 
         # zombie_info is empty should also have external process metric
         zombie_info = []
 
-        pid_to_cid_mapping = {33: "def", 22: "ghi"} # only 44 is external process
+        pid_to_cid_mapping = {
+            33: "def",
+            22: "ghi"
+        }  # only 44 is external process
 
-        metrics = GpuCollector.convert_to_metrics(gpu_info, zombie_info,
-                self.make_pid_to_cid_fn(pid_to_cid_mapping), 20 * 1024)
+        metrics = GpuCollector.convert_to_metrics(
+            gpu_info, zombie_info, self.make_pid_to_cid_fn(pid_to_cid_mapping),
+            20 * 1024)
 
         core_utils, mem_utils, ecc_errors, mem_leak, external_process, zombie_container, gpu_temp, gpu_retired = metrics
 
         self.assertEqual(0, len(zombie_container.samples))
         self.assertEqual(1, len(external_process.samples))
-        self.assertEqual("0", external_process.samples[0].labels["minor_number"])
+        self.assertEqual("0",
+                         external_process.samples[0].labels["minor_number"])
         self.assertEqual("44", external_process.samples[0].labels["pid"])
 
         # zombie_info is None should also have external process metric
         zombie_info = None
 
-        metrics = GpuCollector.convert_to_metrics(gpu_info, zombie_info,
-                self.make_pid_to_cid_fn(pid_to_cid_mapping), 20 * 1024)
+        metrics = GpuCollector.convert_to_metrics(
+            gpu_info, zombie_info, self.make_pid_to_cid_fn(pid_to_cid_mapping),
+            20 * 1024)
 
         core_utils, mem_utils, ecc_errors, mem_leak, external_process, zombie_container, gpu_temp, gpu_retired = metrics
 
         self.assertEqual(0, len(zombie_container.samples))
         self.assertEqual(1, len(external_process.samples))
-        self.assertEqual("0", external_process.samples[0].labels["minor_number"])
+        self.assertEqual("0",
+                         external_process.samples[0].labels["minor_number"])
         self.assertEqual("44", external_process.samples[0].labels["pid"])
 
     def test_convert_to_metrics_with_real_id_BUGFIX(self):
         gpu_info = nvidia.construct_gpu_info([
-            nvidia.NvidiaGpuStatus(20, 21, [22], nvidia.EccError(), "0", "GPU-uuid0", 50.0)])
+            nvidia.NvidiaGpuStatus(20, 21, [22], nvidia.EccError(), "0",
+                                   "GPU-uuid0", 50.0)
+        ])
 
         # zombie_info is empty should also have external process metric
         zombie_info = {"ce5de12d6275"}
 
-        pid_to_cid_mapping = {22: "ce5de12d6275dc05c9ec5b7f58484f075f4775d8f54f6a4be3dc1439344df356"}
+        pid_to_cid_mapping = {
+            22:
+            "ce5de12d6275dc05c9ec5b7f58484f075f4775d8f54f6a4be3dc1439344df356"
+        }
 
-        metrics = GpuCollector.convert_to_metrics(gpu_info, zombie_info,
-                self.make_pid_to_cid_fn(pid_to_cid_mapping), 20 * 1024)
+        metrics = GpuCollector.convert_to_metrics(
+            gpu_info, zombie_info, self.make_pid_to_cid_fn(pid_to_cid_mapping),
+            20 * 1024)
 
         core_utils, mem_utils, ecc_errors, mem_leak, external_process, zombie_container, gpu_temp, gpu_retired = metrics
 
         self.assertEqual(1, len(zombie_container.samples))
-        self.assertEqual("0", zombie_container.samples[0].labels["minor_number"])
-        self.assertEqual("ce5de12d6275", zombie_container.samples[0].labels["container_id"])
+        self.assertEqual("0",
+                         zombie_container.samples[0].labels["minor_number"])
+        self.assertEqual("ce5de12d6275",
+                         zombie_container.samples[0].labels["container_id"])
+
 
 class TestAtomicRef(base.TestBase):
     """
     Test AtomicRef in collecotr.py
     """
-
     def test_expiration(self):
         ref = collector.AtomicRef(datetime.timedelta(seconds=10))
 

--- a/src/docker-images/job-exporter/test/test_docker_inspect.py
+++ b/src/docker-images/job-exporter/test/test_docker_inspect.py
@@ -25,11 +25,11 @@ sys.path.append(os.path.abspath("../src/"))
 
 from docker_inspect import parse_docker_inspect, InspectResult
 
+
 class TestDockerInspect(base.TestBase):
     """
     Test docker_inspect.py
     """
-
     def test_parse_docker_inspect(self):
         sample_path = "data/docker_inspect_sample.json"
         with open(sample_path, "r") as f:
@@ -37,16 +37,17 @@ class TestDockerInspect(base.TestBase):
 
         inspect_info = parse_docker_inspect(docker_inspect)
         target_inspect_info = InspectResult(
-                "openmindstudio",
-                "trialslot_nnimain_d65bc5ac",
-                "tuner",
-                "0",
-                "trialslot_nnimain_d65bc5ac",
-                "0,1,",
-                95539,
-                None,
-                None,
-                )
+            "openmindstudio",
+            "trialslot_nnimain_d65bc5ac",
+            "tuner",
+            "0",
+            "trialslot_nnimain_d65bc5ac",
+            "0,1,",
+            95539,
+            None,
+            None,
+            False,
+        )
 
         self.assertEqual(target_inspect_info, inspect_info)
 
@@ -57,16 +58,17 @@ class TestDockerInspect(base.TestBase):
 
         inspect_info = parse_docker_inspect(docker_inspect)
         target_inspect_info = InspectResult(
-                "core",
-                "core~tensorflowcifar10",
-                "worker",
-                "0",
-                "core~tensorflowcifar10",
-                "GPU-dc0671b0-61a4-443e-f456-f8fa6359b788",
-                23774,
-                None,
-                None,
-                )
+            "core",
+            "core~tensorflowcifar10",
+            "worker",
+            "0",
+            "core~tensorflowcifar10",
+            "GPU-dc0671b0-61a4-443e-f456-f8fa6359b788",
+            23774,
+            None,
+            None,
+            False,
+        )
         self.assertEqual(target_inspect_info, inspect_info)
 
     def test_parse_docker_inspect_BUGFIX(self):
@@ -76,16 +78,17 @@ class TestDockerInspect(base.TestBase):
 
         inspect_info = parse_docker_inspect(docker_inspect)
         target_inspect_info = InspectResult(
-                "sokoya",
-                "sokoya~train-exp_offrl_sc_discard_0231-10th-beta07-lrfixed_13e9bf5_gCYv",
-                "train",
-                "0",
-                "sokoya~train-exp_offrl_sc_discard_0231-10th-beta07-lrfixed_13e9bf5_gCYv",
-                "3,2,1,0",
-                30332,
-                None,
-                None,
-                )
+            "sokoya",
+            "sokoya~train-exp_offrl_sc_discard_0231-10th-beta07-lrfixed_13e9bf5_gCYv",
+            "train",
+            "0",
+            "sokoya~train-exp_offrl_sc_discard_0231-10th-beta07-lrfixed_13e9bf5_gCYv",
+            "3,2,1,0",
+            30332,
+            None,
+            None,
+            False,
+        )
         self.assertEqual(target_inspect_info, inspect_info)
 
     def test_adapt_dlts_jobs(self):
@@ -95,17 +98,19 @@ class TestDockerInspect(base.TestBase):
 
         inspect_info = parse_docker_inspect(docker_inspect)
         target_inspect_info = InspectResult(
-                "dixu",
-                "0c435eee-d31f-43d5-a1b3-442845fa1d0c",
-                None,
-                None,
-                "0c435eee-d31f-43d5-a1b3-442845fa1d0c",
-                "GPU-7c583998-b3ff-a885-8979-2d32d334cde4",
-                3533,
-                "dixu@example.com",
-                "platform",
-                )
+            "dixu",
+            "0c435eee-d31f-43d5-a1b3-442845fa1d0c",
+            None,
+            None,
+            "0c435eee-d31f-43d5-a1b3-442845fa1d0c",
+            "GPU-7c583998-b3ff-a885-8979-2d32d334cde4",
+            3533,
+            "dixu@example.com",
+            "platform",
+            False,
+        )
         self.assertEqual(target_inspect_info, inspect_info)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously we use `iftop` to get all connections in host and traffic in these connections, and then we distributed traffic to jobs with knowledge of which connection belongs to which container. We gained such knowledge by using `lsof` in each container namespace.

Such method may miss some data when connection is short and doesn't fetched by `iftop`, so the traffic is out of record.

With this PR. We get network metric using following method instead:
* If container is using host network, we assume this container take all resource of the host, hence we get its network consumption from host's real ethernet.
* else we get network consumption by first get virtual ethernet using techniq from [here](https://www.digitalocean.com/community/tutorials/how-to-inspect-kubernetes-networking#finding-a-pod%E2%80%99s-virtual-ethernet-interface), and get network consumption of this virtual ethernet.

Hopefully with this method, network metrics of both host network container and non host network container are more accurate.

This also changed meaning of `task_net_in_byte` and `task_net_out_byte`, previously these two metrics represent byte rate, now they represent byte sent/received.