### PR TITLE
[RepairManager] add RepairManagerAgent service

### DIFF
--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -62,7 +62,9 @@ default_config_parameters = {
         "prometheus-ip": "localhost",
         "prometheus-port": 9091,
         "etcd": {
-            "data-dir": "/etc/RepairManager/etcd"
+            "data-dir": "/etc/RepairManager/etcd",
+            "peer-port": 2381,
+            "client-port": 2382
         }
     },
 
@@ -91,6 +93,7 @@ default_config_parameters = {
     "storagemanager": "storagemanager",
     "repairmanager": "repairmanager",
     "repairmanageretcd": "repairmanageretcd",
+    "repairmanageragent": "repairmanageragent",
     "ssh_cert": "./deploy/sshkey/id_rsa",
     "admin_username": "core",
     # the path of where dfs/nfs is source linked and consumed on each node,
@@ -697,7 +700,7 @@ default_config_parameters = {
         # There is no udp port requirement for now
         #"udp_port_ranges": "25826",
         "inter_connect": {
-            "tcp_port_ranges": "22 1443 2379 3306 5000 8086 9092 9114 9200 9300 10250",
+            "tcp_port_ranges": "22 1443 2379 2382 3306 5000 8086 9092 9114 9200 9300 10250",
             # Need to white list dev machines to connect
             # "source_addresses_prefixes": [ "52.151.0.0/16"]
         },

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -293,6 +293,7 @@ default_config_parameters = {
         'worker': {
             "worker": "active",
             "beta.kubernetes.io/os": "linux",
+            "repairmanageragent": "active"
             },
         'mysqlserver': {
             "mysql-server": "active"

--- a/src/ClusterBootstrap/services/repairmanageragent/launch_order
+++ b/src/ClusterBootstrap/services/repairmanageragent/launch_order
@@ -1,0 +1,1 @@
+repairmanageragent.yaml

--- a/src/ClusterBootstrap/services/repairmanageragent/repairmanageragent.yaml
+++ b/src/ClusterBootstrap/services/repairmanageragent/repairmanageragent.yaml
@@ -1,0 +1,90 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: repairmanageragent
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      repairmanageragent-node: pod
+  template:
+    metadata:
+      name: repairmanageragent
+      labels:
+        repairmanageragent-node: pod
+        app: repairmanageragent
+    spec:
+      {% if cnf["dnsPolicy"] %}
+      dnsPolicy: {{cnf["dnsPolicy"]}}
+      {% endif %}
+      hostPID: true
+      nodeSelector:
+        repairmanageragent: active
+      containers:
+      - name: repairmanageragent
+        image: {{cnf["worker-dockerregistry"]}}/{{cnf["dockerprefix"]}}/{{cnf["repairmanageragent"]}}:{{cnf["dockertag"]}}
+        securityContext:
+          capabilities:
+            add: ["SYS_BOOT"]
+        command: ["/run.sh"]
+        imagePullPolicy: Always
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ETCD_SERVER
+          value: "{{cnf['kubernetes_master_node'][0]}}"
+        - name: ETCD_PORT
+          value: "{{cnf['repair-manager']['etcd']['client-port']}}"
+        volumeMounts:
+        - mountPath: /etc/kubernetes/ssl
+          name: certs
+        - mountPath: /etc/kubernetes/restapi-kubeconfig.yaml
+          name: kubeconfig
+        - mountPath: {{cnf["storage-mount-path"]}}/work
+          name: dlwsdatawork
+        - mountPath: {{cnf["storage-mount-path"]}}/storage
+          name: dlwsdatadata
+        - mountPath: {{cnf["storage-mount-path"]}}/jobfiles
+          name: dlwsdatajobfiles
+        - mountPath: {{cnf["dltsdata-storage-mount-path"]}}
+          name: dltsdata
+        - mountPath: {{cnf["folder_auto_share"]}}
+          name: folderautoshare
+        - mountPath: /var/log/dlworkspace
+          name: log
+      {% if cnf["private_docker_registry_username"] %}
+      imagePullSecrets:
+      - name: svccred
+      {% endif %}
+      volumes:
+      - name: certs
+        hostPath:
+          path: /etc/kubernetes/ssl
+      - name: kubeconfig
+        hostPath:
+          path: /etc/kubernetes/restapi-kubeconfig.yaml
+      - name: dlwsdatawork
+        hostPath:
+          path: {{cnf["storage-mount-path"]}}/work
+      - name: dlwsdatadata
+        hostPath:
+          path: {{cnf["storage-mount-path"]}}/storage
+      - name: dlwsdatajobfiles
+        hostPath:
+          path: {{cnf["storage-mount-path"]}}/jobfiles
+      - name: dltsdata
+        hostPath:
+          path: {{cnf["dltsdata-storage-mount-path"]}}
+      - name: folderautoshare
+        hostPath:
+          path: {{cnf["folder_auto_share"]}}
+      - name: log
+        hostPath:
+          path: /var/log/clustermanager
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule

--- a/src/ClusterBootstrap/services/repairmanageragent/repairmanageragent.yaml
+++ b/src/ClusterBootstrap/services/repairmanageragent/repairmanageragent.yaml
@@ -82,7 +82,7 @@ spec:
           path: {{cnf["folder_auto_share"]}}
       - name: log
         hostPath:
-          path: /var/log/clustermanager
+          path: /var/log/dlworkspace
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/src/RepairManagerAgent/commands.py
+++ b/src/RepairManagerAgent/commands.py
@@ -1,0 +1,5 @@
+import os
+
+def reboot_node():
+    os.system('sync')
+    os.system('reboot -f')

--- a/src/RepairManagerAgent/etcd_util.py
+++ b/src/RepairManagerAgent/etcd_util.py
@@ -1,0 +1,33 @@
+import requests
+import logging
+import commands
+
+def check_for_reboot_signal(etcd_url, node_name):
+    key = f'{node_name}/reboot'
+    reboot_url = f'{etcd_url}/{key}'
+
+    try:
+        response = requests.get(reboot_url, timeout=5)
+        r_json = response.json()
+
+        if r_json is not None:
+            logging.debug(r_json)
+
+        if 'node' in r_json and \
+            r_json['node']['key'] == f'/{key}':
+
+            value = r_json['node']['value']
+
+            if value == 'True':
+                # delete the key before attempting to reboot
+                requests.delete(reboot_url)
+                logging.warning("!!!Rebooting the node!!!")
+                commands.reboot_node()
+
+            if value == 'DryRun':
+                requests.delete(reboot_url)
+                logging.warning("Dry-Run request to reboot the node received")
+
+    except:
+        logging.exception(f'Error retrieving data from {reboot_url}')
+

--- a/src/RepairManagerAgent/logging.yaml
+++ b/src/RepairManagerAgent/logging.yaml
@@ -14,7 +14,7 @@ handlers:
     class : logging.handlers.RotatingFileHandler
     formatter: simple
     filename: /var/log/dlworkspace/repairmanageragent.log
-    # roll over at 10MB
+    # roll over at 100MB
     maxBytes: 102400000
     # At most 10 logging files
     backupCount: 10

--- a/src/RepairManagerAgent/logging.yaml
+++ b/src/RepairManagerAgent/logging.yaml
@@ -1,0 +1,28 @@
+---
+version: 1
+disable_existing_loggers: False
+formatters:
+  simple:
+    format: '%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s'
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: simple
+    stream: ext://sys.stdout
+  file:
+    class : logging.handlers.RotatingFileHandler
+    formatter: simple
+    filename: repairmanageragent.log
+    # roll over at 10MB
+    maxBytes: 10240000
+    # At most 10 logging files
+    backupCount: 10
+loggers:
+  basic:
+    level: DEBUG
+    handlers: ['console','file']
+    propagate: no
+root:
+  level: DEBUG
+  handlers: ['console','file']

--- a/src/RepairManagerAgent/logging.yaml
+++ b/src/RepairManagerAgent/logging.yaml
@@ -16,6 +16,8 @@ handlers:
     filename: /var/log/dlworkspace/repairmanageragent.log
     # roll over at 10MB
     maxBytes: 102400000
+    # At most 10 logging files
+    backupCount: 10
 loggers:
   basic:
     level: DEBUG

--- a/src/RepairManagerAgent/logging.yaml
+++ b/src/RepairManagerAgent/logging.yaml
@@ -13,11 +13,9 @@ handlers:
   file:
     class : logging.handlers.RotatingFileHandler
     formatter: simple
-    filename: repairmanageragent.log
+    filename: /var/log/dlworkspace/repairmanageragent.log
     # roll over at 10MB
-    maxBytes: 10240000
-    # At most 10 logging files
-    backupCount: 10
+    maxBytes: 102400000
 loggers:
   basic:
     level: DEBUG

--- a/src/RepairManagerAgent/main.py
+++ b/src/RepairManagerAgent/main.py
@@ -17,24 +17,31 @@ def reboot_node():
 
 def Run():
     while True:
-        logger.debug('Polling ETCD...')
-        reboot_key = "worker0/reboot"
-        etcd_ip = "INSERT_IP_HERE"
-        url = f'http://{etcd_ip}:INSERT_PORT_HERE/v2/keys'
-        response = requests.get(f'{url}/{reboot_key}')
-        r_json = response.json()
-        logger.debug(r_json)
-        
-        if 'node' in r_json and 'key' in r_json['node']:
-            value = r_json['node']['value']
-            if value == 'True':
-                requests.put(f'{url}/{reboot_key}', data={'value':'False'})
-                logger.debug("Attempting to reboot the node!")
-                #reboot_node()
-        else:
-            logger.debug(r_json)
+        etcd_server = os.environ["ETCD_SERVER"]
+        etcd_port = os.environ["ETCD_PORT"]
+        node_name = os.environ["NODE_NAME"]
+        etcd_url = f'http://{etcd_server}:{etcd_port}/v2/keys/{node_name}/reboot'
+        logger.debug(etcd_url)
+
+        try: 
+            response = requests.get(etcd_url, timeout=5)
+            r_json = response.json()
+
+            if r_json is not None:
+                logger.debug(r_json)
+
+                if 'node' in r_json and 'key' in r_json['node']:
+                    value = r_json['node']['value']
+                    if value == 'True':
+                        requests.put(f'{etcd_url}', data={'value':'False'})
+
+                        logger.debug("Attempting to reboot the node!")
+                        reboot_node()
+        except:
+            logger.exception(f'Error retrieving data from {etcd_url}')
 
         time.sleep(5)
+
 
 if __name__ == '__main__':
     Run()

--- a/src/RepairManagerAgent/main.py
+++ b/src/RepairManagerAgent/main.py
@@ -1,0 +1,40 @@
+import requests
+import time
+import yaml
+import logging
+import logging.config
+import os
+
+with open('./logging.yaml', 'r') as log_file:
+    log_config = yaml.safe_load(log_file)
+
+logging.config.dictConfig(log_config)
+logger = logging.getLogger(__name__)
+
+def reboot_node():
+    os.system('sync')
+    os.system('reboot -f')
+
+def Run():
+    while True:
+        logger.debug('Polling ETCD...')
+        reboot_key = "worker0/reboot"
+        etcd_ip = "INSERT_IP_HERE"
+        url = f'http://{etcd_ip}:INSERT_PORT_HERE/v2/keys'
+        response = requests.get(f'{url}/{reboot_key}')
+        r_json = response.json()
+        logger.debug(r_json)
+        
+        if 'node' in r_json and 'key' in r_json['node']:
+            value = r_json['node']['value']
+            if value == 'True':
+                requests.put(f'{url}/{reboot_key}', data={'value':'False'})
+                logger.debug("Attempting to reboot the node!")
+                #reboot_node()
+        else:
+            logger.debug(r_json)
+
+        time.sleep(5)
+
+if __name__ == '__main__':
+    Run()

--- a/src/RepairManagerAgent/main.py
+++ b/src/RepairManagerAgent/main.py
@@ -16,13 +16,13 @@ def reboot_node():
     os.system('reboot -f')
 
 def Run():
-    while True:
-        etcd_server = os.environ["ETCD_SERVER"]
-        etcd_port = os.environ["ETCD_PORT"]
-        node_name = os.environ["NODE_NAME"]
-        etcd_url = f'http://{etcd_server}:{etcd_port}/v2/keys/{node_name}/reboot'
-        logger.debug(etcd_url)
+    etcd_server = os.environ["ETCD_SERVER"]
+    etcd_port = os.environ["ETCD_PORT"]
+    node_name = os.environ["NODE_NAME"]
+    etcd_url = f'http://{etcd_server}:{etcd_port}/v2/keys/{node_name}/reboot'
+    logger.debug(etcd_url)
 
+    while True:
         try: 
             response = requests.get(etcd_url, timeout=5)
             r_json = response.json()
@@ -33,9 +33,9 @@ def Run():
                 if 'node' in r_json and 'key' in r_json['node']:
                     value = r_json['node']['value']
                     if value == 'True':
-                        requests.put(f'{etcd_url}', data={'value':'False'})
+                        requests.put(etcd_url, data={'value':'False'})
 
-                        logger.debug("Attempting to reboot the node!")
+                        logger.warning("Attempting to reboot the node!")
                         reboot_node()
         except:
             logger.exception(f'Error retrieving data from {etcd_url}')

--- a/src/RepairManagerAgent/main.py
+++ b/src/RepairManagerAgent/main.py
@@ -1,9 +1,9 @@
-import requests
 import time
 import yaml
 import logging
 import logging.config
 import os
+import etcd_util
 
 with open('./logging.yaml', 'r') as log_file:
     log_config = yaml.safe_load(log_file)
@@ -11,35 +11,17 @@ with open('./logging.yaml', 'r') as log_file:
 logging.config.dictConfig(log_config)
 logger = logging.getLogger(__name__)
 
-def reboot_node():
-    os.system('sync')
-    os.system('reboot -f')
 
 def Run():
     etcd_server = os.environ["ETCD_SERVER"]
     etcd_port = os.environ["ETCD_PORT"]
     node_name = os.environ["NODE_NAME"]
-    key = f'{node_name}/reboot'
-    etcd_url = f'http://{etcd_server}:{etcd_port}/v2/keys/{key}'
+    etcd_url = f'http://{etcd_server}:{etcd_port}/v2/keys'
     logger.debug(etcd_url)
 
     while True:
-        try: 
-            response = requests.get(etcd_url, timeout=5)
-            r_json = response.json()
 
-            if r_json is not None:
-                logger.debug(r_json)
-
-                if 'node' in r_json and \
-                r_json['node']['key'] == f'/{key}' and \
-                r_json['node']['value'] == 'True':
-                    # delete the key before attempting to reboot
-                    requests.delete(etcd_url)
-                    logger.warning("!!!Attempting to reboot the node!!!")
-                    reboot_node()
-        except:
-            logger.exception(f'Error retrieving data from {etcd_url}')
+        etcd_util.check_for_reboot_signal(etcd_url, node_name)
 
         time.sleep(5)
 

--- a/src/RepairManagerAgent/tests/test_main.py
+++ b/src/RepairManagerAgent/tests/test_main.py
@@ -1,7 +1,0 @@
-import unittest
-import mock
-
-class TestRepairManagerAgent(unittest.TestCase):
-
-    def test_repairmanager_agent(self):
-        self.assertTrue(True)

--- a/src/RepairManagerAgent/tests/test_main.py
+++ b/src/RepairManagerAgent/tests/test_main.py
@@ -1,0 +1,7 @@
+import unittest
+import mock
+
+class TestRepairManagerAgent(unittest.TestCase):
+
+    def test_repairmanager_agent(self):
+        self.assertTrue(True)

--- a/src/docker-images/RepairManagerAgent/Dockerfile
+++ b/src/docker-images/RepairManagerAgent/Dockerfile
@@ -1,15 +1,10 @@
-FROM ubuntu:18.04
+FROM python:3.7
 MAINTAINER Deborah Sandoval <Deborah.Sandoval@microsoft.com>
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
-    python3.5 \
-    python3-pip \
     systemd-sysv
 
-RUN pip3 install wheel
-RUN pip3 install setuptools
-RUN pip3 install requests
-RUN pip3 install pyyaml
+RUN pip3 install wheel setuptools requests pyyaml
 
 COPY run.sh /
 RUN chmod +x /run.sh

--- a/src/docker-images/RepairManagerAgent/Dockerfile
+++ b/src/docker-images/RepairManagerAgent/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:18.04
+MAINTAINER Deborah Sandoval <Deborah.Sandoval@microsoft.com>
+
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    python3.5 \
+    python3-pip \
+    systemd-sysv
+
+RUN pip3 install wheel
+RUN pip3 install setuptools
+RUN pip3 install requests
+RUN pip3 install pyyaml
+
+COPY run.sh /
+RUN chmod +x /run.sh
+
+ADD RepairManagerAgent /DLWorkspace/src/RepairManagerAgent
+
+CMD /run.sh

--- a/src/docker-images/RepairManagerAgent/prebuild.sh
+++ b/src/docker-images/RepairManagerAgent/prebuild.sh
@@ -1,0 +1,5 @@
+#!/bin/bash 
+# This command will be executed under directory 
+# src/ClusterBootstrap/deploy/docker-images/.../
+rm -rf RepairManagerAgent
+cp -r ../../../../RepairManagerAgent RepairManagerAgent

--- a/src/docker-images/RepairManagerAgent/run.sh
+++ b/src/docker-images/RepairManagerAgent/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /DLWorkspace/src/RepairManagerAgent/
+python3 main.py


### PR DESCRIPTION
The repair-manager agent runs on each worker node, polling etcd for signal to reboot.

When reboot signal is found, repairmanager agent deletes the key and reboots the node. The repairmanager agent pod will return when the node is back up and running (This takes a few minutes). There is also dry-run capability.

@hongzhili @Anbang-Hu @YinYangOfDao @xudifsd 

![MicrosoftTeams-image](https://user-images.githubusercontent.com/8230841/79671556-dc97ff80-817f-11ea-8b15-8f3945600f5d.png)
