### PR TITLE
rollback to ubuntu 16.04 in building ssh

### DIFF
--- a/src/docker-images/init-container/Dockerfile
+++ b/src/docker-images/init-container/Dockerfile
@@ -1,11 +1,20 @@
-FROM ubuntu:18.04 as builder
+FROM ubuntu:16.04 as builder
 
 RUN apt-get update && apt-get install -y wget gzip build-essential
 
 WORKDIR /ssh_build
 
-COPY build-openssh-static.sh /ssh_build
-RUN sh build-openssh-static.sh
+ENV DIST_DIR=/ssh_build/dist ROOT=/ssh_build/root BUILD_DIR=/ssh_build/build
+
+# make it cache friendly
+COPY download.sh  /ssh_build
+RUN sh download.sh
+COPY build_zlib.sh /ssh_build
+RUN sh build_zlib.sh
+COPY build_openssl.sh /ssh_build
+RUN sh build_openssl.sh
+COPY build_ssh.sh /ssh_build/
+RUN sh build_ssh.sh
 
 FROM python:3.8.0-alpine3.10
 

--- a/src/docker-images/init-container/build-openssh-static.sh
+++ b/src/docker-images/init-container/build-openssh-static.sh
@@ -1,58 +1,20 @@
 #!/bin/sh
 
-set -u
-set -e
-set -x
+set -uex
 umask 0077
 
-ZLIB_URL="https://www.zlib.net/zlib-1.2.11.tar.gz"
-SSH_URL="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz"
-SSL_URL="https://www.openssl.org/source/openssl-1.0.2t.tar.gz"
-
-mkdir dist
-
-(cd dist
-    wget $ZLIB_URL
-    wget $SSH_URL
-    wget $SSL_URL
-)
-
+export DIST_DIR=dist
 top="$(pwd)"
-root="$top/root"
-build="$top/build"
+export ROOT="$top/root"
+export BUILD="$top/build"
 
-export CFLAGS="-I$root/usr/include -L. -fPIC"
-export CPPFLAGS="-I$root/usr/include -L. -fPIC"
+export CFLAGS="-I$ROOT/usr/include -L. -fPIC -O2"
+export CPPFLAGS="-I$ROOT/usr/include -L. -fPIC"
 
-rm -rf "$root" "$build"
-mkdir -p "$root" "$build"
+rm -rf "$ROOT" "$BUILD"
+mkdir -p "$ROOT" "$BUILD"
 
-gzip -dc dist/zlib-*.tar.gz |(cd "$build" && tar xf -)
-cd "$build"/zlib-*
-./configure --prefix="$root/usr" --static
-make -j12
-make install
-cd "$top"
-
-gzip -dc dist/openssl-*.tar.gz |(cd "$build" && tar xf -)
-cd "$build"/openssl-*
-./config --prefix="/usr" no-shared
-make -j12
-make INSTALL_PREFIX="$root" install
-cd "$top"
-
-gzip -dc dist/openssh-*.tar.gz |(cd "$build" && tar xf -)
-cd "$build"/openssh-*
-cp -p "$root"/usr/lib/*.a .
-[ -f sshd_config.orig ] || cp -p sshd_config sshd_config.orig
-sed \
-  -e 's/^#\(PubkeyAuthentication\) .*/\1 yes/' \
-  -e '/^# *Kerberos/d' \
-  -e '/^# *GSSAPI/d' \
-  -e 's/^#\([A-Za-z]*Authentication\) .*/\1 no/' \
-  sshd_config.orig \
-  >sshd_config \
-;
-./configure --prefix="/usr" --with-privsep-user=nobody --with-privsep-path="/var/run/sshd"
-make -j12
-make DESTDIR="$root" install
+sh download.sh
+sh build_zlib.sh
+sh build_openssl.sh
+sh build_ssh.sh

--- a/src/docker-images/init-container/build_openssl.sh
+++ b/src/docker-images/init-container/build_openssl.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -uex
+umask 0077
+
+export CFLAGS="-I$ROOT/usr/include -L. -fPIC -O2"
+export CPPFLAGS="-I$ROOT/usr/include -L. -fPIC"
+
+gzip -dc $DIST_DIR/openssl-*.tar.gz |(cd "$BUILD_DIR" && tar xf -)
+(
+cd "$BUILD_DIR"/openssl-*
+./config --prefix="/usr" no-shared
+make -j12
+make INSTALL_PREFIX="$ROOT" install
+)

--- a/src/docker-images/init-container/build_ssh.sh
+++ b/src/docker-images/init-container/build_ssh.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -uex
+umask 0077
+
+export CFLAGS="-I$ROOT/usr/include -L. -fPIC"
+export CPPFLAGS="-I$ROOT/usr/include -L. -fPIC"
+
+gzip -dc $DIST_DIR/openssh-*.tar.gz |(cd "$BUILD_DIR" && tar xf -)
+(
+cd "$BUILD_DIR"/openssh-*
+cp -p "$ROOT"/usr/lib/*.a .
+[ -f sshd_config.orig ] || cp -p sshd_config sshd_config.orig
+sed \
+  -e 's/^#\(PubkeyAuthentication\) .*/\1 yes/' \
+  -e '/^# *Kerberos/d' \
+  -e '/^# *GSSAPI/d' \
+  -e 's/^#\([A-Za-z]*Authentication\) .*/\1 no/' \
+  sshd_config.orig \
+  >sshd_config \
+;
+
+./configure --prefix="/usr" --with-privsep-user=nobody --with-privsep-path="/var/run/sshd"
+
+make -j12
+make DESTDIR="$ROOT" install
+)

--- a/src/docker-images/init-container/build_zlib.sh
+++ b/src/docker-images/init-container/build_zlib.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -uex
+umask 0077
+
+export CFLAGS="-I$ROOT/usr/include -L. -fPIC -O2"
+export CPPFLAGS="-I$ROOT/usr/include -L. -fPIC"
+
+gzip -dc dist/zlib-*.tar.gz |(cd "$BUILD_DIR" && tar xf -)
+(
+cd "$BUILD_DIR"/zlib-*
+./configure --prefix="$ROOT/usr" --static
+make -j12
+make install
+)

--- a/src/docker-images/init-container/download.sh
+++ b/src/docker-images/init-container/download.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -uex
+umask 0077
+
+LIBC_URL="http://ftp.gnu.org/gnu/glibc/glibc-2.31.tar.gz"
+ZLIB_URL="https://www.zlib.net/zlib-1.2.11.tar.gz"
+SSH_URL="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz"
+SSL_URL="https://www.openssl.org/source/openssl-1.0.2t.tar.gz"
+
+mkdir $DIST_DIR
+
+(cd $DIST_DIR
+    wget $LIBC_URL
+    wget $ZLIB_URL
+    wget $SSH_URL
+    wget $SSL_URL
+)
+
+rm -rf "$ROOT" "$BUILD_DIR"
+mkdir -p "$ROOT" "$BUILD_DIR"


### PR DESCRIPTION
build ssh in ubuntu 18.04 will make it link to GLIBC_2.25 or GLIBC_2.26, which not exist in some customer's image. Rollback to 16.04 temporary. Will investigate on how to avoid such issue later.