### PR TITLE
Remove GPU reporter dependency in RestfulAPI

### DIFF
--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -72,8 +72,6 @@ enable_custom_registry_secrets: {{cnf["enable_custom_registry_secrets"]}}
 master_token: {{cnf["master_token"]}}
 vc_node_hard_assignment: {{cnf["vc_node_hard_assignment"]}}
 
-gpu_reporter: 'http://{{cnf["prometheus"]["host"]}}:{{cnf["prometheus"]["reporter"]["port"]}}'
-
 elasticsearch:
   {% for elasticsearch_node in cnf["elasticsearch_node"] %}
   - 'http://{{elasticsearch_node}}:{{cnf["elasticsearch"]["port"]["http"]}}'

--- a/src/dashboard/server/api/v2/controllers/team/cluster.js
+++ b/src/dashboard/server/api/v2/controllers/team/cluster.js
@@ -93,11 +93,6 @@ module.exports = async context => {
     }
   }
 
-  for (const [userName, data] of _team.get('gpu_idle').entries()) {
-    _setBody(['users', userName, 'gpu', 'booked'], data['booked'])
-    _setBody(['users', userName, 'gpu', 'idle'], data['idle'])
-  }
-
   for (const node of _team.get('node_status').filter(_.matches({ 'labels': { 'worker': 'active' } }))) {
     const _node = _.chain(node)
     _setBody(['workers', node.name, 'healthy'], !node['unschedulable'])

--- a/src/dashboard/server/test/v2/controllers/team/cluster/index.js
+++ b/src/dashboard/server/test/v2/controllers/team/cluster/index.js
@@ -48,13 +48,6 @@ describe('GET /teams/:teamId/clusters/:clusterId', function () {
           userMemory: { [TYPE_NAME]: 21 }
         }],
 
-        gpu_idle: {
-          [USER_NAME]: {
-            booked: 22,
-            idle: 23
-          }
-        },
-
         node_status: [{
           name: WORKER_NAME,
           labels: { worker: 'active' },
@@ -122,9 +115,6 @@ describe('GET /teams/:teamId/clusters/:clusterId', function () {
     response.data.should.have.propertyByPath('users', USER_NAME, 'types', TYPE_NAME, 'cpu', 'preemptable').equal(19)
     response.data.should.have.propertyByPath('users', USER_NAME, 'types', TYPE_NAME, 'gpu', 'preemptable').equal(20)
     response.data.should.have.propertyByPath('users', USER_NAME, 'types', TYPE_NAME, 'memory', 'preemptable').equal(21)
-
-    response.data.should.have.propertyByPath('users', USER_NAME, 'gpu', 'booked').equal(22)
-    response.data.should.have.propertyByPath('users', USER_NAME, 'gpu', 'idle').equal(23)
 
     response.data.should.have.propertyByPath('workers', WORKER_NAME, 'healthy').equal(true)
     response.data.should.have.propertyByPath('workers', WORKER_NAME, 'ip').equal('0.0.0.0')

--- a/src/dashboard/src/pages/Cluster/Users.tsx
+++ b/src/dashboard/src/pages/Cluster/Users.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState
 } from 'react';
-import { entries, find, get, set } from 'lodash';
+import { entries, find, get, keys, set, union } from 'lodash';
 
 import {
   Button,
@@ -37,6 +37,12 @@ const humanHours = (seconds: number) => {
   return formatHours(seconds);
 }
 
+interface GpuMetrics {
+  idle?: number;
+  bookedLast31Days?: number;
+  idleLast31Days?: number;
+}
+
 interface Props {
   data: any;
 }
@@ -48,20 +54,32 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
   const [filterCurrent, setFilterCurrent] = useState(true);
 
   const gpuIdleMetrics = usePrometheus(config.grafana, `count (task_gpu_percent{vc_name="${currentTeamId}"} == 0) by (username)`);
+  const gpuBookedLast31DaysMetrics = usePrometheus(config.grafana, `sum(job_booked_gpu_second{vc="${currentTeamId}", since="31d"}) by (user)`)
+  const gpuIdleLast31DaysMetrics = usePrometheus(config.grafana, `sum(job_idle_gpu_second{vc="${currentTeamId}", since="31d"}) by (user)`)
 
   const handleButtonClick = useCallback(() => {
     setFilterCurrent((filterCurrent) => !filterCurrent);
   }, [setFilterCurrent]);
 
-  const usersGPUIdle = useMemo(() => {
-    const usersGPUIdle: { [user: string]: number } = Object.create(null);
+  const usersGPUMetrics = useMemo(() => {
+    const usersGPUMetrics: { [user: string]: GpuMetrics } = Object.create(null);
     if (gpuIdleMetrics != null)  {
       for (const { metric, value } of gpuIdleMetrics.result) {
-        usersGPUIdle[metric.username] = Number(value[1]);
+        set(usersGPUMetrics, [metric.username, 'idle'], Number(value[1]));
       }
     }
-    return usersGPUIdle;
-  }, [gpuIdleMetrics]);
+    if (gpuBookedLast31DaysMetrics != null)  {
+      for (const { metric, value } of gpuBookedLast31DaysMetrics.result) {
+        set(usersGPUMetrics, [metric.user, 'bookedLast31Days'], Number(value[1]));
+      }
+    }
+    if (gpuIdleLast31DaysMetrics != null)  {
+      for (const { metric, value } of gpuIdleLast31DaysMetrics.result) {
+        set(usersGPUMetrics, [metric.user, 'idleLast31Days'], Number(value[1]));
+      }
+    }
+    return usersGPUMetrics;
+  }, [gpuIdleMetrics, gpuBookedLast31DaysMetrics, gpuIdleLast31DaysMetrics]);
 
   const data = useMemo(() => {
     const data = [];
@@ -69,19 +87,34 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
     const totalStatus = Object.create(null);
     const total = {
       status: totalStatus,
-      gpu: { booked: 0, idle: 0 },
-      gpuIdle: 0,
+      gpuMetrics: {
+        idle: 0,
+        bookedLast31Days: 0,
+        idleLast31Days: 0
+      },
       tableData: { isTreeExpanded: true }
     };
     data.push(total);
-    for (const [userName, {types, gpu}] of entries<any>(users)) {
-      if (types == null && filterCurrent) continue;
+
+    const userNames = filterCurrent ? keys(users) : union(keys(users), keys(usersGPUMetrics));
+    userNames.sort();
+
+    for (const userName of userNames) {
       const userStatus = Object.create(null);
-      const gpuIdle = usersGPUIdle[userName];
-      data.push({ id: userName, status: userStatus, gpu, gpuIdle });
-      total.gpu.booked += get(gpu, 'booked', 0);
-      total.gpu.idle += get(gpu, 'idle', 0);
-      total.gpuIdle += gpuIdle !== undefined ? gpuIdle : 0;
+      const gpuMetrics: GpuMetrics | undefined = get(usersGPUMetrics, [userName]);
+      data.push({ id: userName, status: userStatus, gpuMetrics });
+      if (gpuMetrics != null) {
+        const {
+          idle,
+          bookedLast31Days,
+          idleLast31Days,
+        } = gpuMetrics;
+        total.gpuMetrics.idle += idle || 0;
+        total.gpuMetrics.bookedLast31Days += bookedLast31Days || 0;
+        total.gpuMetrics.idleLast31Days += idleLast31Days || 0;
+      }
+
+      const types = get(users, [userName, 'types']);
       for (const [typeName, status] of entries(types)) {
         data.push({ id: typeName, userName, status })
         for (const resourceType of ['cpu', 'gpu', 'memory']) {
@@ -97,7 +130,7 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
       }
     }
     return data;
-  }, [filterCurrent, users, usersGPUIdle]);
+  }, [filterCurrent, users, usersGPUMetrics]);
   const tableData = useTableData(data);
 
   const handleUserClick = useCallback((userName: string) => () => {
@@ -159,29 +192,29 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
     width: 'auto'
   } as Column<any>, {
     title: 'GPU Idle',
-    field: 'gpuIdle',
+    field: 'gpuMetrics.idle',
     type: 'numeric',
-    render: ({ gpuIdle }) => typeof gpuIdle === 'number' && (
-      <Typography variant="inherit" color={gpuIdle > 0 ? "error" : "inherit"}>
-        {gpuIdle}
+    render: ({ gpuMetrics }) => gpuMetrics != null && typeof gpuMetrics.idle === 'number' && (
+      <Typography variant="inherit" color={gpuMetrics.idle > 0 ? "error" : "inherit"}>
+        {gpuMetrics.idle}
       </Typography>
     ),
     width: 'auto'
   } as Column<any>, {
-    title: <CaptionColumnTitle caption="Last 30 days">Booked GPU</CaptionColumnTitle>,
-    field: 'gpu.booked',
+    title: <CaptionColumnTitle caption="Last 31 days">Booked GPU</CaptionColumnTitle>,
+    field: 'gpuMetrics.bookedLast31Days',
     type: 'numeric',
-    render: (data) => <>{humanHours(get(data, 'gpu.booked'))}</>,
+    render: (data) => <>{humanHours(get(data, 'gpuMetrics.bookedLast31Days'))}</>,
     width: 'auto'
   } as Column<any>, {
-    title: <CaptionColumnTitle caption="Last 30 days">Idle GPU (%)</CaptionColumnTitle>,
-    field: 'gpu.idle',
+    title: <CaptionColumnTitle caption="Last 31 days">Idle GPU (%)</CaptionColumnTitle>,
+    field: 'gpu.idleLast31Days',
     type: 'numeric',
     render: (data) => {
       if (data.userName) return;
 
-      const booked = get(data, 'gpu.booked', 0);
-      const idle = get(data, 'gpu.idle', 0);
+      const booked = get(data, 'gpuMetrics.bookedLast31Days', 0);
+      const idle = get(data, 'gpuMetrics.idleLast31Days', 0);
 
       if (booked === 0) return <>{humanHours(idle)}</>;
 

--- a/src/dashboard/src/pages/ClusterStatus/components/TeamVCUserStatus.tsx
+++ b/src/dashboard/src/pages/ClusterStatus/components/TeamVCUserStatus.tsx
@@ -56,10 +56,6 @@ export const TeamVCUserStatus = (props: TeamUsr) => {
           columns={[{title: 'Username', field: 'userName'},
             {title: 'Currently Allocated GPU', field: 'usedGPU',type:'numeric'},
             {title: 'Currently Allocated Preemptible GPU', field: 'preemptableGPU',type:'numeric', render: (rowData: any) => <span>{rowData['preemptableGPU'] ? rowData['preemptableGPU'] : '0'}</span>},
-            {title: 'Currently Idle GPU', field: 'idleGPU',type:'numeric'},
-            {title: 'Past Month Booked GPU Hour', field: 'booked',type:'numeric'},
-            {title: 'Past Month Idle GPU Hour', field: 'idle',type:'numeric'},
-            {title: 'Past Month Idle GPU Hour %', field: '',type:'numeric', render: (rowData: any) => currentCluster === 'Lab-RR1-V100' ? null : <span style={{ color: Math.floor((rowData['idle'] / rowData['booked']) * 100) > 50 ? "red" : "black" }}>{rowData['booked'] == '0' ? '-' : Math.floor((rowData['idle'] / rowData['booked']) * 100)}</span>, customSort: (a: any, b: any) => {return Math.floor((a['idle'] / a['booked']) * 100) - Math.floor((b['idle'] / b['booked']) * 100)}}
           ]}
           data={showCurrentUser ? userStatus.filter((uc: any)=>uc['usedGPU'] > 0 && uc['userName'] !== 'Total') : userStatus}
           options={{filtering: false, paging: false, sorting: true}}

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -894,19 +894,6 @@ def ListVCs(userName):
     return ret
 
 
-def get_gpu_idle(vc_name):
-    ret = None
-    try:
-        gpu_idle_url = config["gpu_reporter"] + '/gpu_idle'
-        gpu_idle_params = {"vc": vc_name}
-        gpu_idle_response = requests.get(gpu_idle_url, params=gpu_idle_params)
-        gpu_idle_json = gpu_idle_response.json()
-        ret = gpu_idle_json
-    except Exception:
-        logger.exception("Failed to fetch gpu_idle from " "gpu-exporter")
-    return ret
-
-
 def get_vc(username, vc_name):
     ret = None
     try:
@@ -929,9 +916,6 @@ def get_vc(username, vc_name):
                 # TODO: deprecate typo "AvaliableJobNum" in legacy code
                 ret["AvaliableJobNum"] = ret["available_job_num"]
 
-                gpu_idle = get_gpu_idle(vc_name)
-                if gpu_idle is not None:
-                    ret["gpu_idle"] = gpu_idle
                 break
     except:
         logger.exception("Exception in getting VC %s for user %s", vc_name,


### PR DESCRIPTION
Currently RestfulAPI will call gpu reporter for gpu metrics in /GetVC API, this PR will remove these calls and make dashboard directly query Prometheus for those data.

**Require #1038, #1057 to be deployed. If there will be other dashboard deployments before that, do not merge.**

- [x] Unit tests
- [ ] Legacy Cluster Status page support: removed these columns