### PR TITLE
Bring job["log"] back in v1 API

### DIFF
--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -612,8 +612,21 @@ def GetJobDetail(userName, jobId):
                 userName, ResourceType.VC, jobs[0]["vcName"],
                 Permission.Collaborator):
             job = jobs[0]
+            job["log"] = ""
             if "jobDescription" in job:
                 job.pop("jobDescription", None)
+            if not elasticsearch_deployed or config.get('__extract_job_log_legacy', False):
+                try:
+                    log = dataHandler.GetJobTextField(jobId, "jobLog")
+                    try:
+                        if isBase64(log):
+                            log = base64decode(log)
+                    except Exception:
+                        pass
+                    if log is not None:
+                        job["log"] = log
+                except Exception:
+                    job["log"] = "fail-to-get-logs"
     dataHandler.Close()
     return job
 


### PR DESCRIPTION
Ref: https://github.com/microsoft/DLWorkspace/pull/784/files#diff-1d886fc19ee0a084ef132f0fb1b00133L689-L712


Note: if there is no elasticsearch deployed or `__extract_job_log_legacy` set, jobmanager will write active job log to db and jobdetail v1 will response with logs, otherwise jobdetail will have `job["log"] = ""`