### PR TITLE
[RepairManager] fix repairmanageragent hostnetwork

### DIFF
--- a/src/ClusterBootstrap/services/repairmanageragent/repairmanageragent.yaml
+++ b/src/ClusterBootstrap/services/repairmanageragent/repairmanageragent.yaml
@@ -17,6 +17,7 @@ spec:
       {% if cnf["dnsPolicy"] %}
       dnsPolicy: {{cnf["dnsPolicy"]}}
       {% endif %}
+      hostNetwork: true # allow to bypass firewall
       hostPID: true
       nodeSelector:
         repairmanageragent: active


### PR DESCRIPTION
allow repairmanager agent docker container to bypass firewall and communicate with etcd container on infra node

@xudifsd @Anbang-Hu @YinYangOfDao 