### PR TITLE
elasticsearch log backend: open file as utf-8

### DIFF
--- a/src/ClusterManager/joblog_manager.py
+++ b/src/ClusterManager/joblog_manager.py
@@ -77,7 +77,7 @@ def extract_job_log_with_elastic_search(jobId, logPath, userId):
             try:
                 containerLogPath = os.path.join(
                     jobLogDir, "log-conatainer-" + container_id + ".txt")
-                with open(containerLogPath, 'a') as f:
+                with open(containerLogPath, 'a', encoding="utf-8") as f:
                     f.write(log_text)
                 os.system("chown -R %s %s" % (userId, containerLogPath))
             except Exception:


### PR DESCRIPTION
Since we are using `ubuntu:16.04` as base image in restfulapi image which is using POSIX as default locale, we should set file encoding implicitly.

```
docker run -it --rm ubuntu:16.04 locale
LANG=
LANGUAGE=
LC_CTYPE="POSIX"
LC_NUMERIC="POSIX"
LC_TIME="POSIX"
LC_COLLATE="POSIX"
LC_MONETARY="POSIX"
LC_MESSAGES="POSIX"
LC_PAPER="POSIX"
LC_NAME="POSIX"
LC_ADDRESS="POSIX"
LC_TELEPHONE="POSIX"
LC_MEASUREMENT="POSIX"
LC_IDENTIFICATION="POSIX"
LC_ALL=
```

```
docker run -it --rm python:3.5 locale
LANG=C.UTF-8
LANGUAGE=
LC_CTYPE="C.UTF-8"
LC_NUMERIC="C.UTF-8"
LC_TIME="C.UTF-8"
LC_COLLATE="C.UTF-8"
LC_MONETARY="C.UTF-8"
LC_MESSAGES="C.UTF-8"
LC_PAPER="C.UTF-8"
LC_NAME="C.UTF-8"
LC_ADDRESS="C.UTF-8"
LC_TELEPHONE="C.UTF-8"
LC_MEASUREMENT="C.UTF-8"
LC_IDENTIFICATION="C.UTF-8"
LC_ALL=
```