### PR TITLE
Add ACME issued TLS to cluster dashboard: Kubernetes solution

### DIFF
--- a/src/ClusterBootstrap/deploy.py
+++ b/src/ClusterBootstrap/deploy.py
@@ -1662,11 +1662,6 @@ def deploy_webUI_on_node(ipAddress):
     utils.sudo_scp(config["ssh_cert"], "./deploy/RestfulAPI/config.yaml",
                    "/etc/RestfulAPI/config.yaml", sshUser, webUIIP)
 
-    utils.render_template_directory(
-        "./template/dashboard", "./deploy/dashboard", config)
-    utils.sudo_scp(config["ssh_cert"], "./deploy/dashboard/production.yaml",
-                   "/etc/dashboard/production.yaml", sshUser, webUIIP)
-
     print("===============================================")
     print("Web UI is running at: http://%s:%s" %
           (webUIIP, str(config["webuiport"])))

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -746,6 +746,10 @@ default_config_parameters = {
             "memory_ratio": 0.9
         }
     },
+
+    "acme": {
+        "server": "https://acme-staging-v02.api.letsencrypt.org/directory"
+    },
 }
 
 # These are super scripts

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -309,6 +309,11 @@ default_config_parameters = {
         "container-network-iprange": "192.168.0.1/24",
     },
 
+    "dashboard": {
+        # If "for-cluster" is False, we have to generate dashboard configmap manually.
+        "for-cluster": True,
+    },
+
 
     "localdisk": {
         # The following pair of options control how local disk is formated and

--- a/src/ClusterBootstrap/services/dashboard/dashboard.yaml
+++ b/src/ClusterBootstrap/services/dashboard/dashboard.yaml
@@ -81,7 +81,7 @@ metadata:
   name: letsencrypt
 spec:
   acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
+    server: '{{cnf["acme"]["server"]}}'
     privateKeySecretRef:
       name: letsencrypt
     solvers:

--- a/src/ClusterBootstrap/services/dashboard/dashboard.yaml
+++ b/src/ClusterBootstrap/services/dashboard/dashboard.yaml
@@ -71,19 +71,19 @@ spec:
   tls:
     - hosts:
       - '{{cnf["kubernetes_master_node"][0]}}'
-      secretName: domain-tls
+      secretName: dashboard-tls
 
 ---
 
 kind: Issuer
 apiVersion: cert-manager.io/v1alpha2
 metadata:
-  name: letsencrypt
+  name: dashboard
 spec:
   acme:
     server: '{{cnf["acme"]["server"]}}'
     privateKeySecretRef:
-      name: letsencrypt
+      name: dashboard
     solvers:
     - selector: {}
       http01:
@@ -95,10 +95,10 @@ spec:
 kind: Certificate
 apiVersion: cert-manager.io/v1alpha2
 metadata:
-  name: domain-certificate
+  name: dashboard
 spec:
-  secretName: domain-tls
+  secretName: dashboard-tls
   issuerRef:
-    name: letsencrypt
+    name: dashboard
   dnsNames:
   - '{{cnf["kubernetes_master_node"][0]}}'

--- a/src/ClusterBootstrap/services/dashboard/dashboard.yaml
+++ b/src/ClusterBootstrap/services/dashboard/dashboard.yaml
@@ -1,16 +1,3 @@
-{% if false %}
-apiVersion: v1
-kind: Service
-metadata:
-  name: dashboard
-  namespace: default
-spec:
-  ports:
-  - port: {{cnf["webuiport"]}}
-  selector:
-    app: dashboard
----
-{% endif %}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -27,42 +14,32 @@ spec:
         app: dashboard
         dashboard-node: pod
     spec:
-      {% if cnf["dnsPolicy"] %}    
-      dnsPolicy: {{cnf["dnsPolicy"]}}
+      {% if cnf["dnsPolicy"] %}
+      dnsPolicy: '{{cnf["dnsPolicy"]}}'
       {% endif %}
       nodeSelector:
         dashboard: active
-      {% if true %}  
       hostNetwork: true
-      {% endif %}
       containers:
       - name: dashboard
-        image: {{cnf["worker-dockerregistry"]}}/{{cnf["dockerprefix"]}}/dashboard:{{cnf["dockertag"]}}
+        image: '{{cnf["worker-dockerregistry"]}}{{cnf["dockerprefix"]}}dashboard:{{cnf["dockertag"]}}'
         imagePullPolicy: Always
-        {% if false %}
         ports:
-          - name: dashboard
-            containerPort: 80
-        {% endif %}
-        imagePullPolicy: Always
+        - name: dashboard
+          containerPort: 80
         volumeMounts:
-        - mountPath: /usr/src/app/config
-          name: dashboardconfig
-        - mountPath: /var/log/dashboard
-          name: dashboardlog
+        - name: config
+          mountPath: /usr/src/app/config
       {% if cnf["private_docker_registry_username"] %}
       imagePullSecrets:
       - name: svccred
       {% endif %}
       volumes:
-      - name: dashboardconfig
+      - name: config
         hostPath:
           path: /etc/dashboard
-      - name: dashboardlog
-        hostPath:
-          path: /var/log/dashboard
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
       - key: node-role.kubernetes.io/master
-        effect: NoSchedule            
+        effect: NoSchedule

--- a/src/ClusterBootstrap/services/dashboard/dashboard.yaml
+++ b/src/ClusterBootstrap/services/dashboard/dashboard.yaml
@@ -43,6 +43,8 @@ spec:
 
 ---
 
+{% if cnf["dashboard"]["for-cluster"] %}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -70,6 +72,8 @@ data:
       wiki: https://aka.ms/dltsuserwiki_v2
 
 ---
+
+{% endif %}
 
 kind: Service
 apiVersion: v1

--- a/src/ClusterBootstrap/services/dashboard/dashboard.yaml
+++ b/src/ClusterBootstrap/services/dashboard/dashboard.yaml
@@ -2,30 +2,27 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: dashboard
-  namespace: default
 spec:
   selector:
     matchLabels:
-      dashboard-node: pod
+      app: dashboard
   template:
     metadata:
       name: dashboard
       labels:
         app: dashboard
-        dashboard-node: pod
     spec:
-      {% if cnf["dnsPolicy"] %}
-      dnsPolicy: '{{cnf["dnsPolicy"]}}'
-      {% endif %}
       nodeSelector:
         dashboard: active
-      hostNetwork: true
       containers:
       - name: dashboard
         image: '{{cnf["worker-dockerregistry"]}}{{cnf["dockerprefix"]}}dashboard:{{cnf["dockertag"]}}'
         imagePullPolicy: Always
+        env:
+        - name: TRUST_PROXY
+          value: "true"
         ports:
-        - name: dashboard
+        - name: http
           containerPort: 80
         volumeMounts:
         - name: config
@@ -43,3 +40,65 @@ spec:
         operator: Exists
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: dashboard
+spec:
+  selector:
+    app: dashboard
+  ports:
+  - port: 80
+    targetPort: http
+
+---
+
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: dashboard
+spec:
+  rules:
+  - host: '{{cnf["kubernetes_master_node"][0]}}'
+    http:
+      paths:
+      - backend:
+          serviceName: dashboard
+          servicePort: 80
+  tls:
+    - hosts:
+      - '{{cnf["kubernetes_master_node"][0]}}'
+      secretName: domain-tls
+
+---
+
+kind: Issuer
+apiVersion: cert-manager.io/v1alpha2
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+    - selector: {}
+      http01:
+        ingress:
+          class: nginx
+
+---
+
+kind: Certificate
+apiVersion: cert-manager.io/v1alpha2
+metadata:
+  name: domain-certificate
+spec:
+  secretName: domain-tls
+  issuerRef:
+    name: letsencrypt
+  dnsNames:
+  - '{{cnf["kubernetes_master_node"][0]}}'

--- a/src/ClusterBootstrap/services/dashboard/dashboard.yaml
+++ b/src/ClusterBootstrap/services/dashboard/dashboard.yaml
@@ -33,13 +33,41 @@ spec:
       {% endif %}
       volumes:
       - name: config
-        hostPath:
-          path: /etc/dashboard
+        configMap:
+          name: dashboard
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard
+data:
+  production.yaml: |
+    sign: {{cnf["master_token"]}}
+
+    masterToken: {{cnf["master_token"]}}
+
+    activeDirectory:
+      tenant: {{cnf["activeDirectory"]["tenant"]}}
+      clientId: {{cnf["activeDirectory"]["clientId"]}}
+      clientSecret: {{cnf["activeDirectory"]["clientSecret"]}}
+
+    clusters:
+      {{cnf["cluster_name"]}}:
+        restfulapi: http://{{cnf["kubernetes_master_node"][0]}}:{{cnf["restfulapiport"]}}
+        grafana: http://{{cnf["Dashboards"]["grafana"]["servers"]}}:{{cnf["Dashboards"]["grafana"]["port"]}}
+        workStorage: {{cnf["workFolderAccessPoint"]}}
+        dataStorage: {{cnf["dataFolderAccessPoint"]}}
+
+    frontend:
+      addGroup: https://dlts.azurewebsites.net/v2/htmlfiles/Overview/VirtualClusters.html
+      wiki: https://aka.ms/dltsuserwiki_v2
 
 ---
 

--- a/src/ClusterBootstrap/services/dashboard/dashboard.yaml
+++ b/src/ClusterBootstrap/services/dashboard/dashboard.yaml
@@ -16,7 +16,7 @@ spec:
         dashboard: active
       containers:
       - name: dashboard
-        image: '{{cnf["worker-dockerregistry"]}}{{cnf["dockerprefix"]}}dashboard:{{cnf["dockertag"]}}'
+        image: '{{cnf["worker-dockerregistry"]}}/{{cnf["dockerprefix"]}}/dashboard:{{cnf["dockertag"]}}'
         imagePullPolicy: Always
         env:
         - name: TRUST_PROXY

--- a/src/dashboard/server/index.js
+++ b/src/dashboard/server/index.js
@@ -16,7 +16,8 @@ if (require.main === module) {
     HOST,
     PORT = 3000,
     SSL_KEY,
-    SSL_CERT
+    SSL_CERT,
+    TRUST_PROXY = false
   } = process.env
 
   const server = SSL_KEY && SSL_CERT
@@ -27,6 +28,8 @@ if (require.main === module) {
     })
     : http.createServer()
 
+  app.proxy = Boolean(TRUST_PROXY)
+
   server.on('request', app.callback())
-  server.listen(PORT, HOST)
+  server.listen(Number(PORT), HOST)
 }


### PR DESCRIPTION
Manual
---

1. Deploy [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/) to Kubernetes.
2. Install [cert-manager](https://cert-manager.io/docs/installation/) to Kubernetes
3. Edit `deployment/nginx-ingress-controller` in namespace `ingress-nginx`.
    1. Schedule to the master node only (nodeSelector and toleration)
    2. Enable hostNetwork.
    3. Create fake ingress-nginx service to workaround flood warnings.
4. Open port 80 to Internet for ACME use
5. ./deploy.py kubernetes start dashboard
6. Waiting for the tls cert issued
7. Close port 80
8. Visit <https://master-node/>

Pros
---

Additional Ingress deployment could be used for Grafana proxy as well as multiple dashboard instances.

Cons
---

Many external dependencies, nginx-ingress-controller is maintained by nginx Inc and Kubernetes communitiy, cert-manager is maintained by jetstack