### PR TITLE
Maintaindb

### DIFF
--- a/src/ClusterBootstrap/deploy.sh
+++ b/src/ClusterBootstrap/deploy.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-rm -rf deploy/!\(bin\) cloudinit* !\(config\).yaml
+shopt -s extglob
+rm -rf deploy/!(bin) cloudinit* !(config).yaml
 # prepare clusterID
 ./cloud_init_deploy.py clusterID
 # render a machine list which is to be deployed


### PR DESCRIPTION
support more convenient database interaction,
might need to add columns_to_ignore to dumped yaml before pushing.
e.g.
```
./ctl.py db connect
./ctl.py db pull vc
```
(edit vc.yaml)
```
./ctl.py db push vc
```

TODO: this is 1st version, use in backend.
It's also necessary to have a restfulapi version (admin tool)