### PR TITLE
.ssh folder needs to have 700

### DIFF
--- a/src/ClusterManager/user_manager.py
+++ b/src/ClusterManager/user_manager.py
@@ -66,6 +66,8 @@ def set_user_directory():
                 wf.write(public_key)
             os.system("chown -R " + str(userid) + ":" + "500000513 " +
                       userpath)
+            # Permission of .ssh has to be 700, otherwise, users cannot access
+            # .ssh via Samba file share.
             os.system("chmod 700 " + os.path.dirname(sshkeypath))
             os.system("chmod 600 " + sshkeypath)
             os.system("chmod 600 " + pubkeypath)

--- a/src/ClusterManager/user_manager.py
+++ b/src/ClusterManager/user_manager.py
@@ -66,7 +66,9 @@ def set_user_directory():
                 wf.write(public_key)
             os.system("chown -R " + str(userid) + ":" + "500000513 " +
                       userpath)
-            os.system("chmod 600 -R " + os.path.dirname(sshkeypath))
+            os.system("chmod 700 " + os.path.dirname(sshkeypath))
+            os.system("chmod 600 " + sshkeypath)
+            os.system("chmod 600 " + pubkeypath)
 
         if not os.path.exists(authorized_keyspath):
             logger.info("Creating authorized_keys for user %s" % (username))


### PR DESCRIPTION
`.ssh` needs to have 700, otherwise, samba access fails.