### PR TITLE
[RepairManager] ECCRebootNodeRule

### DIFF
--- a/src/ClusterBootstrap/services/repairmanager/repairmanager.yaml
+++ b/src/ClusterBootstrap/services/repairmanager/repairmanager.yaml
@@ -79,7 +79,7 @@ spec:
           path: {{cnf["folder_auto_share"]}}
       - name: log
         hostPath:
-          path: /var/log/clustermanager
+          path: /var/log/dlworkspace
       - name: repairmanagerdata
         hostPath:
           path: /etc/RepairManager

--- a/src/ClusterBootstrap/services/repairmanager/repairmanager.yaml
+++ b/src/ClusterBootstrap/services/repairmanager/repairmanager.yaml
@@ -25,9 +25,6 @@ spec:
         image: {{cnf["worker-dockerregistry"]}}/{{cnf["dockerprefix"]}}/{{cnf["repairmanager"]}}:{{cnf["dockertag"]}}
         command: ["/run.sh"]
         imagePullPolicy: Always
-        env:
-        - name: PROMETHEUS_URL
-          value: http://{{cnf["repair-manager"]["prometheus-ip"]}}:{{cnf["repair-manager"]["prometheus-port"]}}
         volumeMounts:
         - mountPath: /etc/kubernetes/ssl
           name: certs

--- a/src/RepairManager/actions/reboot_node_action.py
+++ b/src/RepairManager/actions/reboot_node_action.py
@@ -1,0 +1,40 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+import logging
+import requests
+from action_abc import Action
+
+class RebootNodeAction(Action):
+
+    def __init__(self):
+        self.action_logger = logging.getLogger('activity')
+
+    def execute(self, node_name, etcd_config, dry_run=False):
+        etcd_url = etcd_config["advertise-client-urls"]
+        key = f'{node_name}/reboot'
+        success = False
+        try:
+            if dry_run:
+                value = 'DryRun'
+            else:
+                value = 'True'
+
+            response = requests.put(f'{etcd_url}/{key}', data={'value': value})
+            r_json = response.json()
+            if  "node" in r_json and \
+                r_json["node"]["key"] == f'/{key}' and \
+                r_json["node"]["value"] == value:
+                success = True
+
+        except:
+            logging.exception(f'Error sending reboot signal for node {node_name}')
+
+        self.action_logger.info({
+            "action": "reboot",
+            "node": node_name,
+            "dry_run": dry_run,
+            "success": success
+            })
+
+        return success

--- a/src/RepairManager/actions/reboot_node_action.py
+++ b/src/RepairManager/actions/reboot_node_action.py
@@ -11,7 +11,7 @@ class RebootNodeAction(Action):
         self.action_logger = logging.getLogger('activity')
 
     def execute(self, node_name, etcd_config, dry_run=False):
-        etcd_url = etcd_config["advertise-client-urls"]
+        etcd_url = etcd_url = f'{etcd_config["advertise-client-urls"]}/v2/keys'
         key = f'{node_name}/reboot'
         success = False
         try:

--- a/src/RepairManager/actions/uncordon_action.py
+++ b/src/RepairManager/actions/uncordon_action.py
@@ -1,0 +1,22 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+import logging
+from action_abc import Action
+from utils import k8s_util
+
+class UncordonAction(Action):
+
+    def __init__(self):
+        self.action_logger = logging.getLogger('activity')
+
+    def execute(self, node_name, dry_run=False):
+        uncordon_status = k8s_util.uncordon_node(node_name, dry_run=dry_run)
+
+        self.action_logger.info({
+            "action": "uncordon",
+            "node": node_name,
+            "dry_run": dry_run,
+            "status": uncordon_status
+            })
+        return uncordon_status

--- a/src/RepairManager/logging.yaml
+++ b/src/RepairManager/logging.yaml
@@ -13,7 +13,7 @@ handlers:
   file:
     class : logging.handlers.RotatingFileHandler
     formatter: simple
-    filename: repairmanager.log
+    filename: /var/log/dlworkspace/repairmanager.log
     # roll over at 10MB
     maxBytes: 10240000
     # At most 10 logging files

--- a/src/RepairManager/rules/ecc_detect_error_rule.py
+++ b/src/RepairManager/rules/ecc_detect_error_rule.py
@@ -124,7 +124,7 @@ class EccDetectErrorRule(Rule):
                 node_name=node_name,
                 dry_run=cordon_dry_run)
 
-        impacted_jobs = k8s_util.get_job_info_from_nodes(
+        impacted_jobs = k8s_util.get_job_info_indexed_by_job_id(
             nodes=self.new_bad_nodes,
             portal_url=self.config['portal_url'],
             cluster_name=self.config['cluster_name'])

--- a/src/RepairManager/rules/ecc_reboot_node_rule.py
+++ b/src/RepairManager/rules/ecc_reboot_node_rule.py
@@ -8,6 +8,7 @@ import requests
 import time
 from actions.migrate_job_action import MigrateJobAction
 from actions.send_alert_action import SendAlertAction
+from actions.reboot_node_action import RebootNodeAction
 from datetime import datetime, timedelta, timezone
 from rules_abc import Rule
 from utils import prometheus_util, k8s_util
@@ -43,20 +44,6 @@ def _create_email_for_pause_resume_job(job_id, node_names, job_link, job_owner_e
     return message
 
 
-def _create_email_for_issue_with_pause_resume_job(unsuccessful_pause_resume_jobs):
-    message = MIMEMultipart()
-    message['Subject'] = 'Repair Manager Alert [Failed to Pause/Resume Job(s)]'
-    body = f'''<p>Repair manager failed to pause/resume the following job(s):</p>
-     <table border="1"><tr><th>Job Id</th><th>Job Owner</th><th>Node(s)</th></tr>'''
-    for job_id, job_info in unsuccessful_pause_resume_jobs.items():
-        body += f'''<tr><td><a href="{job_info['job_link']}">{job_id}</a></td>
-        <td>{job_info['user_name']}</td>
-        <td>{', '.join(job_info['node_names'])}</td></tr>'''
-    body += '</table><p> Please investigate so node(s) can be repaired.</p>'
-    message.attach(MIMEText(body, 'html'))
-    return message
-
-
 class EccRebootNodeRule(Rule):
 
     def __init__(self, alert, config):
@@ -64,110 +51,140 @@ class EccRebootNodeRule(Rule):
         self.alert = alert
         self.config = config
         self.ecc_config = self.load_ecc_config()
-        self.nodes_ready_for_action = []
+        self.etcd_config = self.load_etcd_config()
+        self.all_jobs_indexed_by_node = {}
+        self.nodes_ready_for_action = set()
+        self.jobs_ready_for_migration = {}
 
     def load_ecc_config(self):
         with open('/etc/RepairManager/config/ecc-config.yaml', 'r') as file:
             return yaml.safe_load(file)
 
+    def load_etcd_config(self):
+        with open('/etc/RepairManager/config/etcd.conf.yaml', 'r') as file:
+            return yaml.safe_load(file)
 
-    def check_status(self):
+    def check_if_nodes_have_rebooted(self):
+        # if node has been rebooted since ecc error initially detected,
+        # remove from rule_cache and mark as resolved
         url = f"http://{self.config['prometheus']['ip']}:{self.config['prometheus']['port']}"
         query = self.config['prometheus']['node_boot_time_query']
-        reboot_url = prometheus_util.format_url_query(url, query)
+        reboot_times_url = prometheus_util.format_url_query(url, query)
 
         try:
-            response = requests.get(reboot_url, timeout=10)
+            response = requests.get(reboot_times_url, timeout=10)
             if response:
                 reboot_data = response.json()
                 reboot_times = _extract_node_boot_time_info(reboot_data)
-                
-                # if node has been rebooted since ecc error first detected,
-                # remove from rule_cache
-                if self.rule in self.alert.rule_cache:
-                    remove_from_cache = []
-                    for node in self.alert.rule_cache[self.rule]:
-                        instance = self.alert.rule_cache[self.rule][node]["instance"]
-                        time_found_string = self.alert.rule_cache[self.rule][node]["time_found"]
-                        time_found_datetime = datetime.strptime(time_found_string, self.config['date_time_format'])
-                        last_reboot_time = reboot_times[instance]
-                        if last_reboot_time > time_found_datetime:
-                            remove_from_cache.append(node)
-                            activity_log.info({"action":"node marked as resolved","node":node})
-
-                    for node in remove_from_cache:
-                        self.alert.remove_from_rule_cache(self.rule, node)
+            bad_nodes = self.alert.get_rule_cache_keys(self.rule)
+            for node in bad_nodes:
+                instance = self.alert.get_rule_cache(self.rule, node)["instance"]
+                time_found_string = self.alert.get_rule_cache(self.rule, node)["time_found"]
+                time_found_datetime = datetime.strptime(time_found_string, self.config['date_time_format'])
+                last_reboot_time = reboot_times[instance]
+                if last_reboot_time > time_found_datetime:
+                    self.alert.remove_from_rule_cache(self.rule, node)
+                    activity_log.info({"action":"marked as resolved from incorrectable ecc error","node":node})
         except:
-            logging.exception(f'Error retrieving data from {reboot_url}')
+            logging.exception(f'Error checking if nodes have rebooted')
 
+    def check_for_nodes_with_no_jobs(self):
+        # if no jobs are running on node, take action on node
+        bad_nodes = self.alert.get_rule_cache_keys(self.rule)
+        self.all_jobs_indexed_by_node = k8s_util.get_job_info_indexed_by_node(
+           nodes=bad_nodes,
+           portal_url=self.config['portal_url'],
+           cluster_name=self.config['cluster_name'])
+        for node in bad_nodes:
+            node_has_no_jobs = node not in self.all_jobs_indexed_by_node
+            node_reboot_pending = 'reboot_requested' in self.alert.get_rule_cache(self.rule, node)
+            if node_has_no_jobs and not node_reboot_pending:
+                logging.debug(f'node {node} has no running jobs')
+                self.nodes_ready_for_action.add(node)
 
-        # if configured time has elapsed since first detection, take action on node (if not done already)
-        if self.rule in self.alert.rule_cache:
-            for node in self.alert.rule_cache[self.rule]:
-                cache_value = self.alert.get_rule_cache(self.rule, node)
-                if 'paused/resumed' not in cache_value:
-                    time_found_string = self.alert.rule_cache[self.rule][node]["time_found"]
-                    time_found_datetime = datetime.strptime(time_found_string, self.config['date_time_format'])
-                    delta = timedelta(days=self.ecc_config.get("days_until_node_reboot", 5))
-                    now = datetime.utcnow()
-                    if now - time_found_datetime > delta:
-                        logging.info(f'Configured time has passed for node {node}')
-                        self.nodes_ready_for_action.append(node)
+    def check_if_nodes_are_due_for_reboot(self):
+        # if configured time has elapsed since initial detection, take action on node
+        bad_nodes = self.alert.get_rule_cache_keys(self.rule)
+        for node in bad_nodes:
+            time_found_string = self.alert.rule_cache[self.rule][node]["time_found"]
+            time_found_datetime = datetime.strptime(time_found_string, self.config['date_time_format'])
+            delta = timedelta(days=self.ecc_config.get("days_until_node_reboot", 5))
+            now = datetime.utcnow()
+            node_reboot_pending = 'reboot_requested' in self.alert.get_rule_cache(self.rule, node)
+            if now - time_found_datetime > delta and not node_reboot_pending:
+                logging.debug(f'Configured time has passed for node {node}')
+                self.nodes_ready_for_action.add(node)
+                self.determine_jobs_to_be_migrated(node)
 
-        logging.debug(f"rule_cache: {json.dumps(self.alert.rule_cache, default=str)}")
-        return len(self.nodes_ready_for_action) > 0
+    def determine_jobs_to_be_migrated(self, node):
+        if node in self.all_jobs_indexed_by_node:
+            jobs_on_node = self.all_jobs_indexed_by_node[node]
+            for job in jobs_on_node:
+                job_id = job["job_id"]
+                if job_id not in self.jobs_ready_for_migration:
+                    self.jobs_ready_for_migration[job_id] = {
+                        "user_name": job["user_name"],
+                        "vc_name": job["vc_name"],
+                        "node_names": [node],
+                        "job_link": job["job_link"]
+                    }
+                else:
+                    self.jobs_ready_for_migration[job_id]["node_names"].append(node)
 
-
-    def take_action(self):
+    def migrate_jobs_and_alert_job_owners(self):
         alert_action = SendAlertAction(self.alert)
-        unsuccessful_pause_resume_jobs = {}
-        job_info = k8s_util.get_job_info_from_nodes(
-            nodes=self.nodes_ready_for_action,
-            portal_url=self.config['portal_url'],
-            cluster_name=self.config['cluster_name'])
+        max_attempts = self.ecc_config.get("attempts_for_pause_resume_jobs", 5)
+        wait_time = self.ecc_config.get("time_sleep_after_pausing", 30)
+        dry_run = not self.ecc_config["enable_reboot"]
 
-        for job_id in job_info:
-            job_owner = job_info[job_id]['user_name']
+        for job_id in self.jobs_ready_for_migration:
+            job = self.jobs_ready_for_migration[job_id]
+            job_owner = job['user_name']
             job_owner_email = f"{job_owner}@{self.config['job_owner_email_domain']}"
-            node_names = job_info[job_id]["node_names"]
-            job_link = job_info[job_id]['job_link']
+            node_names = job["node_names"]
+            job_link = job['job_link']
             rest_url = self.config["rest_url"]
-            max_attempts = self.ecc_config.get("attempts_for_pause_resume_jobs", 5)
-            wait_time = self.ecc_config.get("time_sleep_after_pausing", 30)
-            reboot_enabled = self.ecc_config["enable_reboot"]
 
             # migrate all jobs
-            reboot_dry_run = not reboot_enabled
             migrate_job = MigrateJobAction(rest_url, max_attempts)
             success = migrate_job.execute(
                 job_id=job_id,
                 job_owner_email=job_owner_email,
                 wait_time=wait_time, 
-                dry_run=reboot_dry_run)
+                dry_run=dry_run)
 
             # alert job owners
             if success:
-                    message = _create_email_for_pause_resume_job(job_id, node_names, job_link, job_owner_email)
-                    if not reboot_dry_run and self.ecc_config['enable_alert_job_owners']:
-                        alert_dry_run = False
-                    else:
-                        alert_dry_run = True
-                    alert_action.execute(
-                        message=message,
-                        dry_run=alert_dry_run,
-                        additional_log={"job_id":job_id,"job_owner":job_owner})
+                message = _create_email_for_pause_resume_job(job_id, node_names, job_link, job_owner_email)
+                alert_dry_run = dry_run or not self.ecc_config['enable_alert_job_owners']
+                alert_action.execute(
+                    message=message,
+                    dry_run=alert_dry_run,
+                    additional_log={"job_id":job_id,"job_owner":job_owner})
             else:
                 logging.warning(f"Could not pause/resume the following job: {job_id}")
-                unsuccessful_pause_resume_jobs[job_id] = job_info[job_id]
-            
-        if len(unsuccessful_pause_resume_jobs) > 0:
-            dri_message = _create_email_for_issue_with_pause_resume_job(unsuccessful_pause_resume_jobs)
-            alert_action.execute(dri_message, additional_log={"job_id":job_id,"job_owner":job_owner})
+                # skip rebooting the node this iteration
+                # and try again later
+                for node in node_names:
+                    self.nodes_ready_for_action.remove(node)
 
-        # TODO: reboot node and remove from cache
-
-        # update pause/resume status so action is not taken again
+    def reboot_bad_nodes(self):
+        reboot_action = RebootNodeAction()
         for node in self.nodes_ready_for_action:
-            cache_value = self.alert.get_rule_cache(self.rule, node)
-            cache_value['paused/resumed'] = True
-            self.alert.update_rule_cache(self.rule, node, cache_value)
+           success = reboot_action.execute(node, self.etcd_config)
+           if success:
+                # update reboot status so action is not taken again
+                cache_value = self.alert.get_rule_cache(self.rule, node)
+                cache_value['reboot_requested'] =  datetime.utcnow().strftime(self.config['date_time_format'])
+                self.alert.update_rule_cache(self.rule, node, cache_value)
+
+    def check_status(self):
+        self.check_if_nodes_have_rebooted()
+        self.check_for_nodes_with_no_jobs()
+        self.check_if_nodes_are_due_for_reboot()
+        return len(self.nodes_ready_for_action) > 0
+
+
+    def take_action(self):
+        self.migrate_jobs_and_alert_job_owners()
+        self.reboot_bad_nodes()

--- a/src/RepairManager/test/test_ecc_reboot_node_rule.py
+++ b/src/RepairManager/test/test_ecc_reboot_node_rule.py
@@ -167,6 +167,7 @@ class TestEccRebootNodeRule(unittest.TestCase):
         self.assertTrue("node1" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
         self.assertEqual(0, len(ecc_reboot_node_rule_instance.jobs_ready_for_migration))
 
+    @mock.patch('rules.ecc_detect_error_rule.k8s_util.uncordon_node')
     @mock.patch('utils.k8s_util.list_namespaced_pod')
     @mock.patch('requests.get')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
@@ -179,7 +180,8 @@ class TestEccRebootNodeRule(unittest.TestCase):
             mock_load_ecc_config,
             mock_load_etcd_config,
             mock_request_get,
-            mock_pod_list):
+            mock_pod_list,
+            mock_uncordon_node):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config

--- a/src/RepairManager/test/test_ecc_reboot_node_rule.py
+++ b/src/RepairManager/test/test_ecc_reboot_node_rule.py
@@ -46,9 +46,7 @@ class TestEccRebootNodeRule(unittest.TestCase):
         }
         prometheus_resp = _mock_prometheus_node_boot_time_response(node_boot_times)
 
-
         result_boot_times = ecc_reboot_node_rule._extract_node_boot_time_info(prometheus_resp)
-
 
         self.assertTrue("192.168.0.1" in result_boot_times)
         self.assertEqual(mock_datetime_one, result_boot_times["192.168.0.1"])
@@ -57,21 +55,28 @@ class TestEccRebootNodeRule(unittest.TestCase):
         self.assertEqual(mock_datetime_two, result_boot_times["192.168.0.2"])
 
 
+    @mock.patch('utils.k8s_util.list_namespaced_pod')
     @mock.patch('requests.get')
+    @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_check_status_time_to_take_action(self,
+    def test_check_status_node_due_for_reboot(self,
             mock_load_rule_config,
             mock_email_handler,
-            mock_ecc_config,
-            mock_request_get):
+            mock_load_ecc_config,
+            mock_load_etcd_config,
+            mock_request_get,
+            mock_pod_list):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
 
-        mock_ecc_config.return_value = test_util.mock_ecc_config()
-        mock_ecc_config.return_value["days_until_node_reboot"] = 5
+        etcd_config = test_util.mock_etcd_config()
+        mock_load_etcd_config.return_value = etcd_config
+
+        mock_load_ecc_config.return_value = test_util.mock_ecc_config()
+        mock_load_ecc_config.return_value["days_until_node_reboot"] = 5
 
         time_six_days_ago = datetime.utcnow() - timedelta(days=6)
         time_five_days_ago = datetime.utcnow() - timedelta(days=5, minutes=1)
@@ -85,11 +90,73 @@ class TestEccRebootNodeRule(unittest.TestCase):
             }
         }
 
+        # reboot is due to be rebooted (exceeded configured deadline), should trigger take action
         node_boot_times = {
             "192.168.0.1": str(time_six_days_ago.replace(tzinfo=timezone.utc).timestamp())
         }
         mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(node_boot_times)
+        
+        # at least one job running on the node
+        mock_pod_list.return_value = test_util.mock_v1_pod_list([
+            {
+                "job_name": "87654321-wxyz",
+                "user_name": "user1",
+                "vc_name": "vc1",
+                "node_name": "node1"
+            }
+        ])
 
+        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
+        response = ecc_reboot_node_rule_instance.check_status()
+
+        self.assertTrue(response)
+        self.assertEqual(1, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
+        self.assertTrue("node1" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        self.assertEqual(1, len(ecc_reboot_node_rule_instance.jobs_ready_for_migration))
+        self.assertTrue("87654321-wxyz" in ecc_reboot_node_rule_instance.jobs_ready_for_migration)
+
+    
+    @mock.patch('utils.k8s_util.list_namespaced_pod')
+    @mock.patch('requests.get')
+    @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
+    @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
+    @mock.patch('utils.email_util.EmailHandler')
+    @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
+    def test_check_status_no_jobs_running(self,
+            mock_load_rule_config,
+            mock_email_handler,
+            mock_load_ecc_config,
+            mock_load_etcd_config,
+            mock_request_get,
+            mock_pod_list):
+
+        rule_config = test_util.mock_rule_config()
+        mock_load_rule_config.return_value = rule_config
+
+        etcd_config = test_util.mock_etcd_config()
+        mock_load_etcd_config.return_value = etcd_config
+
+        mock_load_ecc_config.return_value = test_util.mock_ecc_config()
+        mock_load_ecc_config.return_value["days_until_node_reboot"] = 5
+
+        time_two_days_ago = datetime.utcnow() - timedelta(days=2)
+
+        rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
+        rule_alert_handler_instance.rule_cache["ecc_rule"] = {
+            "node1": {
+                "time_found": time_two_days_ago.strftime(rule_config['date_time_format']),
+                "instance": "192.168.0.1"
+            }
+        }
+
+        # node not due to be rebooted
+        node_boot_times = {
+            "192.168.0.1": str(time_two_days_ago.replace(tzinfo=timezone.utc).timestamp())
+        }
+        mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(node_boot_times)
+
+        # no pods running on node, should trigger take action
+        mock_pod_list.return_value = test_util.mock_v1_pod_list([])
 
         ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
         response = ecc_reboot_node_rule_instance.check_status()
@@ -97,24 +164,31 @@ class TestEccRebootNodeRule(unittest.TestCase):
 
         self.assertTrue(response)
         self.assertEqual(1, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
-        self.assertEqual("node1", ecc_reboot_node_rule_instance.nodes_ready_for_action[0])
+        self.assertTrue("node1" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        self.assertEqual(0, len(ecc_reboot_node_rule_instance.jobs_ready_for_migration))
 
-
+    @mock.patch('utils.k8s_util.list_namespaced_pod')
     @mock.patch('requests.get')
+    @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     def test_check_status_node_rebooted_after_detection(self,
             mock_load_rule_config,
             mock_email_handler,
-            mock_ecc_config,
-            mock_request_get):
+            mock_load_ecc_config,
+            mock_load_etcd_config,
+            mock_request_get,
+            mock_pod_list):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
 
-        mock_ecc_config.return_value = test_util.mock_ecc_config()
-        mock_ecc_config.return_value["days_until_node_reboot"] = 5
+        etcd_config = test_util.mock_etcd_config()
+        mock_load_etcd_config.return_value = etcd_config
+
+        mock_load_ecc_config.return_value = test_util.mock_ecc_config()
+        mock_load_ecc_config.return_value["days_until_node_reboot"] = 5
 
         time_one_days_ago = datetime.utcnow() - timedelta(days=1)
         now = datetime.utcnow()
@@ -134,6 +208,7 @@ class TestEccRebootNodeRule(unittest.TestCase):
         }
         mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(node_boot_times)
 
+        mock_pod_list.return_value = test_util.mock_v1_pod_list([])
 
         ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
         response = ecc_reboot_node_rule_instance.check_status()
@@ -144,24 +219,32 @@ class TestEccRebootNodeRule(unittest.TestCase):
         self.assertTrue("node1" not in rule_alert_handler_instance.rule_cache["ecc_rule"])
 
 
+    @mock.patch('utils.k8s_util.list_namespaced_pod')
     @mock.patch('requests.get')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
+    @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     def test_check_status_no_action_needed(self,
         mock_load_rule_config,
-        mock_email_handler, 
-        mock_ecc_config,
-        mock_request_get):
+        mock_email_handler,
+        mock_load_etcd_config,
+        mock_load_ecc_config,
+        mock_request_get,
+        mock_pod_list):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
 
-        mock_ecc_config.return_value = test_util.mock_ecc_config()
-        mock_ecc_config.return_value["days_until_node_reboot"] = 5
+        etcd_config = test_util.mock_etcd_config()
+        mock_load_etcd_config.return_value = etcd_config
+
+        mock_load_ecc_config.return_value = test_util.mock_ecc_config()
+        mock_load_ecc_config.return_value["days_until_node_reboot"] = 5
 
         time_two_days_ago = datetime.utcnow() - timedelta(days=2)
         time_three_days_ago = datetime.utcnow() - timedelta(days=3)
+        time_six_days_ago = datetime.utcnow() - timedelta(days=6)
 
         #  ecc error detection occured in previous iteration
         rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
@@ -169,15 +252,31 @@ class TestEccRebootNodeRule(unittest.TestCase):
             "node1": {
                 "time_found": time_two_days_ago.strftime(rule_config['date_time_format']),
                 "instance": "192.168.0.1"
+            },
+            # this node already has a reboot attempt, so should not trigger take action
+            "node2": {
+                "time_found": time_three_days_ago.strftime(rule_config['date_time_format']),
+                "instance": "192.168.0.2",
+                "reboot_requested": time_two_days_ago.strftime(rule_config['date_time_format'])
             }
         }
 
-        # node rebooted *before* initial ecc error detection
+        # both nodes have not been rebooted after initial detection
         node_boot_times = {
-            "192.168.0.1": str(time_three_days_ago.replace(tzinfo=timezone.utc).timestamp())
+            "192.168.0.1": str(time_three_days_ago.replace(tzinfo=timezone.utc).timestamp()),
+            "192.168.0.2": str(time_six_days_ago.replace(tzinfo=timezone.utc).timestamp())
         }
         mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(node_boot_times)
 
+        # at least one job running on the node
+        mock_pod_list.return_value = test_util.mock_v1_pod_list([
+            {
+                "job_name": "87654321-wxyz",
+                "user_name": "user1",
+                "vc_name": "vc1",
+                "node_name": "node1"
+            }
+        ])
 
         ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
         response = ecc_reboot_node_rule_instance.check_status()
@@ -187,22 +286,27 @@ class TestEccRebootNodeRule(unittest.TestCase):
         self.assertEqual(0, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
 
 
-    @mock.patch('utils.k8s_util.list_namespaced_pod')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
+    @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('requests.get')
+    @mock.patch('requests.put')
     @mock.patch('rules.ecc_reboot_node_rule._create_email_for_pause_resume_job')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     def test_take_action(self, 
         mock_load_rule_config,
         mock_create_email_for_pause_resume_job,
+        mock_put_requests,
         mock_get_requests,
         mock_email_handler,
-        mock_load_ecc_config,
-        mock_pod_list):
+        mock_load_etcd_config,
+        mock_load_ecc_config):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
+
+        etcd_config = test_util.mock_etcd_config()
+        mock_load_etcd_config.return_value = etcd_config
 
         mock_load_ecc_config.return_value = test_util.mock_ecc_config()
         mock_load_ecc_config.return_value["alert_job_owners"] = True
@@ -228,6 +332,26 @@ class TestEccRebootNodeRule(unittest.TestCase):
             {"result": "Success, job resumed."}
         ]
 
+        mock_put_requests.return_value.json.side_effect = [
+            {
+                "action": "set",
+                "node": {
+                    "key": "/mock-worker-one/reboot",
+                    "value": "True",
+                    "modifiedIndex": 39,
+                    "createdIndex": 39
+                }
+            },
+            {
+                "action": "set",
+                "node": {
+                    "key": "/mock-worker-three/reboot",
+                    "value": "True",
+                    "modifiedIndex": 39,
+                    "createdIndex": 39
+                }
+            }]
+
         rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
         rule_alert_handler_instance.rule_cache["ecc_rule"] = {
             "mock-worker-one": {"instance": "192.168.0.1:9090"},
@@ -235,50 +359,66 @@ class TestEccRebootNodeRule(unittest.TestCase):
             "mock-worker-three": {"instance": "192.168.0.3:9090"}
         }
 
-        mock_pod_list.return_value = test_util.mock_v1_pod_list([
-            {
-                "job_name": "87654321-wxyz",
-                "user_name": "user1",
-                "vc_name": "vc1",
-                "node_name": "mock-worker-one"
-            },
-            {
-                "job_name": "12345678-abcd",
-                "user_name": "user2",
-                "vc_name": "vc2",
-                "node_name": "mock-worker-one"
-            },
-            {
-                "job_name": "99999999-efgh",
-                "user_name": "user3",
-                "vc_name": "vc3",
-                "node_name": "mock-worker-three"
-            }
-        ])
-
-        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
-        ecc_reboot_node_rule_instance.nodes_ready_for_action = ["mock-worker-one", "mock-worker-three"]
+        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(
+            rule_alert_handler_instance, rule_config)
+        ecc_reboot_node_rule_instance.nodes_ready_for_action = [
+            "mock-worker-one", "mock-worker-three"]
+        ecc_reboot_node_rule_instance.jobs_ready_for_migration = {
+            "87654321-wxyz":
+                {
+                    "user_name": "user1",
+                    "vc_name": "vc1",
+                    "node_names": ["mock-worker-one"],
+                    "job_link": "/job-link-1"
+                },
+            "12345678-abcd": {
+                    "user_name": "user2",
+                    "vc_name": "vc2",
+                    "node_names": ["mock-worker-one"],
+                    "job_link": "/job-link-2"
+                },
+            "99999999-efgh": {
+                    "user_name": "user3",
+                    "vc_name": "vc3",
+                    "node_names": ["mock-worker-three"],
+                    "job_link": "/job-link-3"
+                }
+        }
 
         ecc_reboot_node_rule_instance.take_action()
 
         self.assertEqual(3, mock_create_email_for_pause_resume_job.call_count)
+        self.assertEqual(3, len(rule_alert_handler_instance.rule_cache["ecc_rule"]))
+        # node should have successfully rebooted
+        self.assertTrue("mock-worker-one" in rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertTrue("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-one"])
+        # no action was taken on this node (not in ready for action list)
+        self.assertTrue("mock-worker-two" in rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertFalse("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-two"])
+        # node should have successfully rebooted
+        self.assertTrue("mock-worker-three" in rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertTrue("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-three"])
+    
 
-    @mock.patch('rules.ecc_reboot_node_rule._create_email_for_issue_with_pause_resume_job')
-    @mock.patch('utils.k8s_util.list_namespaced_pod')
+    @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('requests.get')
+    @mock.patch('requests.put')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     def test_take_action_pause_failed(self, 
         mock_load_rule_config,
+        mock_put_requests,
         mock_get_requests,
         mock_email_load_config,
         mock_load_ecc_config,
-        mock_list_pods,
-        mock_create_email_for_issue_with_pause_resume_job):
+        mock_load_etcd_config):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
+
+        etcd_config = test_util.mock_etcd_config()
+        mock_load_etcd_config.return_value = etcd_config
 
         mock_load_ecc_config.return_value = test_util.mock_ecc_config()
         mock_load_ecc_config.return_value["alert_job_owners"] = True
@@ -287,23 +427,169 @@ class TestEccRebootNodeRule(unittest.TestCase):
 
         rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
         rule_alert_handler_instance.rule_cache["ecc_rule"] = {
-            "mock-worker-one": {"instance": "192.168.0.1:9090"}
+            "mock-worker-one": {"instance": "192.168.0.1:9090"},
+            "mock-worker-two": {"instance": "192.168.0.2:9090"},
+            "mock-worker-three": {"instance": "192.168.0.3:9090"},
+            "mock-worker-four": {"instance": "192.168.0.4:9090"}
         }
-        mock_list_pods.return_value = test_util.mock_v1_pod_list([
-            {
-                "job_name": "87654321-wxyz",
-                "user_name": "user1",
-                "vc_name": "vc1",
-                "node_name": "mock-worker-one"
-            }])
 
         ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
-        ecc_reboot_node_rule_instance.nodes_ready_for_action = ["mock-worker-one"]
+        ecc_reboot_node_rule_instance.nodes_ready_for_action = [
+            "mock-worker-one", 
+            "mock-worker-two",
+            "mock-worker-three",
+            "mock-worker-four"
+        ]
+        ecc_reboot_node_rule_instance.jobs_ready_for_migration = {
+            "87654321-wxyz":
+                {
+                    "user_name": "user1",
+                    "vc_name": "vc1",
+                    "node_names": ["mock-worker-one"],
+                    "job_link": "/job-link-1"
+                },
+                # distributed job
+                "12345678-abcd": {
+                    "user_name": "user2",
+                    "vc_name": "vc1",
+                    "node_names": ["mock-worker-two", "mock-worker-three"],
+                    "job_link": "/job-link-2"
+                }
+        }
+
+        mock_put_requests.return_value.json.return_value = {
+            "action": "set",
+            "node": {
+                "key": "/mock-worker-four/reboot",
+                "value": "True",
+                "modifiedIndex": 39,
+                "createdIndex": 39
+            }
+        }
+
+        ecc_reboot_node_rule_instance.take_action()
+        # node should be skipped since job migration failed
+        self.assertTrue("mock-worker-one" in rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertFalse("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-one"])
+        self.assertFalse("mock-worker-one" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        # node should be skipped since job migration failed (distributed job)
+        self.assertTrue("mock-worker-two" in rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertFalse("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-two"])
+        self.assertFalse("mock-worker-two" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        # node should be skipped since job migration failed (distributed job)
+        self.assertTrue("mock-worker-three" in rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertFalse("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-three"])
+        self.assertFalse("mock-worker-three" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        # node should be successfully rebooted (had no jobs to migrate)
+        self.assertTrue("mock-worker-four" in rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertTrue("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-four"])
+        self.assertTrue("mock-worker-four" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+
+    @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
+    @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
+    @mock.patch('utils.email_util.EmailHandler')
+    @mock.patch('requests.get')
+    @mock.patch('requests.put')
+    @mock.patch('rules.ecc_reboot_node_rule._create_email_for_pause_resume_job')
+    @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
+    def test_take_action_reboot_failed(self, 
+        mock_load_rule_config,
+        mock_create_email_for_pause_resume_job,
+        mock_put_requests,
+        mock_get_requests,
+        mock_email_handler,
+        mock_load_etcd_config,
+        mock_load_ecc_config):
+
+        rule_config = test_util.mock_rule_config()
+        mock_load_rule_config.return_value = rule_config
+
+        etcd_config = test_util.mock_etcd_config()
+        mock_load_etcd_config.return_value = etcd_config
+
+        mock_load_ecc_config.return_value = test_util.mock_ecc_config()
+        mock_load_ecc_config.return_value["alert_job_owners"] = True
+
+        mock_get_requests.return_value.json.side_effect = [
+            # job 1
+            {"result": "Success, job paused."},
+            {"errorMsg": None,
+            "jobStatus": "paused",
+            "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"},
+            {"result": "Success, job resumed."},
+            # job 2
+            {"result": "Success, job paused."},
+            {"errorMsg": None,
+            "jobStatus": "paused",
+            "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"},
+            {"result": "Success, job resumed."},
+            # job 3
+            {"result": "Success, job paused."},
+            {"errorMsg": None,
+            "jobStatus": "paused",
+            "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"},
+            {"result": "Success, job resumed."}
+        ]
+
+        mock_put_requests.return_value.json.side_effect = [
+            {
+                "action": "set",
+                "node": {
+                    "key": "/mock-worker-one/reboot",
+                    "value": "True",
+                    "modifiedIndex": 39,
+                    "createdIndex": 39
+                }
+            },
+            # reboot failed for one of the nodes
+            {
+                "error_code": 100,
+                "message": "Something went wrong",
+                "cause": "Unable to open connection"
+            }]
+
+        rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
+        rule_alert_handler_instance.rule_cache["ecc_rule"] = {
+            "mock-worker-one": {"instance": "192.168.0.1:9090"},
+            "mock-worker-three": {"instance": "192.168.0.3:9090"}
+        }
+
+        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(
+            rule_alert_handler_instance, rule_config)
+        ecc_reboot_node_rule_instance.nodes_ready_for_action = [
+            "mock-worker-one", "mock-worker-three"]
+        ecc_reboot_node_rule_instance.jobs_ready_for_migration = {
+            "87654321-wxyz":
+                {
+                    "user_name": "user1",
+                    "vc_name": "vc1",
+                    "node_names": ["mock-worker-one"],
+                    "job_link": "/job-link-1"
+                },
+            "12345678-abcd": {
+                    "user_name": "user2",
+                    "vc_name": "vc2",
+                    "node_names": ["mock-worker-one"],
+                    "job_link": "/job-link-2"
+                },
+            "99999999-efgh": {
+                    "user_name": "user3",
+                    "vc_name": "vc3",
+                    "node_names": ["mock-worker-three"],
+                    "job_link": "/job-link-3"
+                }
+        }
 
         ecc_reboot_node_rule_instance.take_action()
 
-        self.assertEqual(1, mock_create_email_for_issue_with_pause_resume_job.call_count)
-
+        self.assertEqual(3, mock_create_email_for_pause_resume_job.call_count)
+        self.assertEqual(2, len(rule_alert_handler_instance.rule_cache["ecc_rule"]))
+        # reboot successful for this node
+        self.assertTrue("mock-worker-one" in rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertTrue("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-one"])
+        # reboot failed for this node
+        self.assertTrue("mock-worker-three" in rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertFalse("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-three"])
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/RepairManager/test/test_rule_alert_handler.py
+++ b/src/RepairManager/test/test_rule_alert_handler.py
@@ -93,5 +93,28 @@ class TestRuleAlertHandler(unittest.TestCase):
         self.assertFalse(result)
 
 
+    @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
+    @mock.patch('utils.email_util.EmailHandler')
+    def test_get_rule_cache_keys(self, mock_email_handler, mock_config):
+        mock_config.return_value = _mock_rule_config()
+        rule = "TestRule"
+
+        rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
+
+        keys = rule_alert_handler_instance.get_rule_cache_keys(rule)
+        self.assertEqual(len(keys), 0)
+
+        rule_alert_handler_instance.update_rule_cache(rule, "test_key1", "test_value1")
+        rule_alert_handler_instance.update_rule_cache(rule, "test_key2", "test_value2")
+        rule_alert_handler_instance.update_rule_cache(rule, "test_key3", "test_value3")
+
+        keys = rule_alert_handler_instance.get_rule_cache_keys(rule)
+        self.assertEqual(len(keys), 3)
+        self.assertTrue("test_key1" in keys)
+        self.assertTrue("test_key2" in keys)
+        self.assertTrue("test_key3" in keys)
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/RepairManager/utils/rule_alert_handler.py
+++ b/src/RepairManager/utils/rule_alert_handler.py
@@ -23,6 +23,23 @@ class RuleAlertHandler():
         self.email_handler.send(message)
 
 
+    # check if a key exists in a specified rule dict
+    def check_rule_cache(self, rule, cache_key):
+        if rule in self.rule_cache:
+            if cache_key in self.rule_cache[rule]:
+                return True
+        return False
+
+
+    # retrieve the value for a key in specified a rule dict
+    def get_rule_cache(self, rule, cache_key):
+        if rule in self.rule_cache:
+            if cache_key in self.rule_cache[rule]:
+                return self.rule_cache[rule][cache_key]
+        return None
+
+
+    # add or update key/values for a specified rule dict
     def update_rule_cache(self, rule, cache_key, cache_value):
         if rule not in self.rule_cache:
             self.rule_cache[rule] = {}
@@ -32,7 +49,7 @@ class RuleAlertHandler():
         if 'rule_cache_dump' in self.config:
             self.dump_rule_cache()
 
-
+    # remove key/values for a specified rule dict
     def remove_from_rule_cache(self, rule, cache_key):
         if rule in self.rule_cache:
             if cache_key in self.rule_cache[rule]:
@@ -42,25 +59,20 @@ class RuleAlertHandler():
                     self.dump_rule_cache()
 
 
-    def get_rule_cache(self, rule, cache_key):
+    # retrieve the entire key set for a specified rule dict
+    def get_rule_cache_keys(self, rule):
         if rule in self.rule_cache:
-            if cache_key in self.rule_cache[rule]:
-                return self.rule_cache[rule][cache_key]
-        return None
+            return self.rule_cache[rule].keys()
+        else:
+            return {}
 
 
-    def check_rule_cache(self, rule, cache_key):
-        if rule in self.rule_cache:
-            if cache_key in self.rule_cache[rule]:
-                return True
-        return False
-
-
+    # dump the entire rule cache into a file
     def dump_rule_cache(self):
         with open(self.config['rule_cache_dump'], 'w') as fp:
             json.dump(self.rule_cache, fp)
 
-
+    # load rule cache from a file
     def load_rule_cache(self):
         rule_cache = {}
         if self.config['restore_from_rule_cache_dump']:

--- a/src/RepairManager/utils/rule_alert_handler.py
+++ b/src/RepairManager/utils/rule_alert_handler.py
@@ -62,9 +62,9 @@ class RuleAlertHandler():
     # retrieve the entire key set for a specified rule dict
     def get_rule_cache_keys(self, rule):
         if rule in self.rule_cache:
-            return self.rule_cache[rule].keys()
+            return list(self.rule_cache[rule].keys())
         else:
-            return {}
+            return []
 
 
     # dump the entire rule cache into a file

--- a/src/RepairManager/utils/test_util.py
+++ b/src/RepairManager/utils/test_util.py
@@ -36,7 +36,20 @@ def mock_ecc_config():
         "enable_reboot": True,
         "enable_alert_job_owners": True,
         "days_until_node_reboot": 5,
-        "time_sleep_after_pausing": 0
+        "time_sleep_after_pausing": 0,
+        "attempts_for_pause_resume_jobs" : 1
+    }
+    return ecc_config
+
+def mock_etcd_config():
+    ecc_config = {
+        "data-dir": "/data-dir",
+        "listen-peer-urls": "http://0.0.0.0:2381",
+        "listen-client-urls": "http://0.0.0.0:2382",
+        "advertise-client-urls": "http://127.0.0.1:2382",
+        "initial-advertise-peer-urls": "http://127.0.0.1:2381",
+        "initial-cluster": "default=http://127.0.0.1:2381",
+        "enable-v2": True
     }
     return ecc_config
 


### PR DESCRIPTION
Final step to send reboot node signal to repairmanager agent from repairmanager.

Highlights:
-- if a "bad" node has no jobs, node is ready for action to be taken (reboot)
-- If a "bad" node still has jobs running after a configured amount of time, migrate all jobs and send email to user. Then reboot.
-- if a "bad" node has been rebooted (by repairmanager or admin), mark as resolved and uncordon

**ecc_detect_error_rule and ecc_reboot_node_rule logic (click image to enlarge)**:
![image](https://user-images.githubusercontent.com/8230841/80302186-59694180-875d-11ea-8460-c1fcc1b0318d.png)

** Testing Complete in Dev1**

@Anbang-Hu @xudifsd @YinYangOfDao @hongzhili 