### PR TITLE
fix inference worker log missed on NFS

### DIFF
--- a/src/utils/k8sUtils.py
+++ b/src/utils/k8sUtils.py
@@ -159,7 +159,7 @@ def GetPod(selector):
 def GetLog(jobId, tail=None):
     # assume our job only one container per pod.
 
-    selector = "run=" + jobId
+    selector = "jobId=" + jobId
     podInfo = GetPod(selector)
     logs = []
 


### PR DESCRIPTION
Inference worker does not have label "run". So use label "jobId"