### PR TITLE
JobV2: Fix wrong snackbar triggers in console tab

### DIFF
--- a/src/dashboard/src/pages/JobV2/Tabs/Console.tsx
+++ b/src/dashboard/src/pages/JobV2/Tabs/Console.tsx
@@ -92,7 +92,7 @@ ${log[podName]}
 
   useEffect(() => {
     if (error === undefined) return;
-    if (error.message === 'Not Found') return;
+    if (Number(error.name) === 404) return;
 
     const key = enqueueSnackbar(`Failed to fetch job log: ${clusterId}/${jobId}`, {
       variant: 'error',


### PR DESCRIPTION
In production mode the dashboard is served using HTTP/2, which have no `error.message`. This will cause snackbar keep triggering when there are no more logs.

Ref: https://httpwg.org/specs/rfc7540.html#HttpResponse