### PR TITLE
add preemptible label to task_* metrics

### DIFF
--- a/src/ClusterManager/framework.py
+++ b/src/ClusterManager/framework.py
@@ -275,6 +275,11 @@ def gen_container_envs(job, role):
         result.append({"name": "DLWS_HOST_NETWORK", "value": "enable"})
         result.append({"name": "DLTS_HOST_NETWORK", "value": "enable"})
 
+    if job.is_preemption_allowed:
+        result.append({"name": "DLTS_PREEMPTIBLE", "value": "true"})
+    else:
+        result.append({"name": "DLTS_PREEMPTIBLE", "value": "false"})
+
     for i, key_value in enumerate(job.ssh_public_keys):
         result.append({
             "name": "DLTS_PUBLIC_SSH_KEY_%d" % i,

--- a/src/Jobs_Templete/deployment.yaml.template
+++ b/src/Jobs_Templete/deployment.yaml.template
@@ -120,6 +120,12 @@ spec:
           value: {{ job["vcName"] }}
         - name: DLTS_VC_NAME
           value: {{ job["vcName"] }}
+        - name: DLTS_PREEMPTIBLE
+        {% if job["preemptionAllowed"] %}
+          value: true
+        {% else%}
+          value: false
+        {% endif %}
         {% for env in job["envs"] %}
         - name: {{env.name}}
           value: "{{env.value}}"

--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -257,6 +257,12 @@ spec:
     - name: DLTS_HOST_NETWORK
       value: "enable"
     {% endif %}
+    - name: DLTS_PREEMPTIBLE
+    {% if job["preemptionAllowed"] %}
+      value: true
+    {% else%}
+      value: false
+    {% endif %}
     {% for env in job["envs"] %}
     - name: {{env.name}}
       value: "{{env.value}}"

--- a/src/docker-images/job-exporter/src/collector.py
+++ b/src/docker-images/job-exporter/src/collector.py
@@ -133,6 +133,7 @@ class ResourceGauges(object):
             "pod_name",
             "user_email",
             "vc_name",
+            "preemptible",
         ]
         self.service_labels = ["name"]
 
@@ -203,6 +204,12 @@ class ResourceGauges(object):
         label_array = [None] * len(gauge._labelnames)
 
         for k, v in labels.items():
+            if type(k) != str or \
+                    type(v) != str or \
+                    type(val) not in {int, float}:
+                raise RuntimeError("type error for add_value %s, %s, %s",
+                                   metric_name, labels,
+                                   val) # fail fast to facilitate debug
             try:
                 index = gauge._labelnames.index(k)
                 label_array[index] = v
@@ -613,6 +620,7 @@ class ContainerCollector(Collector):
         result_labels["pod_name"] = inspect_info.pod_name or "unknown"
         result_labels["user_email"] = inspect_info.email or "unknown"
         result_labels["vc_name"] = inspect_info.vc_name or "unknown"
+        result_labels["preemptible"] = str(inspect_info.is_preemptible).lower()
 
         if inspect_info.gpu_ids:
             ids = inspect_info.gpu_ids.replace("\"", "").split(",")

--- a/src/docker-images/job-exporter/src/docker_inspect.py
+++ b/src/docker-images/job-exporter/src/docker_inspect.py
@@ -58,7 +58,8 @@ class InspectResult(object):
                 self.pid == o.pid and \
                 self.email == o.email and \
                 self.vc_name == o.vc_name and \
-                self.is_host_network == o.is_host_network
+                self.is_host_network == o.is_host_network and \
+                self.is_preemptible == o.is_preemptible
 
 
 keys = {

--- a/src/docker-images/job-exporter/src/docker_inspect.py
+++ b/src/docker-images/job-exporter/src/docker_inspect.py
@@ -29,17 +29,18 @@ logger = logging.getLogger(__name__)
 class InspectResult(object):
     """ Represents a task meta data, parsed from docker inspect result """
     def __init__(self, username, job_name, role_name, task_index, pod_name,
-                 gpu_ids, pid, email, vc_name, is_host_network):
+                 gpu_ids, pid, email, vc_name, is_host_network, is_preemptible):
         self.username = username
         self.job_name = job_name
         self.role_name = role_name
         self.task_index = task_index
         self.pod_name = pod_name
-        self.gpu_ids = gpu_ids  # comma seperated str, str may be minor_number or UUID
+        self.gpu_ids = gpu_ids # comma seperated str, str may be minor_number or UUID
         self.pid = pid
-        self.email = email  # None on no value
-        self.vc_name = vc_name  # None on no value
-        self.is_host_network = is_host_network  # boolean
+        self.email = email # None on no value
+        self.vc_name = vc_name # None on no value
+        self.is_host_network = is_host_network # boolean
+        self.is_preemptible = is_preemptible # boolean
 
     def __repr__(self):
         return "username %s, job_name %s, role_name %s, task_index %s, pod_name %s, gpu_ids %s, pid %s, email %s, vc %s" % \
@@ -61,12 +62,28 @@ class InspectResult(object):
 
 
 keys = {
-    "PAI_JOB_NAME", "PAI_USER_NAME", "PAI_CURRENT_TASK_ROLE_NAME", "GPU_ID",
-    "PAI_TASK_INDEX", "POD_NAME", "FC_TASK_INDEX", "DLWS_JOB_ID",
-    "DLWS_USER_NAME", "DLWS_USER_EMAIL", "DLWS_VC_NAME", "DLWS_ROLE_NAME",
-    "DLWS_ROLE_IDX", "DLWS_HOST_NETWORK", "DLTS_JOB_ID", "DLTS_USER_NAME",
-    "DLTS_USER_EMAIL", "DLTS_VC_NAME", "DLTS_ROLE_NAME", "DLTS_ROLE_IDX",
-    "DLTS_HOST_NETWORK"
+    "PAI_JOB_NAME",
+    "PAI_USER_NAME",
+    "PAI_CURRENT_TASK_ROLE_NAME",
+    "GPU_ID",
+    "PAI_TASK_INDEX",
+    "POD_NAME",
+    "FC_TASK_INDEX",
+    "DLWS_JOB_ID",
+    "DLWS_USER_NAME",
+    "DLWS_USER_EMAIL",
+    "DLWS_VC_NAME",
+    "DLWS_ROLE_NAME",
+    "DLWS_ROLE_IDX",
+    "DLWS_HOST_NETWORK",
+    "DLTS_JOB_ID",
+    "DLTS_USER_NAME",
+    "DLTS_USER_EMAIL",
+    "DLTS_VC_NAME",
+    "DLTS_ROLE_NAME",
+    "DLTS_ROLE_IDX",
+    "DLTS_HOST_NETWORK",
+    "DLTS_PREEMPTIBLE",
 }
 
 
@@ -111,8 +128,7 @@ def parse_docker_inspect(inspect_output):
                               ["PAI_JOB_NAME", "DLWS_JOB_ID", "DLTS_JOB_ID"]),
         select_value_with_key(
             m,
-            ["PAI_CURRENT_TASK_ROLE_NAME", "DLWS_ROLE_NAME", "DLTS_ROLE_NAME"
-             ]),
+            ["PAI_CURRENT_TASK_ROLE_NAME", "DLWS_ROLE_NAME", "DLTS_ROLE_NAME"]),
         select_value_with_key(m, [
             "PAI_TASK_INDEX", "DLWS_ROLE_IDX", "DLTS_ROLE_IDX", "FC_TASK_INDEX"
         ]),
@@ -121,8 +137,9 @@ def parse_docker_inspect(inspect_output):
         pid,
         select_value_with_key(m, ["DLWS_USER_EMAIL", "DLTS_USER_EMAIL"]),
         select_value_with_key(m, ["DLWS_VC_NAME", "DLTS_VC_NAME"]),
-        m.get("DLWS_HOST_NETWORK") == "enable"
-        or m.get("DLTS_HOST_NETWORK") == "enable",
+        m.get("DLWS_HOST_NETWORK") == "enable" or
+        m.get("DLTS_HOST_NETWORK") == "enable",
+        m.get("DLTS_PREEMPTIBLE") == "true",
     )
 
 

--- a/src/docker-images/job-exporter/test/test_collector.py
+++ b/src/docker-images/job-exporter/test/test_collector.py
@@ -51,6 +51,7 @@ class TestContainerCollector(base.TestBase):
             "dixu@example.com",
             "platform",
             False,
+            False,
         )
 
         gpu_ids, labels = ContainerCollector.parse_from_labels(
@@ -65,6 +66,7 @@ class TestContainerCollector(base.TestBase):
             "pod_name": "this_is_pod_name_val",
             "user_email": "dixu@example.com",
             "vc_name": "platform",
+            "preemptible": "false",
         }
 
         self.assertEqual(target_labels, labels)

--- a/src/docker-images/job-exporter/test/test_docker_inspect.py
+++ b/src/docker-images/job-exporter/test/test_docker_inspect.py
@@ -47,6 +47,7 @@ class TestDockerInspect(base.TestBase):
             None,
             None,
             False,
+            False,
         )
 
         self.assertEqual(target_inspect_info, inspect_info)
@@ -68,6 +69,7 @@ class TestDockerInspect(base.TestBase):
             None,
             None,
             False,
+            False,
         )
         self.assertEqual(target_inspect_info, inspect_info)
 
@@ -88,6 +90,7 @@ class TestDockerInspect(base.TestBase):
             None,
             None,
             False,
+            False,
         )
         self.assertEqual(target_inspect_info, inspect_info)
 
@@ -107,6 +110,7 @@ class TestDockerInspect(base.TestBase):
             3533,
             "dixu@example.com",
             "platform",
+            False,
             False,
         )
         self.assertEqual(target_inspect_info, inspect_info)


### PR DESCRIPTION
Add a `preemptible` label to all `task_*` metrics, with possible value `true` and `false`.

Old jobs already running will have default value `false` regardless their settings.