### PR TITLE
Dashboard: support reloading the SSL key and cert automatically

### DIFF
--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -22,6 +22,7 @@
     "koa-router": "^7.4.0",
     "koa-send": "^5.0.0",
     "koa-static": "^5.0.0",
+    "live-secure-context": "0.0.0",
     "lodash": "^4.17.15",
     "luxon": "^1.17.2",
     "material-table": "^1.49.0",

--- a/src/dashboard/server/index.js
+++ b/src/dashboard/server/index.js
@@ -10,7 +10,7 @@ app.use(require('./frontend'))
 if (require.main === module) {
   const http = require('http')
   const http2 = require('http2')
-  const fs = require('fs')
+  const liveSecureContext = require('live-secure-context')
 
   const {
     HOST,
@@ -21,12 +21,15 @@ if (require.main === module) {
 
   const server = SSL_KEY && SSL_CERT
     ? http2.createSecureServer({
-      allowHTTP1: true,
-      key: fs.readFileSync(SSL_KEY),
-      cert: fs.readFileSync(SSL_CERT)
+      allowHTTP1: true
     })
     : http.createServer()
-
+  if (SSL_KEY && SSL_CERT) {
+    liveSecureContext(server, {
+      key: SSL_KEY,
+      cert: SSL_CERT
+    })
+  }
   server.on('request', app.callback())
   server.listen(PORT, HOST)
 }

--- a/src/dashboard/yarn.lock
+++ b/src/dashboard/yarn.lock
@@ -7637,6 +7637,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+live-secure-context@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/live-secure-context/-/live-secure-context-0.0.0.tgz#a166df91a2a4479cdef71d5733e6efd534d66de7"
+  integrity sha512-Kcm5/K79gdxmuC6DT3v36I6pKnQNPNFRNhQAEpm1L9vs6r7IbHgpx/LxIbTV2X52RGfpaJC7Htcvj3FIC14XMQ==
+  dependencies:
+    debug "^4.1.1"
+
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"


### PR DESCRIPTION
Currently, the key and cert of the server are not updated when the file is updated. And this causes us to stop the server to update the certification.
After checking in this PR, it will replace the certification with the server  automatically when the file of SSL is updated.