### PR TITLE
[RepairManager] improve repairmanager docker images

### DIFF
--- a/src/docker-images/RepairManager/Dockerfile
+++ b/src/docker-images/RepairManager/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 MAINTAINER Deborah Sandoval <Deborah.Sandoval@microsoft.com>
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
-    python3.5 \
+    python3.7 \
     python3-pip
 
 RUN pip3 install wheel setuptools requests
@@ -16,5 +16,4 @@ RUN chmod +x /run.sh
 ADD RepairManager /DLWorkspace/src/RepairManager
 
 RUN pip3 install -r /DLWorkspace/src/RepairManager/requirements.txt
-
 CMD /run.sh

--- a/src/docker-images/RepairManager/Dockerfile
+++ b/src/docker-images/RepairManager/Dockerfile
@@ -5,9 +5,7 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
     python3.5 \
     python3-pip
 
-RUN pip3 install wheel
-RUN pip3 install setuptools
-RUN pip3 install requests
+RUN pip3 install wheel setuptools requests
 
 COPY kubectl /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl

--- a/src/docker-images/RepairManagerAgent/Dockerfile
+++ b/src/docker-images/RepairManagerAgent/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
     systemd-sysv
 
 RUN pip3 install wheel setuptools requests
+
+# separate line as pyyaml has dependency on setuptools
 RUN pip3 install pyyaml
 
 COPY run.sh /

--- a/src/docker-images/RepairManagerAgent/Dockerfile
+++ b/src/docker-images/RepairManagerAgent/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.7
+FROM ubuntu:18.04
 MAINTAINER Deborah Sandoval <Deborah.Sandoval@microsoft.com>
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
+    python3.7 \
+    python3-pip \
     systemd-sysv
 
-RUN pip3 install wheel setuptools requests pyyaml
+RUN pip3 install wheel setuptools requests
+RUN pip3 install pyyaml
 
 COPY run.sh /
 RUN chmod +x /run.sh


### PR DESCRIPTION
Currently ubuntu base image is smaller than python base image. 
This Dockerfile change decreases image size from 965MB to 173MB.

@xudifsd @Anbang-Hu @YinYangOfDao 