### PR TITLE
refactor gpu-reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,6 @@ matrix:
     before_install:
       - cd src/docker-images/gpu-reporter/test
     install:
-      - pip install requests flask prometheus_client flask-cors
+      - pip install pyyaml requests flask prometheus_client flask-cors
     script:
       - python -m unittest discover .

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,3 +59,11 @@ matrix:
       - pip install requests
     script:
       - python -m unittest discover .
+  - language: python
+    python: 3.6
+    before_install:
+      - cd src/docker-images/gpu-reporter/test
+    install:
+      - pip install requests flask prometheus_client flask-cors
+    script:
+      - python -m unittest discover .

--- a/src/ClusterBootstrap/services/monitor/alerting/aggregate.rules
+++ b/src/ClusterBootstrap/services/monitor/alerting/aggregate.rules
@@ -13,6 +13,14 @@ groups:
         expr: avg(task_dcgm_gpu_util > 0)
       - record: aggregate:cluster:dcgm_retired_pages_pending:count
         expr: count(dcgm_retired_pages_pending > 0)
+      - record: aggregate:cluster:cluster_booked_gpu_second:avg
+        expr: avg(cluster_booked_gpu_second) by (since)
+      - record: aggregate:cluster:cluster_idle_gpu_second:avg
+        expr: avg(cluster_idle_gpu_second) by (since)
+      - record: aggregate:cluster:cluster_non_idle_utils:avg
+        expr: avg(cluster_non_idle_utils) by (since)
+      - record: aggregate:cluster:cluster_assigned_utils:avg
+        expr: avg(cluster_assigned_utils) by (since)
     - name: aggregate.vc
       rules:
       - record: aggregate:vc:k8s_vc_gpu_total:avg
@@ -25,6 +33,14 @@ groups:
         expr: avg(task_dcgm_gpu_util) by (vc_name)
       - record: aggregate:vc:active_task_dcgm_gpu_util:avg
         expr: avg(task_dcgm_gpu_util > 0) by (vc_name)
+      - record: aggregate:vc:vc_booked_gpu_second:avg
+        expr: avg(vc_booked_gpu_second) by (vc, since)
+      - record: aggregate:vc:vc_idle_gpu_second:avg
+        expr: avg(vc_idle_gpu_second) by (vc, since)
+      - record: aggregate:vc:vc_non_idle_utils:avg
+        expr: avg(vc_non_idle_utils) by (vc, since)
+      - record: aggregate:vc:vc_assigned_utils:avg
+        expr: avg(vc_assigned_utils) by (vc, since)
     - name: aggregate.user
       rules:
       - record: aggregate:user:assigned_task_dcgm_gpu_util:count
@@ -35,6 +51,10 @@ groups:
         expr: avg(task_dcgm_gpu_util) by (vc_name, username)
       - record: aggregate:user:active_task_dcgm_gpu_util:avg
         expr: avg(task_dcgm_gpu_util > 0) by (vc_name, username)
+      - record: aggregate:user:user_booked_gpu_second:avg
+        expr: avg(user_booked_gpu_second) by (vc, user, since)
+      - record: aggregate:user:user_idle_gpu_second:avg
+        expr: avg(user_idle_gpu_second) by (vc, user, since)
       - record: aggregate:user:user_non_idle_utils:avg
         expr: avg(user_non_idle_utils) by (vc, user, since)
       - record: aggregate:user:user_assigned_utils:avg

--- a/src/docker-images/gpu-reporter/reporter.py
+++ b/src/docker-images/gpu-reporter/reporter.py
@@ -10,6 +10,7 @@ import timeit
 import collections
 import faulthandler
 import signal
+import copy
 
 import requests
 
@@ -79,26 +80,12 @@ def request_with_error_handling(url, timeout=180):
         return None
 
 
-def get_monthly_idleness(prometheus_url):
-    IDLENESS_THRESHOLD = 0
-    STEP_MINUTE = 5
-
-    step_seconds = STEP_MINUTE * 60
-
-    now = datetime.datetime.now()
-    seven_day_ago = int(
-        datetime.datetime.timestamp(now - datetime.timedelta(days=1)))
-    fourteen_days_ago = int(
-        datetime.datetime.timestamp(now - datetime.timedelta(days=14)))
-    one_month_ago = int(
-        datetime.datetime.timestamp(now - datetime.timedelta(days=31)))
-    now = int(datetime.datetime.timestamp(now))
-
+def query_prometheus(prometheus_url, query, since, end, step_minute):
     args = urllib.parse.urlencode({
-        "query": "task_gpu_percent",
-        "start": str(one_month_ago),
-        "end": str(now),
-        "step": str(STEP_MINUTE) + "m",
+        "query": query,
+        "start": str(since),
+        "end": str(end),
+        "step": str(step_minute) + "m",
     })
 
     url = urllib.parse.urljoin(prometheus_url,
@@ -110,38 +97,117 @@ def get_monthly_idleness(prometheus_url):
     prometheus_request_histogram.observe(elapsed)
     logger.info("request spent %.2fs", elapsed)
 
-    start = timeit.default_timer()
     if walk_json_field_safe(obj, "status") != "success":
         logger.warning("requesting %s failed, body is %s", url, obj)
         return None
 
+    return obj
+
+
+def copy_without_next(m):
+    result = {}
+    for k, v in m.items():
+        if k == "next":
+            continue
+        result[k] = v
+    return result
+
+
+class Register(object):
+    def __init__(self):
+        self.booked = 0
+        self.idle = 0
+        self.nonidle_util_sum = 0.0
+        self.next = collections.defaultdict(lambda: Register()) # chained
+
+    def add(self, step_seconds, idleness_threshold, actual_util):
+        self.booked += step_seconds
+
+        if actual_util <= idleness_threshold:
+            self.idle += step_seconds
+        else:
+            self.nonidle_util_sum += actual_util * step_seconds
+
+    def export(self):
+        nonidle_time = self.booked - self.idle
+
+        nonidle_util = 0.0
+        if nonidle_time != 0:
+            nonidle_util = self.nonidle_util_sum / nonidle_time
+        assigned_util = 0.0
+        if self.booked != 0:
+            assigned_util = self.nonidle_util_sum / self.booked
+
+        next_items = {}
+        for key, reg in self.next.items():
+            next_items[key] = reg.export()
+
+        return {
+            "booked": self.booked,
+            "idle": self.idle,
+            "nonidle_util": nonidle_util,
+            "assigned_util": assigned_util,
+            "next": next_items,
+        }
+
+
+class IdlenessCalculator(object):
+    def __init__(self, step_seconds, idleness_threshold, now):
+        self.step_seconds = step_seconds
+        self.idleness_threshold = idleness_threshold
+        self.now = now
+
+        self.seven_day_ago = int(
+            datetime.datetime.timestamp(now - datetime.timedelta(days=1)))
+        self.fourteen_days_ago = int(
+            datetime.datetime.timestamp(now - datetime.timedelta(days=14)))
+        self.one_month_ago = int(
+            datetime.datetime.timestamp(now - datetime.timedelta(days=31)))
+
+        self.since_one_month = Register()
+        self.since_fourteen_day = Register()
+        self.since_seven_day = Register()
+
+    def add_to_register(self, register, vc, user, job_id, util):
+        register.add(self.step_seconds, self.idleness_threshold, util)
+
+        vc_reg = register.next[vc]
+        vc_reg.add(self.step_seconds, self.idleness_threshold, util)
+
+        user_reg = vc_reg.next[user]
+        user_reg.add(self.step_seconds, self.idleness_threshold, util)
+
+        job_reg = user_reg.next[job_id]
+        job_reg.add(self.step_seconds, self.idleness_threshold, util)
+
+    def observe(self, vc, user, job_id, time, util):
+        if time < self.one_month_ago:
+            return
+
+        self.add_to_register(self.since_one_month, vc, user, job_id, util)
+
+        if time < self.fourteen_days_ago:
+            return
+
+        self.add_to_register(self.since_fourteen_day, vc, user, job_id, util)
+
+        if time < self.seven_day_ago:
+            return
+
+        self.add_to_register(self.since_seven_day, vc, user, job_id, util)
+
+    def export(self):
+        return {
+            "31d": self.since_one_month.export(),
+            "14d": self.since_fourteen_day.export(),
+            "7d": self.since_seven_day.export(),
+        }
+
+
+def calculate(obj, calculator):
+    start = timeit.default_timer()
+
     metrics = walk_json_field_safe(obj, "data", "result")
-
-    default = lambda: {
-        "booked": 0, "idle": 0, "nonidle_util_sum": 0.0, "assigned_util": 0.0}
-
-    # the first level is vc, the second level is user
-    vc_levels = [
-        ("7d", seven_day_ago,
-         collections.defaultdict(lambda: collections.defaultdict(default))),
-        ("14d", fourteen_days_ago,
-         collections.defaultdict(lambda: collections.defaultdict(default))),
-        ("31d", one_month_ago,
-         collections.defaultdict(lambda: collections.defaultdict(default))),
-    ]
-
-    # the first level is vc, the second level is user, the third level is job
-    user_levels = [
-        ("7d", seven_day_ago,
-         collections.defaultdict(lambda: collections.defaultdict(
-             lambda: collections.defaultdict(default)))),
-        ("14d", fourteen_days_ago,
-         collections.defaultdict(lambda: collections.defaultdict(
-             lambda: collections.defaultdict(default)))),
-        ("31d", one_month_ago,
-         collections.defaultdict(lambda: collections.defaultdict(
-             lambda: collections.defaultdict(default)))),
-    ]
 
     for metric in metrics:
         username = walk_json_field_safe(metric, "metric", "username")
@@ -158,72 +224,30 @@ def get_monthly_idleness(prometheus_url):
         if values is None or len(values) == 0:
             continue
 
-        for time, utils in values:
-            utils = float(utils)
+        for time, util in values:
+            util = float(util)
+            calculator.observe(vc_name, username, job_id, time, util)
 
-            for _, ago, vc_level in vc_levels:
-                if ago < time:
-                    continue
-
-                vc_level[vc_name][username]["booked"] += step_seconds
-                if utils <= IDLENESS_THRESHOLD:
-                    vc_level[vc_name][username]["idle"] += step_seconds
-                else:
-                    vc_level[vc_name][username][
-                        "nonidle_util_sum"] += utils * step_seconds
-
-            for _, ago, user_level in user_levels:
-                if ago < time:
-                    continue
-
-                user_level[vc_name][username][job_id]["booked"] += step_seconds
-                if utils <= IDLENESS_THRESHOLD:
-                    user_level[vc_name][username][job_id][
-                        "idle"] += step_seconds
-                else:
-                    user_level[vc_name][username][job_id][
-                        "nonidle_util_sum"] += utils * step_seconds
-
-    for _, _, vc_level in vc_levels:
-        for vc_name, vc_values in vc_level.items():
-            for username, user_val in vc_values.items():
-                nonidle_time = user_val["booked"] - user_val["idle"]
-                nonidle_util_sum = user_val["nonidle_util_sum"]
-
-                if nonidle_time == 0:
-                    user_val["nonidle_util"] = 0.0
-                else:
-                    user_val["nonidle_util"] = nonidle_util_sum / nonidle_time
-                user_val["assigned_util"] = \
-                    nonidle_util_sum / user_val["booked"]
-                user_val.pop("nonidle_util_sum")
-
-    for _, _, user_level in user_levels:
-        for vc_name, vc_values in user_level.items():
-            for username, user_values in vc_values.items():
-                for job_id, job_val in user_values.items():
-                    nonidle_time = job_val["booked"] - job_val["idle"]
-                    nonidle_util_sum = job_val["nonidle_util_sum"]
-
-                    if nonidle_time == 0:
-                        job_val["nonidle_util"] = 0.0
-                    else:
-                        job_val["nonidle_util"] = \
-                            nonidle_util_sum / nonidle_time
-                    job_val["assigned_util"] = \
-                        nonidle_util_sum / job_val["booked"]
-                    job_val.pop("nonidle_util_sum")
-
-    result_vc_levels = {}
-    for ago_s, _, vc_level in vc_levels:
-        result_vc_levels[ago_s] = vc_level
-    result_user_levels = {}
-    for ago_s, _, user_level in user_levels:
-        result_user_levels[ago_s] = user_level
-
+    result = calculator.export()
     elapsed = timeit.default_timer() - start
     logger.info("calculation spent %.2fs", elapsed)
-    return {"vc_level": result_vc_levels, "user_level": result_user_levels}
+    return result
+
+
+def get_monthly_idleness(prometheus_url):
+    IDLENESS_THRESHOLD = 0
+    STEP_MINUTE = 5
+    QUERY = "task_gpu_percent"
+
+    step_seconds = STEP_MINUTE * 60
+
+    now = datetime.datetime.now()
+    since = int(datetime.datetime.timestamp(now - datetime.timedelta(days=31)))
+    end = int(datetime.datetime.timestamp(now))
+
+    obj = query_prometheus(prometheus_url, QUERY, since, end, STEP_MINUTE)
+    calculator = IdlenessCalculator(step_seconds, IDLENESS_THRESHOLD, now)
+    return calculate(obj, calculator)
 
 
 def refresher(prometheus_url, atomic_ref):
@@ -242,71 +266,75 @@ class CustomCollector(object):
     def __init__(self, atomic_ref):
         self.atomic_ref = atomic_ref
 
+    def gen_gauges(self, level_name, labels):
+        label_copy = copy.deepcopy(labels)
+
+        booked = GaugeMetricFamily("%s_booked_gpu_second" % level_name,
+                                   "booked gpu second per %s" % level_name,
+                                   labels=label_copy)
+        idle = GaugeMetricFamily("%s_idle_gpu_second" % level_name,
+                                 "idle gpu second per %s" % level_name,
+                                 labels=label_copy)
+        nonidle_util = GaugeMetricFamily("%s_non_idle_utils" % level_name,
+                                         "non idle gpu avg util %s" %
+                                         level_name,
+                                         labels=label_copy)
+        assigned_util = GaugeMetricFamily("%s_assigned_utils" % level_name,
+                                          "assigned gpu avg util %s" %
+                                          level_name,
+                                          labels=label_copy)
+
+        return {
+            "booked": booked,
+            "idle": idle,
+            "nonidle_util": nonidle_util,
+            "assigned_util": assigned_util,
+        }
+
+    def add_metric(self, gauges, label_values, register):
+        for gauge_key, gauge in gauges.items():
+            gauge.add_metric(copy.deepcopy(label_values), register[gauge_key])
+
+    def walk_exported_register(self, exported):
+        level_names = ["vc", "user", "job_id"]
+        labels = ["since"]
+
+        cluster_gauges = self.gen_gauges("cluster", labels) # special case
+
+        level_gauges = []
+        for level_name in level_names:
+            labels.append(level_name)
+            if level_name == "job_id":
+                level_name = "job"
+            level_gauges.append(self.gen_gauges(level_name, labels))
+
+        for since in ["31d", "14d", "7d"]:
+            self.add_metric(cluster_gauges, [since], exported[since])
+            self.add_leveled_metric(exported[since]["next"], level_gauges, 0,
+                                    [since])
+
+        result = []
+        result.extend(cluster_gauges.values())
+        for gauges in level_gauges:
+            result.extend(gauges.values())
+        return result
+
+    def add_leveled_metric(self, exported, gauges, gauge_index, label_values):
+        for key, register in exported.items():
+            label_values.append(key)
+            self.add_metric(gauges[gauge_index], label_values, register)
+
+            self.add_leveled_metric(register["next"], gauges, gauge_index + 1,
+                                    label_values)
+
+            label_values.pop()
+
     def collect(self):
-        job_booked = GaugeMetricFamily("job_booked_gpu_second",
-                                       "booked gpu second per job",
-                                       labels=["vc", "user", "job_id", "since"])
+        exported = self.atomic_ref.get()
+        if exported is None:
+            return []
 
-        job_idle = GaugeMetricFamily("job_idle_gpu_second",
-                                     "idle gpu hour per job",
-                                     labels=["vc", "user", "job_id", "since"])
-
-        job_non_idle_utils = GaugeMetricFamily(
-            "job_non_idle_utils",
-            "non idle gpu avg utils per job",
-            labels=["vc", "user", "job_id", "since"])
-
-        job_assigned_utils = GaugeMetricFamily(
-            "job_assigned_utils",
-            "assigned gpu avg utils per job",
-            labels=["vc", "user", "job_id", "since"])
-
-        user_non_idle_utils = GaugeMetricFamily(
-            "user_non_idle_utils",
-            "non idle gpu avg utils per user",
-            labels=["vc", "user", "since"])
-
-        user_assigned_utils = GaugeMetricFamily(
-            "user_assigned_utils",
-            "assigned gpu avg utils per user",
-            labels=["vc", "user", "since"])
-
-        result = self.atomic_ref.get()
-        if result is None:
-            # https://stackoverflow.com/a/6266586
-            # yield nothing
-            return
-            yield
-
-        for ago, user_level in result["user_level"].items():
-            for vc_name, vc_values in user_level.items():
-                for username, user_values in vc_values.items():
-                    for job_id, job_val in user_values.items():
-                        job_booked.add_metric([vc_name, username, job_id, ago],
-                                              job_val["booked"])
-                        job_idle.add_metric([vc_name, username, job_id, ago],
-                                            job_val["idle"])
-                        job_non_idle_utils.add_metric(
-                            [vc_name, username, job_id, ago],
-                            job_val["nonidle_util"])
-                        job_assigned_utils.add_metric(
-                            [vc_name, username, job_id, ago],
-                            job_val["assigned_util"])
-
-        for ago, vc_level in result["vc_level"].items():
-            for vc_name, vc_values in vc_level.items():
-                for username, user_val in vc_values.items():
-                    user_non_idle_utils.add_metric([vc_name, username, ago],
-                                                   user_val["nonidle_util"])
-                    user_assigned_utils.add_metric([vc_name, username, ago],
-                                                   user_val["assigned_util"])
-
-        yield job_booked
-        yield job_idle
-        yield job_non_idle_utils
-        yield job_assigned_utils
-        yield user_non_idle_utils
-        yield user_assigned_utils
+        return self.walk_exported_register(exported)
 
 
 def serve(prometheus_url, port):
@@ -330,21 +358,26 @@ def serve(prometheus_url, port):
         if vc_name is None:
             return Response("should provide vc parameter", 400)
 
+        since = "31d"
+
         if user_name is None:
             result = atomic_ref.get()
-            vc_level = result["vc_level"]["31d"]
-            if result is None or vc_level.get(vc_name) is None:
-                return flask.jsonify({})
+            vc_result = walk_json_field_safe(result, "31d", "next", vc_name,
+                                             "next") or {}
+            result = {}
+            for username, user_val in vc_result.items():
+                result[username] = copy_without_next(user_val)
 
-            return flask.jsonify(vc_level[vc_name])
+            return flask.jsonify(result)
         else:
             result = atomic_ref.get()
-            user_level = result["user_level"]["31d"]
-            if result is None or user_level.get(vc_name) is None or user_level[
-                    vc_name].get(user_name) is None:
-                return flask.jsonify({})
+            user_result = walk_json_field_safe(result, "31d", "next", vc_name,
+                                               "next", user_name, "next") or {}
+            result = {}
+            for job_id, job_val in user_result.items():
+                result[job_id] = copy_without_next(job_val)
 
-            return flask.jsonify(user_level[vc_name][user_name])
+            return flask.jsonify(result)
 
     @app.route("/metrics")
     def metrics():

--- a/src/docker-images/gpu-reporter/reporter.py
+++ b/src/docker-images/gpu-reporter/reporter.py
@@ -158,7 +158,7 @@ class IdlenessCalculator(object):
         self.now = now
 
         self.seven_day_ago = int(
-            datetime.datetime.timestamp(now - datetime.timedelta(days=1)))
+            datetime.datetime.timestamp(now - datetime.timedelta(days=7)))
         self.fourteen_days_ago = int(
             datetime.datetime.timestamp(now - datetime.timedelta(days=14)))
         self.one_month_ago = int(
@@ -362,7 +362,7 @@ def serve(prometheus_url, port):
 
         if user_name is None:
             result = atomic_ref.get()
-            vc_result = walk_json_field_safe(result, "31d", "next", vc_name,
+            vc_result = walk_json_field_safe(result, since, "next", vc_name,
                                              "next") or {}
             result = {}
             for username, user_val in vc_result.items():
@@ -371,7 +371,7 @@ def serve(prometheus_url, port):
             return flask.jsonify(result)
         else:
             result = atomic_ref.get()
-            user_result = walk_json_field_safe(result, "31d", "next", vc_name,
+            user_result = walk_json_field_safe(result, since, "next", vc_name,
                                                "next", user_name, "next") or {}
             result = {}
             for job_id, job_val in user_result.items():

--- a/src/docker-images/gpu-reporter/test/data/exported.json
+++ b/src/docker-images/gpu-reporter/test/data/exported.json
@@ -1,0 +1,117 @@
+{
+  "31d": {
+    "booked": 900,
+    "idle": 300,
+    "nonidle_util": 60,
+    "assigned_util": 40,
+    "next": {
+      "platform": {
+        "booked": 300,
+        "idle": 0,
+        "nonidle_util": 20,
+        "assigned_util": 20,
+        "next": {
+          "bbb": {
+            "booked": 300,
+            "idle": 0,
+            "nonidle_util": 20,
+            "assigned_util": 20,
+            "next": {
+              "89ba301e-58d0-4ce5-ba6b-5781a7926f63": {
+                "booked": 300,
+                "idle": 0,
+                "nonidle_util": 20,
+                "assigned_util": 20,
+                "next": {}
+              }
+            }
+          }
+        }
+      },
+      "vvv": {
+        "booked": 600,
+        "idle": 300,
+        "nonidle_util": 100,
+        "assigned_util": 50,
+        "next": {
+          "aaa": {
+            "booked": 600,
+            "idle": 300,
+            "nonidle_util": 100,
+            "assigned_util": 50,
+            "next": {
+              "f29f07ab-8510-4ad9-ac24-363bd7271571": {
+                "booked": 600,
+                "idle": 300,
+                "nonidle_util": 100,
+                "assigned_util": 50,
+                "next": {}
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "14d": {
+    "booked": 900,
+    "idle": 300,
+    "nonidle_util": 60,
+    "assigned_util": 40,
+    "next": {
+      "platform": {
+        "booked": 300,
+        "idle": 0,
+        "nonidle_util": 20,
+        "assigned_util": 20,
+        "next": {
+          "bbb": {
+            "booked": 300,
+            "idle": 0,
+            "nonidle_util": 20,
+            "assigned_util": 20,
+            "next": {
+              "89ba301e-58d0-4ce5-ba6b-5781a7926f63": {
+                "booked": 300,
+                "idle": 0,
+                "nonidle_util": 20,
+                "assigned_util": 20,
+                "next": {}
+              }
+            }
+          }
+        }
+      },
+      "vvv": {
+        "booked": 600,
+        "idle": 300,
+        "nonidle_util": 100,
+        "assigned_util": 50,
+        "next": {
+          "aaa": {
+            "booked": 600,
+            "idle": 300,
+            "nonidle_util": 100,
+            "assigned_util": 50,
+            "next": {
+              "f29f07ab-8510-4ad9-ac24-363bd7271571": {
+                "booked": 600,
+                "idle": 300,
+                "nonidle_util": 100,
+                "assigned_util": 50,
+                "next": {}
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "7d": {
+    "booked": 0,
+    "idle": 0,
+    "nonidle_util": 0,
+    "assigned_util": 0,
+    "next": {}
+  }
+}

--- a/src/docker-images/gpu-reporter/test/data/raw.json
+++ b/src/docker-images/gpu-reporter/test/data/raw.json
@@ -1,0 +1,59 @@
+{
+  "status": "success",
+  "data": {
+    "resultType": "matrix",
+    "result": [
+      {
+        "metric": {
+          "__name__": "task_gpu_percent",
+          "exporter_name": "job-exporter",
+          "instance": "192.168.0.4:9102",
+          "job": "serivce_exporter",
+          "job_name": "89ba301e-58d0-4ce5-ba6b-5781a7926f63",
+          "minor_number": "3",
+          "pod_name": "89ba301e58d04ce5ba6b5781a7926f63-master-0",
+          "role_name": "master",
+          "scraped_from": "job-exporter-gkshs",
+          "task_index": "0",
+          "user_email": "bbb@microsoft.com",
+          "username": "bbb",
+          "uuid": "GPU-1b1967bf-6125-d744-338b-4e22d3370bc0",
+          "vc_name": "platform"
+        },
+        "values": [
+          [
+            1586991515,
+            "20"
+          ]
+        ]
+      },
+      {
+        "metric": {
+          "__name__": "task_gpu_percent",
+          "exporter_name": "job-exporter",
+          "instance": "192.168.0.7:9102",
+          "job": "serivce_exporter",
+          "job_name": "f29f07ab-8510-4ad9-ac24-363bd7271571",
+          "minor_number": "3",
+          "pod_name": "f29f07ab85104ad9ac24363bd7271571-master-0",
+          "role_name": "master",
+          "scraped_from": "job-exporter-8rjwb",
+          "task_index": "0",
+          "user_email": "aaa@microsoft.com",
+          "username": "aaa",
+          "vc_name": "vvv"
+        },
+        "values": [
+          [
+            1586654915,
+            "0"
+          ],
+          [
+            1586655215,
+            "100"
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/src/docker-images/gpu-reporter/test/logging.yaml
+++ b/src/docker-images/gpu-reporter/test/logging.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+version: 1
+disable_existing_loggers: False
+formatters:
+    pai_k8sdp:
+        format: "%(asctime)s [%(levelname)s] - %(name)s : %(message)s"
+
+handlers:
+    console:
+        class: logging.StreamHandler
+        level: DEBUG
+        formatter: pai_k8sdp
+        stream: ext://sys.stdout
+
+loggers:
+    unittest_module:
+        level: DEBUG
+        handler: [console]
+        propagate: no
+
+
+root:
+    level: DEBUG
+    handlers: [console]

--- a/src/docker-images/gpu-reporter/test/logging.yaml
+++ b/src/docker-images/gpu-reporter/test/logging.yaml
@@ -34,7 +34,6 @@ loggers:
         handler: [console]
         propagate: no
 
-
 root:
     level: DEBUG
     handlers: [console]

--- a/src/docker-images/gpu-reporter/test/test_reporter.py
+++ b/src/docker-images/gpu-reporter/test/test_reporter.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import unittest
+import yaml
+import json
+import logging
+import logging.config
+import datetime
+
+sys.path.append(os.path.abspath(".."))
+
+import reporter
+
+logger = logging.getLogger(__name__)
+
+
+class TestReporter(unittest.TestCase):
+    """
+    Test reporter.py
+    """
+    def setUp(self):
+        try:
+            os.chdir(os.path.abspath("test"))
+        except:
+            pass
+
+        configuration_path = "logging.yaml"
+
+        if os.path.exists(configuration_path):
+            with open(configuration_path, 'rt') as f:
+                logging_configuration = yaml.safe_load(f.read())
+            logging.config.dictConfig(logging_configuration)
+            logging.getLogger()
+
+    def load_data(self, path):
+        with open(path) as f:
+            return f.read()
+
+    def get_samples(self, metrics, target_name, labels):
+        result = []
+
+        for m in metrics:
+            if m.name != target_name:
+                continue
+            for sample in m.samples:
+                add = True
+                for k, v in labels.items():
+                    if sample.labels.get(k) != v:
+                        add = False
+                        break
+                if add:
+                    result.append(sample)
+        return result
+
+    def test_calculate(self):
+        step_seconds = 300
+        idleness_threshold = 0
+        end = datetime.datetime.fromtimestamp(1587768375)
+
+        calculator = reporter.IdlenessCalculator(step_seconds,
+                                                 idleness_threshold, end)
+        raw = json.loads(self.load_data("data/raw.json"))
+        result = reporter.calculate(raw, calculator)
+        self.assertTrue(result["31d"]["booked"] >= result["14d"]["booked"])
+        self.assertTrue(result["14d"]["booked"] >= result["7d"]["booked"])
+
+        self.assertTrue(result["31d"]["idle"] >= result["14d"]["idle"])
+        self.assertTrue(result["14d"]["idle"] >= result["7d"]["idle"])
+
+        self.assertEqual(50.0, result["31d"]["next"]["vvv"]["assigned_util"])
+        self.assertEqual(100.0, result["31d"]["next"]["vvv"]["nonidle_util"])
+        self.assertEqual(600, result["31d"]["next"]["vvv"]["booked"])
+        self.assertEqual(300, result["31d"]["next"]["vvv"]["idle"])
+
+        self.assertEqual(20.0,
+                         result["31d"]["next"]["platform"]["assigned_util"])
+        self.assertEqual(20.0,
+                         result["31d"]["next"]["platform"]["nonidle_util"])
+        self.assertEqual(300, result["31d"]["next"]["platform"]["booked"])
+        self.assertEqual(0, result["31d"]["next"]["platform"]["idle"])
+
+    def assert_metric_value(self, metrics, target_name, labels, value):
+        target = self.get_samples(metrics, target_name, labels)
+        self.assertEqual(1, len(target), "zero/multiple target %s" % (target))
+        self.assertEqual(value, target[0].value)
+
+    def test_walk_exported_regiter(self):
+        obj = json.loads(self.load_data("data/exported.json"))
+
+        collector = reporter.CustomCollector(None)
+        metrics = collector.walk_exported_register(obj)
+        self.assert_metric_value(metrics, "cluster_booked_gpu_second",
+                                 {"since": "31d"}, 900)
+        self.assert_metric_value(metrics, "cluster_idle_gpu_second",
+                                 {"since": "31d"}, 300)
+        self.assert_metric_value(metrics, "cluster_non_idle_utils",
+                                 {"since": "31d"}, 60)
+        self.assert_metric_value(metrics, "cluster_assigned_utils",
+                                 {"since": "31d"}, 40)
+
+        self.assert_metric_value(metrics, "cluster_booked_gpu_second",
+                                 {"since": "14d"}, 900)
+        self.assert_metric_value(metrics, "cluster_idle_gpu_second",
+                                 {"since": "14d"}, 300)
+        self.assert_metric_value(metrics, "cluster_non_idle_utils",
+                                 {"since": "14d"}, 60)
+        self.assert_metric_value(metrics, "cluster_assigned_utils",
+                                 {"since": "14d"}, 40)
+
+        self.assert_metric_value(metrics, "cluster_booked_gpu_second",
+                                 {"since": "7d"}, 0)
+        self.assert_metric_value(metrics, "cluster_idle_gpu_second",
+                                 {"since": "7d"}, 0)
+        self.assert_metric_value(metrics, "cluster_non_idle_utils",
+                                 {"since": "7d"}, 0)
+        self.assert_metric_value(metrics, "cluster_assigned_utils",
+                                 {"since": "7d"}, 0)
+
+        self.assert_metric_value(metrics, "vc_booked_gpu_second", {
+            "since": "31d",
+            "vc": "platform"
+        }, 300)
+        self.assert_metric_value(metrics, "vc_booked_gpu_second", {
+            "since": "31d",
+            "vc": "vvv"
+        }, 600)
+        self.assert_metric_value(metrics, "vc_booked_gpu_second", {
+            "since": "14d",
+            "vc": "platform"
+        }, 300)
+        self.assert_metric_value(metrics, "vc_booked_gpu_second", {
+            "since": "14d",
+            "vc": "vvv"
+        }, 600)
+        self.assert_metric_value(metrics, "vc_idle_gpu_second", {
+            "since": "31d",
+            "vc": "platform"
+        }, 0)
+        self.assert_metric_value(metrics, "vc_idle_gpu_second", {
+            "since": "31d",
+            "vc": "vvv"
+        }, 300)
+        self.assert_metric_value(metrics, "vc_idle_gpu_second", {
+            "since": "14d",
+            "vc": "platform"
+        }, 0)
+        self.assert_metric_value(metrics, "vc_idle_gpu_second", {
+            "since": "14d",
+            "vc": "vvv"
+        }, 300)
+        self.assert_metric_value(metrics, "vc_non_idle_utils", {
+            "since": "31d",
+            "vc": "platform"
+        }, 20)
+        self.assert_metric_value(metrics, "vc_non_idle_utils", {
+            "since": "31d",
+            "vc": "vvv"
+        }, 100)
+        self.assert_metric_value(metrics, "vc_non_idle_utils", {
+            "since": "14d",
+            "vc": "platform"
+        }, 20)
+        self.assert_metric_value(metrics, "vc_non_idle_utils", {
+            "since": "14d",
+            "vc": "vvv"
+        }, 100)
+        self.assert_metric_value(metrics, "vc_assigned_utils", {
+            "since": "31d",
+            "vc": "platform"
+        }, 20)
+        self.assert_metric_value(metrics, "vc_assigned_utils", {
+            "since": "31d",
+            "vc": "vvv"
+        }, 50)
+        self.assert_metric_value(metrics, "vc_assigned_utils", {
+            "since": "14d",
+            "vc": "platform"
+        }, 20)
+        self.assert_metric_value(metrics, "vc_assigned_utils", {
+            "since": "14d",
+            "vc": "vvv"
+        }, 50)
+        self.assert_metric_value(metrics, "user_booked_gpu_second", {
+            "since": "31d",
+            "vc": "platform",
+            "user": "bbb"
+        }, 300)
+        self.assert_metric_value(metrics, "user_booked_gpu_second", {
+            "since": "31d",
+            "vc": "vvv",
+            "user": "aaa"
+        }, 600)
+        self.assert_metric_value(metrics, "user_booked_gpu_second", {
+            "since": "14d",
+            "vc": "platform",
+            "user": "bbb"
+        }, 300)
+        self.assert_metric_value(metrics, "user_booked_gpu_second", {
+            "since": "14d",
+            "vc": "vvv",
+            "user": "aaa"
+        }, 600)
+        self.assert_metric_value(metrics, "user_idle_gpu_second", {
+            "since": "31d",
+            "vc": "platform",
+            "user": "bbb"
+        }, 0)
+        self.assert_metric_value(metrics, "user_idle_gpu_second", {
+            "since": "31d",
+            "vc": "vvv",
+            "user": "aaa"
+        }, 300)
+        self.assert_metric_value(metrics, "user_idle_gpu_second", {
+            "since": "14d",
+            "vc": "platform",
+            "user": "bbb"
+        }, 0)
+        self.assert_metric_value(metrics, "user_idle_gpu_second", {
+            "since": "14d",
+            "vc": "vvv",
+            "user": "aaa"
+        }, 300)
+        self.assert_metric_value(metrics, "user_non_idle_utils", {
+            "since": "31d",
+            "vc": "platform",
+            "user": "bbb"
+        }, 20)
+        self.assert_metric_value(metrics, "user_non_idle_utils", {
+            "since": "31d",
+            "vc": "vvv",
+            "user": "aaa"
+        }, 100)
+        self.assert_metric_value(metrics, "user_non_idle_utils", {
+            "since": "14d",
+            "vc": "platform",
+            "user": "bbb"
+        }, 20)
+        self.assert_metric_value(metrics, "user_non_idle_utils", {
+            "since": "14d",
+            "vc": "vvv",
+            "user": "aaa"
+        }, 100)
+        self.assert_metric_value(metrics, "user_assigned_utils", {
+            "since": "31d",
+            "vc": "platform",
+            "user": "bbb"
+        }, 20)
+        self.assert_metric_value(metrics, "user_assigned_utils", {
+            "since": "31d",
+            "vc": "vvv",
+            "user": "aaa"
+        }, 50)
+        self.assert_metric_value(metrics, "user_assigned_utils", {
+            "since": "14d",
+            "vc": "platform",
+            "user": "bbb"
+        }, 20)
+        self.assert_metric_value(metrics, "user_assigned_utils", {
+            "since": "14d",
+            "vc": "vvv",
+            "user": "aaa"
+        }, 50)
+        self.assert_metric_value(
+            metrics, "job_booked_gpu_second", {
+                "since": "31d",
+                "vc": "platform",
+                "user": "bbb",
+                "job_id": "89ba301e-58d0-4ce5-ba6b-5781a7926f63"
+            }, 300)
+        self.assert_metric_value(
+            metrics, "job_booked_gpu_second", {
+                "since": "31d",
+                "vc": "vvv",
+                "user": "aaa",
+                "job_id": "f29f07ab-8510-4ad9-ac24-363bd7271571"
+            }, 600)
+        self.assert_metric_value(
+            metrics, "job_booked_gpu_second", {
+                "since": "14d",
+                "vc": "platform",
+                "user": "bbb",
+                "job_id": "89ba301e-58d0-4ce5-ba6b-5781a7926f63"
+            }, 300)
+        self.assert_metric_value(
+            metrics, "job_booked_gpu_second", {
+                "since": "14d",
+                "vc": "vvv",
+                "user": "aaa",
+                "job_id": "f29f07ab-8510-4ad9-ac24-363bd7271571"
+            }, 600)
+        self.assert_metric_value(
+            metrics, "job_idle_gpu_second", {
+                "since": "31d",
+                "vc": "platform",
+                "user": "bbb",
+                "job_id": "89ba301e-58d0-4ce5-ba6b-5781a7926f63"
+            }, 0)
+        self.assert_metric_value(
+            metrics, "job_idle_gpu_second", {
+                "since": "31d",
+                "vc": "vvv",
+                "user": "aaa",
+                "job_id": "f29f07ab-8510-4ad9-ac24-363bd7271571"
+            }, 300)
+        self.assert_metric_value(
+            metrics, "job_idle_gpu_second", {
+                "since": "14d",
+                "vc": "platform",
+                "user": "bbb",
+                "job_id": "89ba301e-58d0-4ce5-ba6b-5781a7926f63"
+            }, 0)
+        self.assert_metric_value(
+            metrics, "job_idle_gpu_second", {
+                "since": "14d",
+                "vc": "vvv",
+                "user": "aaa",
+                "job_id": "f29f07ab-8510-4ad9-ac24-363bd7271571"
+            }, 300)
+        self.assert_metric_value(
+            metrics, "job_non_idle_utils", {
+                "since": "31d",
+                "vc": "platform",
+                "user": "bbb",
+                "job_id": "89ba301e-58d0-4ce5-ba6b-5781a7926f63"
+            }, 20)
+        self.assert_metric_value(
+            metrics, "job_non_idle_utils", {
+                "since": "31d",
+                "vc": "vvv",
+                "user": "aaa",
+                "job_id": "f29f07ab-8510-4ad9-ac24-363bd7271571"
+            }, 100)
+        self.assert_metric_value(
+            metrics, "job_non_idle_utils", {
+                "since": "14d",
+                "vc": "platform",
+                "user": "bbb",
+                "job_id": "89ba301e-58d0-4ce5-ba6b-5781a7926f63"
+            }, 20)
+        self.assert_metric_value(
+            metrics, "job_non_idle_utils", {
+                "since": "14d",
+                "vc": "vvv",
+                "user": "aaa",
+                "job_id": "f29f07ab-8510-4ad9-ac24-363bd7271571"
+            }, 100)
+        self.assert_metric_value(
+            metrics, "job_assigned_utils", {
+                "since": "31d",
+                "vc": "platform",
+                "user": "bbb",
+                "job_id": "89ba301e-58d0-4ce5-ba6b-5781a7926f63"
+            }, 20)
+        self.assert_metric_value(
+            metrics, "job_assigned_utils", {
+                "since": "31d",
+                "vc": "vvv",
+                "user": "aaa",
+                "job_id": "f29f07ab-8510-4ad9-ac24-363bd7271571"
+            }, 50)
+        self.assert_metric_value(
+            metrics, "job_assigned_utils", {
+                "since": "14d",
+                "vc": "platform",
+                "user": "bbb",
+                "job_id": "89ba301e-58d0-4ce5-ba6b-5781a7926f63"
+            }, 20)
+        self.assert_metric_value(
+            metrics, "job_assigned_utils", {
+                "since": "14d",
+                "vc": "vvv",
+                "user": "aaa",
+                "job_id": "f29f07ab-8510-4ad9-ac24-363bd7271571"
+            }, 50)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ref #1038 

Fix a [bug](https://github.com/microsoft/DLWorkspace/pull/1038/files#diff-857652c504b9a971153cd95045bdfcd3R164) regarding time: booked gpu seconds in 31d interval is less than 14d interval. Added test case to prevent this.

Also reports several more metrics, with previous metrics, gpu reporter now report metrics with following suffix:
* `_booked_gpu_second`
* `_idle_gpu_second`
* `_non_idle_utils`
* `_assigned_utils`

These metrics will have prefix of `cluster`, `vc`, `user`, `job`. They all will have a label `since` with fixed value `7d`, `14d` and `31d`.