### PR TITLE
Fix log blob fetching rule when there are >= 10 blobs

### DIFF
--- a/src/docker-images/azure-blob-adapter/wsgi.py
+++ b/src/docker-images/azure-blob-adapter/wsgi.py
@@ -64,11 +64,11 @@ def application(request):
                     #   P4. [Full, ..., ->Full<-]
                     if blob_name == tag:
                         # Fist blob is full: P1, P2 or P3
-                        blob_names = append_blob_service.list_blob_names(
+                        blobs = append_blob_service.list_blobs(
                             container_name=container_name,
                             prefix=tag)
-                        blob_names = list(blob_names)
-                        if len(blob_names) == 1:
+                        blobs = list(blobs)
+                        if len(blobs) == 1:
                             # P1: make it [Full, ->New<-]
                             blob_name = tag + '.1'
                             append_blob_service.create_blob(
@@ -77,7 +77,8 @@ def application(request):
                             continue
                         else:
                             # P2 or P3: point to the last one and retry
-                            blob_name = blob_names[-1]
+                            blob = max(blobs, key=lambda blob: blob.properties.last_modified)
+                            blob_name = blob.name
                             continue
                     else:
                         # P4: make it [Full, ..., Full, ->New<-]

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -44,7 +44,7 @@ if config.get("logging") == 'azure_blob':
                 if len(blobs) == 0:
                     return ({}, None)
 
-                blob = blobs[-1]
+                blob = max(blobs, key=lambda blob: blob.properties.last_modified)
                 start_range = max(0, blob.properties.content_length - CHUNK_SIZE)
                 chunk = append_blob_service.get_blob_to_bytes(
                     container_name=container_name,
@@ -53,7 +53,7 @@ if config.get("logging") == 'azure_blob':
                 content = chunk.content.decode(
                     encoding='utf-8', errors='ignore')
 
-                content_lines = content.split('\n')
+                content_lines = content.splitlines()
                 for i, content_line in enumerate(content_lines, 1):
                     try:
                         line = loads(content_line)
@@ -62,7 +62,7 @@ if config.get("logging") == 'azure_blob':
                         if i == 1:
                             # Normal case, invalid JSON at the start of the log:
                             #     Directly continue to next line
-                            pass
+                            continue
 
                         # Bad case, invalid JSON in the middle / tail of the log:
                         #     Log it down and parse next lines


### PR DESCRIPTION
Azure blob API returns blobs order by name but not by creation / updated time, when there are more than 10 blobs, the list is

    [
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b'
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b.1'
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b.10'
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b.2'
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b.3'
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b.4'
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b.5'
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b.6'
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b.7'
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b.8'
      'jobs.f01f216f-e209-4903-8600-d8242c633b4b.9'
    ]

which the `.10` should be chose.