### PR TITLE
add __get_job_log_legacy

### DIFF
--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -83,6 +83,9 @@ elasticsearch:
 {% if cnf["__extract_job_log_legacy"] %}
 __extract_job_log_legacy: True
 {% endif %}
+{% if cnf["__get_job_log_legacy"] %}
+__get_job_log_legacy: True
+{% endif %}
 job_mountpoints: {{cnf["job_mountpoints"]}}
 
 {% if cnf["job_resource_policy"] %}

--- a/src/ClusterManager/joblog_manager.py
+++ b/src/ClusterManager/joblog_manager.py
@@ -35,7 +35,7 @@ def create_log(logdir='/var/log/dlworkspace'):
 
 
 _get_job_log_enabled = config.get('logging') in ['azure_blob', 'elasticsearch']
-_extract_job_log_legacy = not _get_job_log_enabled or config.get('__extract_job_log_legacy', False)
+_extract_job_log_legacy = config.get('__extract_job_log_legacy', not _get_job_log_enabled)
 
 
 def extract_job_log(job_id, log_path, user_id):

--- a/src/ClusterManager/joblog_manager.py
+++ b/src/ClusterManager/joblog_manager.py
@@ -34,13 +34,12 @@ def create_log(logdir='/var/log/dlworkspace'):
         logging.config.dictConfig(logging_config)
 
 
-_use_legacy = config.get('logging') not in [
-    'azure_blob', 'elaticsearch'
-] or config.get('__extract_job_log_legacy', False)
+_get_job_log_enabled = config.get('logging') in ['azure_blob', 'elasticsearch']
+_extract_job_log_legacy = not _get_job_log_enabled or config.get('__extract_job_log_legacy', False)
 
 
 def extract_job_log(job_id, log_path, user_id):
-    if not _use_legacy:
+    if not _extract_job_log_legacy:
         _extract_job_log(job_id, log_path, user_id)
     else:
         _extract_job_log_legacy(job_id, log_path, user_id)

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -600,7 +600,7 @@ def isBase64(s):
 
 _get_job_log_enabled = config.get('logging') in ['azure_blob', 'elasticsearch']
 _extract_job_log_legacy = config.get('__extract_job_log_legacy', not _get_job_log_enabled)
-_get_job_log_legacy = config.get('__get_job_log_legacy', False)
+_get_job_log_legacy = config.get('__get_job_log_legacy', _extract_job_log_legacy)
 
 
 def GetJobDetail(userName, jobId):

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -598,6 +598,10 @@ def isBase64(s):
         pass
     return False
 
+_get_job_log_enabled = config.get('logging') in ['azure_blob', 'elasticsearch']
+_extract_job_log_legacy = config.get('__extract_job_log_legacy', False) or not _get_job_log_enabled
+_get_job_log_legacy = config.get('__get_job_log_legacy', False)
+
 
 def GetJobDetail(userName, jobId):
     job = None
@@ -611,7 +615,7 @@ def GetJobDetail(userName, jobId):
             job["log"] = ""
             if "jobDescription" in job:
                 job.pop("jobDescription", None)
-            if not _get_job_log_enabled or _get_job_legacy:
+            if _extract_job_log_legacy:
                 try:
                     log = dataHandler.GetJobTextField(jobId, "jobLog")
                     try:
@@ -656,11 +660,6 @@ def GetJobStatus(jobId):
     dataHandler.Close()
     return result
 
-
-_get_job_log_enabled = config.get('logging') in ['azure_blob', 'elasticsearch']
-_get_job_legacy = config.get('__extract_job_log_legacy', False)
-
-
 def GetJobLog(userName, jobId, cursor=None, size=100):
     dataHandler = DataHandler()
     jobs = dataHandler.GetJob(jobId=jobId)
@@ -668,7 +667,7 @@ def GetJobLog(userName, jobId, cursor=None, size=100):
         if jobs[0]["userName"] == userName or AuthorizationManager.HasAccess(
                 userName, ResourceType.VC, jobs[0]["vcName"],
                 Permission.Collaborator):
-            if _get_job_legacy:
+            if _get_job_log_legacy:
                 try:
                     log = dataHandler.GetJobTextField(jobId, "jobLog")
                     try:

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -599,7 +599,7 @@ def isBase64(s):
     return False
 
 _get_job_log_enabled = config.get('logging') in ['azure_blob', 'elasticsearch']
-_extract_job_log_legacy = config.get('__extract_job_log_legacy', False) or not _get_job_log_enabled
+_extract_job_log_legacy = config.get('__extract_job_log_legacy', not _get_job_log_enabled)
 _get_job_log_legacy = config.get('__get_job_log_legacy', False)
 
 


### PR DESCRIPTION
## `__extract_job_log_legacy`

- default: whether there is no back-ends configured
- If true: use database to store job log
  - joblog_manager: write logs from kubectl, to database / NFS
  - GetJobDetail: fetch `job['log']` from database
- If false: do not use database to store job log
  - joblog_manager: write logs from back-end to NFS, controlled by jobLogCursor
  - GetJobDetail: left `job['log']` as empty string

## `__get_jog_log_legacy`

- default: `_extract_job_log_legacy`
- If true: GetJobLog fetches logs from database
- If false: GetJobLog fetches logs from logging backend