### PR TITLE
add preemptible-job-priority

### DIFF
--- a/src/ClusterManager/framework.py
+++ b/src/ClusterManager/framework.py
@@ -680,10 +680,6 @@ def transform_regular_job(params, cluster_config):
 
     labels = params.get("label", {})
     annotations = params.get("annotations", {})
-    if cluster_config["is_support_pod_priority"]:
-        priority_class = "job-priority"
-    else:
-        priority_class = None
 
     framework = Framework(
         params["init-container"],
@@ -705,7 +701,7 @@ def transform_regular_job(params, cluster_config):
         params.get("nodeSelector", {}),
         params.get("private_key", ""),
         params.get("ssh_public_keys", []),
-        priority_class,
+        params.get("priority_class"),
         params.get("preemptionAllowed", False),
         params.get("hostNetwork", False),
         params.get("hostIPC", False),
@@ -752,10 +748,6 @@ def transform_distributed_job(params, cluster_config):
 
     labels = params.get("label", {})
     annotations = params.get("annotations", {})
-    if cluster_config["is_support_pod_priority"]:
-        priority_class = "job-priority"
-    else:
-        priority_class = None
 
     framework = Framework(
         params["init-container"],
@@ -777,7 +769,7 @@ def transform_distributed_job(params, cluster_config):
         params.get("nodeSelector", {}),
         params.get("private_key", ""),
         params.get("ssh_public_keys", []),
-        priority_class,
+        params.get("priority_class"),
         params.get("preemptionAllowed", False),
         params.get("hostNetwork", False),
         params.get("hostIPC", False),
@@ -821,11 +813,6 @@ def transform_inference_job(params, cluster_config):
     labels = params.get("label", {})
     annotations = params.get("annotations", {})
 
-    if cluster_config["is_support_pod_priority"]:
-        priority_class = "inference-job-priority"
-    else:
-        priority_class = None
-
     framework = Framework(
         None, # init container
         labels,
@@ -846,7 +833,7 @@ def transform_inference_job(params, cluster_config):
         params.get("nodeSelector", {}),
         params.get("private_key", ""),
         params.get("ssh_public_keys", []),
-        priority_class,
+        params.get("priority_class"),
         params.get("preemptionAllowed", False),
         params.get("hostNetwork", False),
         params.get("hostIPC", False),

--- a/src/Jobs_Templete/deployment.yaml.template
+++ b/src/Jobs_Templete/deployment.yaml.template
@@ -202,4 +202,6 @@ spec:
       {% endif %}
       {% endfor %}
       {% endif %}
-      priorityClassName: inference-job-priority
+      {% if job["priority_class"] %}
+      priorityClassName: {{ job["priority_class"] }}
+      {% endif %}

--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -335,4 +335,6 @@ spec:
   {% endif %}
   {% endfor %}
   {% endif %}
-  priorityClassName: job-priority
+  {% if job["priority_class"] %}
+  priorityClassName: {{ job["priority_class"] }}
+  {% endif %}

--- a/src/docker-images/RestfulAPI/runScheduler.sh
+++ b/src/docker-images/RestfulAPI/runScheduler.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-kubectl create priorityclass job-priority --value=1000 --description="job pod priority" --dry-run -o yaml | kubectl replace --force=true -f -
+kubectl create priorityclass job-priority --value=1000 --description="non-preemptible job pod priority" --dry-run -o yaml | kubectl replace --force=true -f -
+kubectl create priorityclass preemptible-job-priority --value=500 --description="preemptible job pod priority" --dry-run -o yaml | kubectl replace --force=true -f -
 kubectl create priorityclass inference-job-priority --value=100 --description="inference job priority" --dry-run -o yaml | kubectl replace --force=true -f -
 
 export KUBE_SERVER_VERSION=`kubectl version | gawk 'match($0, /Server Version:.*GitVersion:"v([^"]*)"/, a) {print a[1]}'`


### PR DESCRIPTION
let preemptible training job use `preemptible-job-priority` so that when gpu fragment happens, k8s scheduler could preempt preemptible jobs.

With retry policy enabled in framework launcher, preemptible job can retry after being preemption.