### PR TITLE
expose framework diagnostics info for failed job

### DIFF
--- a/src/ClusterManager/job_launcher.py
+++ b/src/ClusterManager/job_launcher.py
@@ -807,7 +807,7 @@ class PythonLauncher(Launcher):
         job_roles = self.get_job_roles(job_id)
 
         if len(job_roles) < 1:
-            return "NotFound", []
+            return "NotFound", [], ""
 
         # role status in ["NotFound", "Pending", "Running", "Succeeded", "Failed", "Unknown"]
         # TODO ??? when ps/master role "Succeeded", return Succeeded
@@ -816,7 +816,7 @@ class PythonLauncher(Launcher):
                 continue
             if job_role.status() == "Succeeded":
                 logger.info("Job: {}, Succeeded!".format(job_id))
-                return "Succeeded", []
+                return "Succeeded", [], ""
 
         statuses = [job_role.status() for job_role in job_roles]
         logger.info("Job: {}, status: {}".format(job_id, statuses))

--- a/src/ClusterManager/joblog_manager.py
+++ b/src/ClusterManager/joblog_manager.py
@@ -85,7 +85,8 @@ def extract_job_log_with_elastic_search(jobId, logPath, userId):
 
         logging.info("cursor of job %s: %s" % (jobId, new_cursor))
         if new_cursor is not None:
-            dataHandler.UpdateJobTextField(jobId, "jobLogCursor", new_cursor)
+            dataHandler.UpdateJobTextFields({"jobId": jobId},
+                                            {"jobLogCursor": new_cursor})
 
     except Exception as e:
         logging.error(e)
@@ -172,9 +173,10 @@ def extract_job_log_legacy(jobId, logPath, userId):
                     logger.exception("write container log failed")
 
         if len(trimlogstr.strip()) > 0:
-            dataHandler.UpdateJobTextField(
-                jobId, "jobLog",
-                base64.b64encode(trimlogstr.encode("utf-8")).decode("utf-8"))
+            encoded_log = base64.b64encode(
+                trimlogstr.encode("utf-8")).decode("utf-8")
+            dataHandler.UpdateJobTextFields({"jobId": jobId},
+                                            {"jobLog": encoded_log})
             with open(logPath, 'w', encoding="utf-8") as f:
                 f.write(logStr)
             f.close()

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -1239,8 +1239,8 @@ def UpdateEndpoints(userName, jobId, requested_endpoints, interactive_ports):
             else:
                 logger.info("Endpoint %s exists. Skip.", endpoint_id)
 
-        dataHandler.UpdateJobTextField(jobId, "endpoints",
-                                       json.dumps(endpoints))
+        dataHandler.UpdateJobTextFields({"jobId": jobId},
+                                        {"endpoints": json.dumps(endpoints)})
         return endpoints, 200
     except Exception as e:
         logger.error("Get endpoint exception, ex: %s", str(e))
@@ -1262,12 +1262,6 @@ def get_job(job_id):
         if data_handler is not None:
             data_handler.Close()
     return None
-
-
-def update_job(job_id, field, value):
-    dataHandler = DataHandler()
-    dataHandler.UpdateJobTextField(job_id, field, value)
-    dataHandler.Close()
 
 
 def get_job_priorities():

--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -1332,7 +1332,7 @@ class DataHandler(object):
 
         sql_template.append(",".join(set_stmt))
         sql_template.append("WHERE")
-        sql_template.append("AND".join(where_stmt))
+        sql_template.append(" AND ".join(where_stmt))
 
         sql = " ".join(sql_template)
         values = []


### PR DESCRIPTION
Ref [framework launcher doc](https://github.com/microsoft/frameworkcontroller/blob/dbcb0d117cdc312136998f26ebd8441dcc87255f/doc/user-manual.md#completionstatus).

Utilize `errorMsg` field of job, which can be fetched by `/GetJobStatus` api. For example it will have following content for job with `false` command:

```
{"errorMsg":"Pod failed: PodPattern unmatched: {\"containers\":[{\"name\":\"init\",\"reason\":\"Completed\",\"code\":0},{\"name\":\"a46d7ae6-c398-4599-9f22-233eeaec79b5\",\"reason\":\"Error\",\"message\":\"\\n+ adduser dixu sudo\\nAdding user `dixu' to group `sudo' ...\\nAdding user dixu to group sudo\\nDone.\\n+ echo '%sudo ALL=(ALL) NOPASSWD:ALL'\\n+ ENV_FILE=/dlts-runtime/env/pod.env\\n+ set +x\\n+ grep -qx '^\\\\s*. /dlts-runtime/env/pod.env' /home/dixu/.profile\\n+ bash /dlws-scripts/setup_sshd.sh\\n+ retry setup_sshd\\n+ local n=1\\n+ local max=3\\n+ local delay=3\\n+ true\\n+ setup_sshd\\n+ SSH_PORT=22\\n+ sed -i -E 's/^#?Port 22/Port 22/' /usr/etc/sshd_config\\n+ echo 22\\n+ echo 10.40.0.2\\n+ /etc/init.d/ssh restart\\n/usr/etc/sshd_config line 84: Unsupported option UsePAM\\r\\n * Restarting OpenBSD Secure Shell server sshd\\n/usr/etc/sshd_config line 84: Unsupported option UsePAM\\r\\n   ...done.\\n\\nreal\\t0m0.028s\\nuser\\t0m0.021s\\nsys\\t0m0.004s\\n+ break\\n+ bash /dlws-scripts/setup_ssh_config.sh\\n+ ps_host_list=\\n++ seq 0 -1\\n+ worker_host_list=\\n+ '[' master = master ']'\\n+ worker_host_list=master\\n+ host_list=' master'\\n+ SSH_CONFIG_FILE=/home/dixu/.ssh/config\\n+ chown dixu /home/dixu/.ssh/config\\n+ chmod 600 /home/dixu/.ssh/config\\n+ for host in ${host_list}\\n+ '[' master = master ']'\\n+ ip=10.40.0.2\\n+ port=22\\n+ cat\\n+ echo -e '10.40.0.2\\\\tmaster'\\n+ set +x\\n+ mkdir -p /root/.ssh\\n+ cp /home/dixu/.ssh/authorized_keys /home/dixu/.ssh/config /home/dixu/.ssh/environment /home/dixu/.ssh/id_rsa /root/.ssh/\\n+ chown root /root/.ssh/authorized_keys /root/.ssh/config /root/.ssh/environment /root/.ssh/id_rsa\\n+ chmod 600 /root/.ssh/authorized_keys /root/.ssh/config /root/.ssh/environment /root/.ssh/id_rsa\\n+ '[' master = master ']'\\n+ SLOT_FILE=/job/hostfile\\n+ chown dixu /job/hostfile\\n+ for host in
${worker_host_list}\\n+ slots=0\\n+ cat\\n+ '[' master = ps ']'\\n++ date\\n+ echo bootstrap ends at Mon Mar 23 21:39:07 UTC 2020\\n+ mkdir -p /dlts-runtime/status\\nbootstrap ends at Mon Mar 23 21:39:07 UTC 2020\\n+ touch /dlts-runtime/status/READY\\n+ set +e\\n+ '[' master = worker ']'\\n+ printenv DLTS_LAUNCH_CMD\\n+ chmod +x /dlts-runtime/status/job_command.sh\\n+ runuser -l dixu -c /dlts-runtime/status/job_command.sh\\n+ EXIT_CODE=1\\n++ date\\n+ echo Mon Mar 23 21:39:07 UTC 2020 ': 1'\\nMon Mar 23 21:39:07 UTC 2020 : 1\\n+ exit 1\\n\",\"code\":1}]}","jobStatus":"failed","jobTime":"Mon, 23 Mar 2020 21:38:52 GMT"}
```

The `errorMsg` itself will be a string generated by framework [launcher](https://github.com/microsoft/frameworkcontroller/blob/40fb74d1d5a6fa056746fec002d61d916e9b93e2/pkg/apis/frameworkcontroller/v1/completion.go#L217-L231).

the python launcher do not provide this, it will be an empty string.

@Gerhut Please show this message somewhere in the dashboard and hopefully this can save DRI some time.