### PR TITLE
fix init container build break

### DIFF
--- a/src/docker-images/init-container/Dockerfile
+++ b/src/docker-images/init-container/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:16.04 as builder
+FROM ubuntu:18.04 as builder
 
-RUN apt-get update && apt-get --no-install-recommends install -y wget gzip build-essential
+RUN apt-get update && apt-get install -y wget gzip build-essential
 
 WORKDIR /ssh_build
 


### PR DESCRIPTION
install wget with `--no-install-recommends` will not install let's encrypt CA, and zlib.net uses it. Hence break the ssh build in init container.