### PR TITLE
Fix typo in preemptable jobs

### DIFF
--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -649,7 +649,7 @@ def mark_schedulable_preemptable_jobs(jobs_info, cluster_schedulable):
         preemption_allowed = job_info.get("preemptionAllowed", False)
         if preemption_allowed and (job_info["allowed"] is False):
             job_resource = job_info["job_resource"]
-            job_id = job_info["job_id"]
+            job_id = job_info["jobId"]
             if cluster_schedulable >= job_resource:
                 logger.info(
                     "Allow preemptable job %s to run. "

--- a/src/ClusterManager/test/test_distributed_job.py
+++ b/src/ClusterManager/test/test_distributed_job.py
@@ -11,8 +11,7 @@ import utils
 logger = logging.getLogger(__file__)
 
 
-@utils.case()
-def test_distributed_job_running(args):
+def test_distributed_job_running(args, preemptable=False):
     expected = "wantThisInLog"
     cmd = "echo %s ; sleep 1800" % expected
 
@@ -20,6 +19,7 @@ def test_distributed_job_running(args):
                                                  args.email,
                                                  args.uid,
                                                  args.vc,
+                                                 preemptable=preemptable,
                                                  cmd=cmd)
     with utils.run_job(args.rest, job_spec) as job:
         state = job.block_until_state_not_in(
@@ -34,6 +34,16 @@ def test_distributed_job_running(args):
 
             time.sleep(0.5)
         assert expected in log, "assert {} in {}".format(expected, log)
+
+
+@utils.case()
+def test_distributed_non_preemptable_job_running(args):
+    test_distributed_job_running(args)
+
+
+@utils.case()
+def test_distributed_preemptable_job_running(args):
+    test_distributed_job_running(args, True)
 
 
 @utils.case()

--- a/src/ClusterManager/test/test_regular_job.py
+++ b/src/ClusterManager/test/test_regular_job.py
@@ -9,8 +9,7 @@ import utils
 logger = logging.getLogger(__file__)
 
 
-@utils.case(unstable=True)
-def test_regular_job_running(args):
+def test_regular_job_running(args, preemptable=False):
     expected = "wantThisInLog"
     cmd = "echo %s ; sleep 1800" % expected
 
@@ -18,6 +17,7 @@ def test_regular_job_running(args):
                                                  args.email,
                                                  args.uid,
                                                  args.vc,
+                                                 preemptable=preemptable,
                                                  cmd=cmd)
 
     with utils.run_job(args.rest, job_spec) as job:
@@ -33,6 +33,16 @@ def test_regular_job_running(args):
 
             time.sleep(0.5)
         assert expected in log, 'assert {} in {}'.format(expected, log)
+
+
+@utils.case(unstable=True)
+def test_regular_non_preemptable_job_running(args):
+    test_regular_job_running(args)
+
+
+@utils.case(unstable=True)
+def test_regular_preemptable_job_running(args):
+    test_regular_job_running(args, True)
 
 
 @utils.case(unstable=True)

--- a/src/ClusterManager/test/utils.py
+++ b/src/ClusterManager/test/utils.py
@@ -90,6 +90,7 @@ def gen_default_job_description(
     email,
     uid,
     vc,
+    preemptable=False,
     image="indexserveregistry.azurecr.io/deepscale:1.0.post0",
     cmd="sleep 120"):
     args = {
@@ -100,7 +101,7 @@ def gen_default_job_description(
         "vcName": vc,
         "containerUserId": 0,
         "jobName": "integration test case",
-        "preemptionAllowed": "False",
+        "preemptionAllowed": preemptable,
         "image": image,
         "cmd": cmd,
         "workPath": "./",


### PR DESCRIPTION
```
2020-03-10 06:17:12,089: INFO - main.py:67@68603: will run 4 cases ['test_distributed_job.test_distributed_non_preemptable_job_running', 'test_distributed_job.test_distributed_preemptable_job_running', 'test_regular_job.test_regular_non_preemptable_job_running', 'test_regular_job.test_regular_preemptable_job_running']
2020-03-10 06:17:12,099: INFO - utils.py:48@68627: test_distributed_job.test_distributed_non_preemptable_job_running ...(0 times)
2020-03-10 06:17:12,099: INFO - utils.py:48@68628: test_distributed_job.test_distributed_preemptable_job_running ...(0 times)
2020-03-10 06:17:12,099: INFO - utils.py:48@68629: test_regular_job.test_regular_non_preemptable_job_running ...(0 times)
2020-03-10 06:17:12,099: INFO - utils.py:48@68630: test_regular_job.test_regular_preemptable_job_running ...(0 times)
2020-03-10 06:17:12,185: INFO - utils.py:232@68630: job e2321dac-2f02-40b7-bef6-d26d6091e0e1 created
2020-03-10 06:17:12,238: INFO - utils.py:232@68629: job 9b16d7dc-d56f-4a36-ad21-95da88e50a95 created
2020-03-10 06:17:12,238: INFO - utils.py:232@68628: job 940ad7a3-9311-48a1-8d23-cda60f008e30 created
2020-03-10 06:17:12,239: INFO - utils.py:232@68627: job cb6c597f-dc74-4c5c-b9a7-bde5176f7352 created
2020-03-10 06:17:25,646: INFO - utils.py:277@68627: spent 0:00:13.407027 in waiting job become running
2020-03-10 06:17:27,675: INFO - utils.py:277@68629: spent 0:00:15.436561 in waiting job become running
2020-03-10 06:17:27,681: INFO - utils.py:277@68630: spent 0:00:15.495037 in waiting job become running
2020-03-10 06:17:29,715: INFO - utils.py:277@68628: spent 0:00:17.476318 in waiting job become running
2020-03-10 06:17:29,783: INFO - utils.py:250@68627: killed job cb6c597f-dc74-4c5c-b9a7-bde5176f7352
2020-03-10 06:17:29,783: INFO - utils.py:56@68627: spent 0:00:17.684492 in executing test case test_distributed_job.test_distributed_non_preemptable_job_running
2020-03-10 06:17:31,799: INFO - utils.py:250@68629: killed job 9b16d7dc-d56f-4a36-ad21-95da88e50a95
2020-03-10 06:17:31,799: INFO - utils.py:56@68629: spent 0:00:19.699849 in executing test case test_regular_job.test_regular_non_preemptable_job_running
2020-03-10 06:17:33,327: INFO - utils.py:250@68630: killed job e2321dac-2f02-40b7-bef6-d26d6091e0e1
2020-03-10 06:17:33,327: INFO - utils.py:56@68630: spent 0:00:21.228258 in executing test case test_regular_job.test_regular_preemptable_job_running
2020-03-10 06:17:34,627: INFO - utils.py:250@68628: killed job 940ad7a3-9311-48a1-8d23-cda60f008e30
2020-03-10 06:17:34,627: INFO - utils.py:56@68628: spent 0:00:22.528483 in executing test case test_distributed_job.test_distributed_preemptable_job_running
2020-03-10 06:17:34,649: INFO - main.py:81@68603: spent 0:00:22.567593 in executing 4 cases ['test_distributed_job.test_distributed_non_preemptable_job_running', 'test_distributed_job.test_distributed_preemptable_job_running', 'test_regular_job.test_regular_non_preemptable_job_running', 'test_regular_job.test_regular_preemptable_job_running'], 0 failed []
```