### PR TITLE
Fix console refresh interval

### DIFF
--- a/src/dashboard/src/pages/JobV2/Tabs/Console.tsx
+++ b/src/dashboard/src/pages/JobV2/Tabs/Console.tsx
@@ -82,7 +82,7 @@ ${log[podName]}
     if (loading) return;
 
     const cursor = data && data.cursor;
-    const delay = error ? 3000 : 0;
+    const delay = error || cursor == null ? 3000 : 0;
     const querystring = cursor && `?cursor=${encodeURIComponent(cursor)}`;
     const timeout = setTimeout(get, delay, querystring);
     return () => {
@@ -112,7 +112,7 @@ ${log[podName]}
       <CodeBlock>
         {logText}
       </CodeBlock>
-      {error === undefined && <Loading/>}
+      {loading && <Loading/>}
     </Box>
   );
 }


### PR DESCRIPTION
Will fetch more logs immediatly if and only if
there is no error and the cursor is not null (not in  full log mode).