### PR TITLE
Logging: output to azure log analytics

### DIFF
--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -16,6 +16,7 @@ default_config_parameters = {
     "cloud_elasticsearch_port": "9200",
 
     "elasticsearch": {
+        "enabled": False,
         "port": {
             "http": 9200,
             "transport": 9300,
@@ -24,8 +25,8 @@ default_config_parameters = {
         },
     },
 
-    "fluentd": {
-        "port": 24231,
+    "logAnalytics": {
+        "enabled": False,
     },
 
     "influxdb_port": "8086",

--- a/src/ClusterBootstrap/services/logging/fluent-bit-config.yaml
+++ b/src/ClusterBootstrap/services/logging/fluent-bit-config.yaml
@@ -89,7 +89,7 @@ data:
   output-azure.conf: |
     [OUTPUT]
         Name            azure
-        Match           *
+        Match           jobs.*
         Customer_ID     ${FLUENT_AZURE_CUSTOMER_ID}
         Shared_Key      ${FLUENT_AZURE_SHARED_KEY}
         Log_Type        ${FLUENT_AZURE_LOG_TYPE}

--- a/src/ClusterBootstrap/services/logging/fluent-bit-config.yaml
+++ b/src/ClusterBootstrap/services/logging/fluent-bit-config.yaml
@@ -20,6 +20,7 @@ data:
 
     @INCLUDE input-kubernetes.conf
     @INCLUDE filter-kubernetes.conf
+    @INCLUDE filter-jobs.conf
     @INCLUDE filter-time_nsec.conf
     @INCLUDE output-elasticsearch.conf
 
@@ -48,10 +49,16 @@ data:
         K8S-Logging.Exclude Off
         tls.vhost           kubernetes.default.svc
 
+  filter-jobs.conf: |
+    [FILTER]
+        Name  rewrite_tag
+        Match kube.*
+        Rule  $kubernetes['labels']['type'] ^job$ jobs.$kubernetes['labels']['vcName'].$kubernetes['labels']['jobId'] false
+
   filter-time_nsec.conf: |
     [FILTER]
         NAME         lua
-        Match        kube.*
+        Match        jobs.*
         Script       time_nsec.lua
         Call         time_nsec
         Type_int_key time_nsec
@@ -66,7 +73,7 @@ data:
   output-elasticsearch.conf: |
     [OUTPUT]
         Name            es
-        Match           *
+        Match           jobs.*
         Host            ${FLUENT_ELASTICSEARCH_HOST}
         Port            ${FLUENT_ELASTICSEARCH_PORT}
         Type            fluentd

--- a/src/ClusterBootstrap/services/logging/fluent-bit-config.yaml
+++ b/src/ClusterBootstrap/services/logging/fluent-bit-config.yaml
@@ -22,7 +22,12 @@ data:
     @INCLUDE filter-kubernetes.conf
     @INCLUDE filter-jobs.conf
     @INCLUDE filter-time_nsec.conf
+    {% if cnf["elasticsearch"]["enabled"] -%}
     @INCLUDE output-elasticsearch.conf
+    {%- endif %}
+    {% if cnf["logAnalytics"]["enabled"] -%}
+    @INCLUDE output-azure.conf
+    {%- endif %}
 
   input-kubernetes.conf: |
     [INPUT]
@@ -80,6 +85,14 @@ data:
         Logstash_Format On
         Replace_Dots    On
         Retry_Limit     False
+
+  output-azure.conf: |
+    [OUTPUT]
+        Name            azure
+        Match           *
+        Customer_ID     ${FLUENT_AZURE_CUSTOMER_ID}
+        Shared_Key      ${FLUENT_AZURE_SHARED_KEY}
+        Log_Type        ${FLUENT_AZURE_LOG_TYPE}
 
   parsers.conf: |
     [PARSER]

--- a/src/ClusterBootstrap/services/logging/fluent-bit.yaml
+++ b/src/ClusterBootstrap/services/logging/fluent-bit.yaml
@@ -29,10 +29,20 @@ spec:
         ports:
         - containerPort: 2020
         env:
+        {% if cnf["elasticsearch"]["enabled"] -%}
         - name: FLUENT_ELASTICSEARCH_HOST
           value: "$(ELASTICSEARCH_SERVICE_HOST)"
         - name: FLUENT_ELASTICSEARCH_PORT
           value: "$(ELASTICSEARCH_SERVICE_PORT)"
+        {%- endif %}
+        {% if cnf["logAnalytics"]["enabled"] -%}
+        - name: FLUENT_AZURE_CUSTOMER_ID
+          value: '{{cnf["logAnalytics"]["workspaceId"]}}'
+        - name: FLUENT_AZURE_SHARED_KEY
+          value: '{{cnf["logAnalytics"]["key"]}}'
+        - name: FLUENT_AZURE_LOG_TYPE
+          value: '{{cnf["logAnalytics"]["tableName"]}}'
+        {%- endif %}
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/src/ClusterBootstrap/services/logging/fluent-bit.yaml
+++ b/src/ClusterBootstrap/services/logging/fluent-bit.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:1.4.0
+        image: fluent/fluent-bit:1.4.1
         imagePullPolicy: Always
         ports:
         - containerPort: 2020

--- a/src/ClusterBootstrap/services/logging/launch_order
+++ b/src/ClusterBootstrap/services/logging/launch_order
@@ -1,4 +1,6 @@
+{% if cnf["elasticsearch"]["enabled"] -%}
 elasticsearch.yaml
+kibana.yaml
+{% endif -%}
 fluent-bit-config.yaml
 fluent-bit.yaml
-kibana.yaml

--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -100,3 +100,13 @@ default_memoryrequest: {{cnf["default_memoryrequest"]}}
 {% if cnf["default_memorylimit"] %}
 default_memorylimit: {{cnf["default_memorylimit"]}}
 {% endif %}
+
+
+{% if cnf["logAnalytics"]["enabled"] %}
+logging: logAnalytics
+{% elif cnf["elasticsearch"]["enabled"] %}
+logging: elasticsearch
+{% endif %}
+
+activeDirectory: {{ cnf["activeDirectory"] | tojson }}
+logAnalytics: {{ cnf["logAnalytics"] | tojson }}

--- a/src/ClusterManager/joblog_manager.py
+++ b/src/ClusterManager/joblog_manager.py
@@ -22,9 +22,6 @@ import k8sUtils
 
 logger = logging.getLogger(__name__)
 
-elasticsearch_deployed = isinstance(config.get('elasticsearch'),
-                                    list) and len(config['elasticsearch']) > 0
-
 
 def create_log(logdir='/var/log/dlworkspace'):
     if not os.path.exists(logdir):
@@ -37,16 +34,20 @@ def create_log(logdir='/var/log/dlworkspace'):
         logging.config.dictConfig(logging_config)
 
 
+_use_legacy = config.get('logging') not in [
+    'logAnalytics', 'elaticsearch'
+] or config.get('__extract_job_log_legacy', False)
+
+
 def extract_job_log(job_id, log_path, user_id):
-    if elasticsearch_deployed and not config.get('__extract_job_log_legacy',
-                                                 False):
-        extract_job_log_with_elastic_search(job_id, log_path, user_id)
+    if not _use_legacy:
+        _extract_job_log(job_id, log_path, user_id)
     else:
-        extract_job_log_legacy(job_id, log_path, user_id)
+        _extract_job_log_legacy(job_id, log_path, user_id)
 
 
 @record
-def extract_job_log_with_elastic_search(jobId, logPath, userId):
+def _extract_job_log(jobId, logPath, userId):
     dataHandler = None
     try:
         dataHandler = DataHandler()
@@ -54,34 +55,21 @@ def extract_job_log_with_elastic_search(jobId, logPath, userId):
         old_cursor = dataHandler.GetJobTextField(jobId, "jobLogCursor")
         if old_cursor is not None and len(old_cursor) == 0:
             old_cursor = None
-        (logs, new_cursor) = GetJobLog(jobId, cursor=old_cursor)
-
-        container_logs = {}
-        for log in logs:
-            try:
-                container_id = log["_source"]["docker"]["container_id"]
-                log_text = log["_source"]["log"]
-                if container_id in container_logs:
-                    container_logs[container_id] += log_text
-                else:
-                    container_logs[container_id] = log_text
-            except Exception:
-                logging.exception(
-                    "Failed to parse elasticsearch log: {}".format(log))
+        (pod_logs, new_cursor) = GetJobLog(jobId, cursor=old_cursor)
 
         jobLogDir = os.path.dirname(logPath)
         if not os.path.exists(jobLogDir):
             mkdirsAsUser(jobLogDir, userId)
 
-        for (container_id, log_text) in container_logs.items():
+        for (pod_name, log_text) in pod_logs.items():
             try:
-                containerLogPath = os.path.join(
-                    jobLogDir, "log-conatainer-" + container_id + ".txt")
-                with open(containerLogPath, 'a') as f:
+                podLogPath = os.path.join(
+                    jobLogDir, "log-pod-" + pod_name + ".txt")
+                with open(podLogPath, 'a') as f:
                     f.write(log_text)
-                os.system("chown -R %s %s" % (userId, containerLogPath))
+                os.system("chown -R %s %s" % (userId, podLogPath))
             except Exception:
-                logger.exception("write container log failed")
+                logger.exception("write pod log failed")
 
         logging.info("cursor of job %s: %s" % (jobId, new_cursor))
         if new_cursor is not None:
@@ -96,7 +84,7 @@ def extract_job_log_with_elastic_search(jobId, logPath, userId):
 
 
 @record
-def extract_job_log_legacy(jobId, logPath, userId):
+def _extract_job_log_legacy(jobId, logPath, userId):
     dataHandler = None
     try:
         dataHandler = DataHandler()

--- a/src/ClusterManager/requirements.txt
+++ b/src/ClusterManager/requirements.txt
@@ -6,3 +6,4 @@ twisted==19.7.0
 cachetools==3.1.1
 redis==3.2.1
 elasticsearch>=6.0.0,<7.0.0
+azure==4.0.0

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -117,5 +117,4 @@ elif config.get("logging") == 'elasticsearch':
             return ({}, None)
 else:
     def GetJobLog(jobId, *args, **kwargs):
-        # TODO: Refer file://samba/foobar.log
         return ({}, None)

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -54,6 +54,8 @@ if config.get("logging") == 'logAnalytics':
 
             if len(rows) > 0:
                 cursor = rows[-1][0]
+            else:
+                cursor = None
 
             return (pod_logs, cursor)
         except Exception:
@@ -106,6 +108,8 @@ elif config.get("logging") == 'elasticsearch':
 
             if len(documents) > 0:
                 cursor = '.'.join(str(i) for i in documents[-1]["sort"])
+            else:
+                cursor = None
 
             return (pod_logs, cursor)
         except Exception:

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -1,6 +1,5 @@
 import logging
-
-from elasticsearch import Elasticsearch
+from itertools import groupby
 
 from config import config
 
@@ -15,45 +14,104 @@ def TryParseCursor(cursor):
         return None
 
 
-def GetJobLog(jobId, cursor=None, size=None):
-    try:
-        elasticsearch = Elasticsearch(config['elasticsearch'])
+if config.get("logging") == 'logAnalytics':
+    from azure.common.credentials import ServicePrincipalCredentials
+    from azure.loganalytics import LogAnalyticsDataClient
 
-        request_json = {
-            "query": {
-                "match_phrase": {
-                    "kubernetes.labels.jobId": jobId
-                }
-            },
-            "sort": [
-                "@timestamp",
-                {
-                    "time_nsec": {
-                        "unmapped_type": "long",
-                        "missing": 0
+    _credentials = ServicePrincipalCredentials(
+        client_id=config["activeDirectory"]["clientId"],
+        secret=config["activeDirectory"]["clientSecret"],
+        tenant=config["activeDirectory"]["tenant"],
+        resource='https://api.loganalytics.io',
+    )
+
+    def GetJobLog(jobId, cursor=None, size=None):
+        try:
+            with LogAnalyticsDataClient(_credentials) as dataClient:
+                query = [
+                    config['logAnalytics']['tableName'] + "_CL",
+                    'where kubernetes_labels_jobId_g == "{}"'.format(jobId),
+                    'extend cursor=toint(_timestamp_d) + time_nsec_d / decimal(1e9)',
+                    'sort by cursor asc',
+                    'project cursor, kubernetes_pod_name_s, stream_s, log_s'
+                ]
+
+                if cursor is not None:
+                    query.append('where cursor > decimal({})'.format(cursor))
+                if size is not None:
+                    query.append('limit {}'.format(size))
+
+                query = '\n| '.join(query)
+                results = dataClient.query(
+                    workspace_id=config["logAnalytics"]["workspaceId"],
+                    body={"query": query})
+
+            rows = results.tables[0].rows
+
+            pod_logs = dict()
+            for pod_name, pod_rows in groupby(rows, lambda row: row[1]):
+                pod_logs[pod_name] = ''.join(pod_row[3] for pod_row in pod_rows)
+
+            if len(rows) > 0:
+                cursor = rows[-1][0]
+
+            return (pod_logs, cursor)
+        except Exception:
+            logger.exception("Request log analytics failed")
+            return ({}, None)
+elif config.get("logging") == 'elasticsearch':
+    from elasticsearch import Elasticsearch
+
+    def GetJobLog(jobId, cursor=None, size=None):
+        try:
+            elasticsearch = Elasticsearch(config['elasticsearch'])
+
+            request_json = {
+                "query": {
+                    "match_phrase": {
+                        "kubernetes.labels.jobId": jobId
                     }
                 },
-            ],
-            "_source": [
-                "docker.container_id", "kubernetes.pod_name", "stream", "log"
-            ]
-        }
-        if cursor is not None:
-            search_after = TryParseCursor(cursor)
-            if search_after is not None:
-                request_json['search_after'] = search_after
-        if size is not None:
-            request_json['size'] = size
+                "sort": [
+                    "@timestamp",
+                    {
+                        "time_nsec": {
+                            "unmapped_type": "long",
+                            "missing": 0
+                        }
+                    },
+                ],
+                "_source": [
+                    "docker.container_id", "kubernetes.pod_name", "stream",
+                    "log"
+                ]
+            }
+            if cursor is not None:
+                search_after = TryParseCursor(cursor)
+                if search_after is not None:
+                    request_json['search_after'] = search_after
+            if size is not None:
+                request_json['size'] = size
 
-        response_json = elasticsearch.search(index="logstash-*",
-                                             body=request_json)
-        documents = response_json["hits"]["hits"]
+            response_json = elasticsearch.search(index="logstash-*",
+                                                 body=request_json)
+            documents = response_json["hits"]["hits"]
 
-        next_cursor = None
-        if len(documents) > 0:
-            next_cursor = '.'.join(str(i) for i in documents[-1]["sort"])
+            pod_logs = dict()
+            for pod_name, pod_documents in groupby(
+                    documents, lambda document: document["_source"][
+                        "kubernetes"]["pod_name"]):
+                pod_logs[pod_name] = ''.join(
+                    pod_document["_source"]["log"] for pod_document in pod_documents)
 
-        return (documents, next_cursor)
-    except Exception:
-        logger.exception("Request elasticsearch failed")
+            if len(documents) > 0:
+                cursor = '.'.join(str(i) for i in documents[-1]["sort"])
+
+            return (pod_logs, cursor)
+        except Exception:
+            logger.exception("Request elasticsearch failed")
+            return ({}, None)
+else:
+    def GetJobLog(jobId, *args, **kwargs):
+        # TODO: Refer file://samba/foobar.log
         return ({}, None)

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -77,10 +77,6 @@ def base64decode(str_val):
     return base64.b64decode(str_val.encode("utf-8")).decode("utf-8")
 
 
-elasticsearch_deployed = isinstance(config.get('elasticsearch'),
-                                    list) and len(config['elasticsearch']) > 0
-
-
 def adjust_job_priority(priority, permission):
     priority_range = (DEFAULT_JOB_PRIORITY, DEFAULT_JOB_PRIORITY)
     if permission == Permission.User:
@@ -648,6 +644,11 @@ def GetJobStatus(jobId):
     return result
 
 
+_job_log_use_legacy = config.get('logging') not in [
+    'logAnalytics', 'elasticsearch'
+] or config.get('__extract_job_log_legacy', False)
+
+
 def GetJobLog(userName, jobId, cursor=None, size=100):
     dataHandler = DataHandler()
     jobs = dataHandler.GetJob(jobId=jobId)
@@ -655,15 +656,8 @@ def GetJobLog(userName, jobId, cursor=None, size=100):
         if jobs[0]["userName"] == userName or AuthorizationManager.HasAccess(
                 userName, ResourceType.VC, jobs[0]["vcName"],
                 Permission.Collaborator):
-            if elasticsearch_deployed:
-                (lines, cursor) = UtilsGetJobLog(jobId, cursor, size)
-
-                pod_logs = {}
-                for (pod_name, pod_lines) in itertools.groupby(
-                        lines,
-                        lambda line: line["_source"]["kubernetes"]["pod_name"]):
-                    pod_logs[pod_name] = ''.join(
-                        line["_source"]["log"] for line in pod_lines)
+            if not _job_log_use_legacy:
+                (pod_logs, cursor) = UtilsGetJobLog(jobId, cursor, size)
 
                 return {
                     "log": pod_logs,


### PR DESCRIPTION
- [x] Support neither deployment (give "See file://log") to user.

```
spent 0:05:18.463647 in executing 26 cases ['test_inference_job.test_inference_job_running', 'test_distributed_j
ob.test_blobfuse', 'test_distributed_job.test_distributed_job_env', 'test_distributed_job.test_distributed_job_ssh', 'test_distributed_job.test_distributed_non_pre
emptable_job_running', 'test_distributed_job.test_distributed_preemptable_job_running', 'test_distributed_job.test_distributed_with_default_cmd', 'test_distributed
_job.test_ssh_cuda_visible_devices', 'test_regular_job.test_batch_kill_jobs', 'test_regular_job.test_batch_op_jobs', 'test_regular_job.test_blobfuse', 'test_regula
r_job.test_data_job_running', 'test_regular_job.test_do_not_expose_private_key', 'test_regular_job.test_job_fail', 'test_regular_job.test_list_all_jobs', 'test_reg
ular_job.test_op_job', 'test_regular_job.test_regular_job_custom_ssh_key', 'test_regular_job.test_regular_job_env', 'test_regular_job.test_regular_job_ssh', 'test_
regular_job.test_regular_non_preemptable_job_running', 'test_regular_job.test_regular_preemptable_job_running', 'test_regular_job.test_ssh_cpu_job_cuda_visible_dev
ices', 'test_regular_job.test_ssh_do_not_expose_private_key', 'test_regular_job.test_ssh_multi_gpu_job_cuda_visible_devices', 'test_regular_job.test_ssh_one_gpu_jo
b_cuda_visible_devices', 'test_regular_job.test_sudo_installed'], 2 failed test_distributed_job.test_ssh_cuda_visible_devices,test_regular_job.test_ssh_multi_gpu_j
ob_cuda_visible_devices```