### PR TITLE
Add / adjust resource limits of logging components.

### DIFF
--- a/src/ClusterBootstrap/services/logging/fluent-bit.yaml
+++ b/src/ClusterBootstrap/services/logging/fluent-bit.yaml
@@ -28,7 +28,8 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            memory: 256Mi
+            cpu: 100m
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi
@@ -64,6 +65,13 @@ spec:
       - name: azure-blob-adapter
         image: '{{cnf["worker-dockerregistry"]}}/{{cnf["dockerprefix"]}}/azure-blob-adapter:{{cnf["dockertag"]}}'
         imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
         ports:
         - containerPort: {{cnf["azure_blob_log"]["port"]["adapter"]}}
         env:

--- a/src/ClusterBootstrap/services/logging/fluent-bit.yaml
+++ b/src/ClusterBootstrap/services/logging/fluent-bit.yaml
@@ -61,6 +61,11 @@ spec:
           readOnly: true
         - name: fluent-bit-config
           mountPath: /fluent-bit/etc/
+        livenessProbe:
+          httpGet:
+            host: '127.0.0.1'
+            port: {{cnf["fluent_bit"]["port"]}}
+            path: /healthz
       {% if cnf["azure_blob_log"]["enabled"] -%}
       - name: azure-blob-adapter
         image: '{{cnf["worker-dockerregistry"]}}/{{cnf["dockerprefix"]}}/azure-blob-adapter:{{cnf["dockertag"]}}'


### PR DESCRIPTION
Data is fetched from dev cluster without (temporarily) any limits:

| Container          | Minimum     | Maximum        |
| ------------------ | ----------- | -------------- |
| fluent-bit         | 29087498.24 | 3321083461.632 |
| azure-blob-adapter |  46609203.2 |      108003328 |

Minimum data is from the general worker.
Maximum data is from the worker with `long long logs` running.