### PR TITLE
should setup sshd first before start sshd

### DIFF
--- a/src/init-scripts/bootstrap.sh
+++ b/src/init-scripts/bootstrap.sh
@@ -28,7 +28,6 @@ fi
 set -e
 
 bash ${CWD}/init_user.sh
-bash ${CWD}/setup_sshd.sh
 bash ${CWD}/setup_ssh_config.sh
 
 echo bootstrap ends at `date`

--- a/src/init-scripts/setup_ssh_config.sh
+++ b/src/init-scripts/setup_ssh_config.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 set -x
 
+CWD=$(dirname $0)
+
 # generate ps host list
 ps_host_list=""
 for i in $(seq 0 $(( ${DLTS_NUM_PS} - 1 )) )
@@ -136,6 +138,8 @@ ${host} slots=${slots}
 EOF
     done
 fi
+
+bash ${CWD}/setup_sshd.sh
 
 # make sure worker have sshd up and running
 if [ "$DLTS_ROLE_NAME" = "ps" ];


### PR DESCRIPTION
The way we manage ssh endpoint may have conflict with init script setup. The endpoint manager may start to setup sshd before setup_ssh_config. But the odd is quite small.

Should also check in endpoint manager if the sshd is already setup before calling `service ssh start`. 