### PR TITLE
Only show Infiniband metrics for worker in Grafana dashboard

### DIFF
--- a/src/ClusterBootstrap/services/monitor/grafana-config-raw/job-status-dashboard.json
+++ b/src/ClusterBootstrap/services/monitor/grafana-config-raw/job-status-dashboard.json
@@ -47,7 +47,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1588881952699,
+  "iteration": 1588910468210,
   "links": [],
   "panels": [
     {
@@ -755,7 +755,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(task_infiniband_receive_bytes_total{job_name=\"$job_name\", link_layer=\"InfiniBand\"}[5m])) by (instance, device, port)",
+          "expr": "sum(rate(task_infiniband_receive_bytes_total{job_name=\"$job_name\", link_layer=\"InfiniBand\", role_name=\"worker\"}[5m])) by (instance, device, port)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -763,7 +763,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(task_infiniband_transmit_bytes_total{job_name=\"$job_name\", link_layer=\"InfiniBand\"}[5m])) by (instance, device, port)",
+          "expr": "sum(rate(task_infiniband_transmit_bytes_total{job_name=\"$job_name\", link_layer=\"InfiniBand\", role_name=\"worker\"}[5m])) by (instance, device, port)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} {{device}}:{{port}} Outbound",
@@ -852,7 +852,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(task_ipoib_receive_bytes_total{job_name=\"$job_name\"}[5m])) by (instance, device)",
+          "expr": "sum(rate(task_ipoib_receive_bytes_total{job_name=\"$job_name\", role_name=\"worker\"}[5m])) by (instance, device)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -860,7 +860,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(task_ipoib_transmit_bytes_total{job_name=\"$job_name\"}[5m])) by (instance, device)",
+          "expr": "sum(rate(task_ipoib_transmit_bytes_total{job_name=\"$job_name\", role_name=\"worker\"}[5m])) by (instance, device)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} {{device}} Outbound",
@@ -965,5 +965,5 @@
   "timezone": "browser",
   "title": "Job Status",
   "uid": "job-status",
-  "version": 6
+  "version": 2
 }


### PR DESCRIPTION
#1079 double counts Infiniband throughput for node hosting worker and ps:
![image](https://user-images.githubusercontent.com/5781796/81369254-ce664080-90a6-11ea-8c3a-5385c9779dcd.png)

Restricting to showing only worker metrics:
![image](https://user-images.githubusercontent.com/5781796/81369375-184f2680-90a7-11ea-91ec-6f942d03473d.png)
