### PR TITLE
Dashboard backend: add a 60 seconds cache

### DIFF
--- a/src/dashboard/server/api/controllers/cluster/job/log.js
+++ b/src/dashboard/server/api/controllers/cluster/job/log.js
@@ -3,11 +3,22 @@
  * @property {import('../../../services/cluster')} cluster
  */
 
+const CACHE_CONTROL = 'private, max-age=60'
+
 /** @type {import('koa').Middleware<State>} */
 module.exports = async context => {
   const { cluster } = context.state
   const { jobId } = context.params
   const { cursor } = context.query
 
-  context.body = await cluster.getJobLog(jobId, cursor)
+  context.set('cache-control', CACHE_CONTROL)
+
+  try {
+    context.body = await cluster.getJobLog(jobId, cursor)
+  } catch (error) {
+    if (error.status === 404) {
+      error.headers = {'cache-control': CACHE_CONTROL}
+    }
+    throw error
+  }
 }


### PR DESCRIPTION
Still not sure if it is the right strategy:

- If there are some logs at the time after a specific cursor: the log will be cached for 60 seconds.
- If there are no more logs at the time after a specific cursor, the 404 response will (also) be cached for 60 seconds.