### PR TITLE
add email sender

### DIFF
--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -769,9 +769,9 @@ default_config_parameters = {
     },
     "cloud_config_nsg_rules": {
         "corpnet_dev_ports": "22 80 1443 3000 3306 5000 9091",
-        "inter_connect_ports": "1443 2379 2382 3306 5000 10250 10255",
+        "inter_connect_ports": "1443 2379 2382 3306 5000 9095 10250 10255",
         "corpnet_user_ports": "30000-49999",
-        "nfs_ports": "'*'", 
+        "nfs_ports": "'*'",
         # all of below except for default_admin_username deprecated after fixing port rules
         "vnet_range": "192.168.0.0/16",
         "default_admin_username": "core",
@@ -780,7 +780,7 @@ default_config_parameters = {
         #"udp_port_ranges": "25826",
         "inter_connect": {
             "tcp_port_ranges":
-                "22 1443 2379 2382 3306 5000 8086 9092 9114 9200 9300 10250 30000-49999",
+                "22 1443 2379 2382 3306 5000 8086 9095 9092 9114 9200 9300 10250 30000-49999",
             # Need to white list dev machines to connect
             # "source_addresses_prefixes": [ "52.151.0.0/16"]
         },

--- a/src/ClusterBootstrap/params.py
+++ b/src/ClusterBootstrap/params.py
@@ -1,12 +1,19 @@
 # These are the default configuration parameter
 default_config_parameters = {
     "supported_platform": ["azure_cluster", "onpremise"],
-    "allroles": {"infra", "infrastructure", "worker", "nfs", "sql", "dev", "etcd", "kubernetes_master", "mysqlserver", "elasticsearch", "samba", "lustre", "mdt", "oss"},
+    "allroles": {
+        "infra", "infrastructure", "worker", "nfs", "sql", "dev", "etcd",
+        "kubernetes_master", "mysqlserver", "elasticsearch", "samba", "lustre",
+        "mdt", "oss"
+    },
     # Kubernetes setting
     "service_cluster_ip_range": "10.3.0.0/16",
     "pod_ip_range": "10.2.0.0/16",
-    "ssl_localhost_ips": [ "127.0.0.1", "127.0.1.1" ],
-    "dns_server": {"azure_cluster": '8.8.8.8', 'onpremise':'10.50.10.50'},
+    "ssl_localhost_ips": ["127.0.0.1", "127.0.1.1"],
+    "dns_server": {
+        "azure_cluster": '8.8.8.8',
+        'onpremise': '10.50.10.50'
+    },
     # Home in server, to aide Kubernete setup
     "homeinserver": "http://dlws-clusterportal.westus.cloudapp.azure.com:5000",
     "cloud_influxdb_node": "dlws-influxdb.westus.cloudapp.azure.com",
@@ -14,9 +21,9 @@ default_config_parameters = {
     "cloud_influxdb_tp_port": "25826",
     "cloud_elasticsearch_node": "dlws-influxdb.westus.cloudapp.azure.com",
     "cloud_elasticsearch_port": "9200",
-
-    "fluent_bit": { "port": 2020 },
-
+    "fluent_bit": {
+        "port": 2020
+    },
     "elasticsearch": {
         "enabled": False,
         "port": {
@@ -26,24 +33,35 @@ default_config_parameters = {
             "kibana": 5601,
         },
     },
-
     "azure_blob_log": {
         "enabled": False,
         "port": {
             "adapter": 6200
         }
     },
-
     "influxdb_port": "8086",
     "influxdb_tp_port": "25826",
     "influxdb_rpc_port": "8088",
     "influxdb_data_path": "/var/lib/influxdb",
-
-    "prometheus": { "port": 9091, "reporter": {"port": 9092} },
-    "job-exporter": { "port": 9102 },
-    "node-exporter": { "port": 9100 },
-    "watchdog": { "port": 9101 },
-    "grafana": { "port": 3000, "prometheus-ip": "localhost" },
+    "prometheus": {
+        "port": 9091,
+        "reporter": {
+            "port": 9092
+        }
+    },
+    "job-exporter": {
+        "port": 9102
+    },
+    "node-exporter": {
+        "port": 9100
+    },
+    "watchdog": {
+        "port": 9101
+    },
+    "grafana": {
+        "port": 3000,
+        "prometheus-ip": "localhost"
+    },
     "alert-manager": {
         "port": 9093,
         "configured": False,
@@ -55,14 +73,15 @@ default_config_parameters = {
             "dry-run": True,
             "port": "9500",
             "restful-url": "http://localhost:5000",
+        },
+        "email-sender": {
+            "port": 9095
         }
     },
-
     "storage-manager": {
         "port": 9094
     },
-
-    "repair-manager": { 
+    "repair-manager": {
         "prometheus-ip": "localhost",
         "prometheus-port": 9091,
         "etcd": {
@@ -71,22 +90,19 @@ default_config_parameters = {
             "client-port": 2382
         }
     },
-
     "mysql_port": "3306",
     "mysql_username": "root",
     "mysql_data_path": "/var/lib/mysql",
-
     "datasource": "MySQL",
     "defalt_virtual_cluster_name": "platform",
     # Discover server is used to find IP address of the host, it need to be a well-known IP address
     # that is pingable.
     "discoverserver": "4.2.2.1",
     "homeininterval": "600",
-
-    "etcd3port1": "2379",  # Etcd3port1 will be used by App to call Etcd
-    "etcd3port2": "4001",  # Etcd3port2 is established for legacy purpose.
-    "etcd3portserver": "2380",  # Server port for etcd
-    "k8sAPIport": "1443",  # Server port for apiserver
+    "etcd3port1": "2379", # Etcd3port1 will be used by App to call Etcd
+    "etcd3port2": "4001", # Etcd3port2 is established for legacy purpose.
+    "etcd3portserver": "2380", # Server port for etcd
+    "k8sAPIport": "1443", # Server port for apiserver
     "nvidiadriverversion": "375.20",
     # Default port for WebUI, Restful API,
     # Port webUI will run upon, nginx will forward to this port.
@@ -111,7 +127,6 @@ default_config_parameters = {
     "physical-mount-path": "/mntdlws",
     # the path of where local device is mounted.
     "local-mount-path": "/mnt",
-
     "physical-mount-path-vc": "/mntdlts/nfs",
 
     # required storage folder under storage-mount-path
@@ -124,8 +139,6 @@ default_config_parameters = {
     "systemdisk": "/dev/sda",
     "data-disk": "/dev/[sh]d[^a]",
     "partition-configuration": ["1"],
-
-
     "render-exclude": {
         "GlusterFSUtils.pyc": True,
         "launch_glusterfs.pyc": True,
@@ -180,10 +193,8 @@ default_config_parameters = {
             "su": True,
             "options": "--net=host",
         },
-
     },
     "mountpoints": {},
-
     "build-docker-via-config": {
         "hdfs": True,
         "spark": True,
@@ -191,57 +202,75 @@ default_config_parameters = {
     },
     #"render-by-line": { "preseed.cfg": True, },
     # glusterFS parameter
-    "glusterFS": {"dataalignment": "1280K",
-                  "physicalextentsize": "128K",
-                  "volumegroup": "gfs_vg",
-                  # metasize is total_capacity / physicalextentsize * 64
-                  "metasize": "16776960K",
-                  # Volume needs to leave room for metadata and thinpool
-                  # provisioning, 98%FREE is doable for a 1TB drive.
-                  "volumesize": "98%FREE",
-                  "metapoolname": "gfs_pool_meta",
-                  "datapoolname": "gfs_pool",
-                  "volumename": "gfs_lv",
-                  "chunksize": "1280K",
-                  "mkfs.xfs.options": "-f -i size=512 -n size=8192 -d su=128k,sw=10",
-                  "mountpoint": "/mnt/glusterfs/localvolume",
-                  # GlusterFS volume to be constructed.
-                  "glustefs_nodes_yaml": "./deploy/docker-images/glusterfs/glusterfs_config.yaml",
-                  "glusterfs_docker": "glusterfs",
-                  # File system should always be accessed from the symbolic
-                  # link, not from the actual mountpoint
-                  "glusterfs_mountpoint": "/mnt/glusterfs/private",
-                  "glusterfs_symlink": "/mnt/glusterfs",
-                  # Spell out a number of glusterFS volumes to be created on the cluster.
-                  # Please refer to https://access.redhat.com/documentation/en-US/Red_Hat_Storage/2.1/html/Administration_Guide/sect-User_Guide-Setting_Volumes-Distributed_Replicated.html
-                  # for proper volumes in glusterFS.
-                  # By default, all worker nodes with glusterFS installed will be placed in the default group.
-                  # The behavior can be modified by spell out the group that the node is expected to be in.
-                  # E.g.,
-                  # node01:
-                  #   gluterfs: 1
-                  # will place node01 into a glusterfs group 1. The nodes in each glusterfs group will form separate volumes
-                  #
-                  "gluster_volumes": {
-                      "default": {
-                          "netvolume": {
-                                "property": "replica 3",
-                                "transport": "tcp,rdma",
-                                # of nodes that can fail before the volume will
-                                # become unaccessible.
-                                "tolerance": 2,
-                              # number of bricks need to be a multiple of this
-                              "multiple": 3,
-                          },
-                      },
-                  },
-                  # These parameters are required for every glusterfs volumes
-                  "gluster_volumes_required_param": ["property", "transport", "tolerance", "multiple"],
-                  # To use glusterFS, you will configure the partitions parameter
-                  # partitions: /dev/sd[^a]
-                  # which is a regular expression calls out all partition
-                  # that will be deployed with glusterfs
-                  },
+    "glusterFS": {
+        "dataalignment":
+            "1280K",
+        "physicalextentsize":
+            "128K",
+        "volumegroup":
+            "gfs_vg",
+        # metasize is total_capacity / physicalextentsize * 64
+        "metasize":
+            "16776960K",
+        # Volume needs to leave room for metadata and thinpool
+        # provisioning, 98%FREE is doable for a 1TB drive.
+        "volumesize":
+            "98%FREE",
+        "metapoolname":
+            "gfs_pool_meta",
+        "datapoolname":
+            "gfs_pool",
+        "volumename":
+            "gfs_lv",
+        "chunksize":
+            "1280K",
+        "mkfs.xfs.options":
+            "-f -i size=512 -n size=8192 -d su=128k,sw=10",
+        "mountpoint":
+            "/mnt/glusterfs/localvolume",
+        # GlusterFS volume to be constructed.
+        "glustefs_nodes_yaml":
+            "./deploy/docker-images/glusterfs/glusterfs_config.yaml",
+        "glusterfs_docker":
+            "glusterfs",
+        # File system should always be accessed from the symbolic
+        # link, not from the actual mountpoint
+        "glusterfs_mountpoint":
+            "/mnt/glusterfs/private",
+        "glusterfs_symlink":
+            "/mnt/glusterfs",
+        # Spell out a number of glusterFS volumes to be created on the cluster.
+        # Please refer to https://access.redhat.com/documentation/en-US/Red_Hat_Storage/2.1/html/Administration_Guide/sect-User_Guide-Setting_Volumes-Distributed_Replicated.html
+        # for proper volumes in glusterFS.
+        # By default, all worker nodes with glusterFS installed will be placed in the default group.
+        # The behavior can be modified by spell out the group that the node is expected to be in.
+        # E.g.,
+        # node01:
+        #   gluterfs: 1
+        # will place node01 into a glusterfs group 1. The nodes in each glusterfs group will form separate volumes
+        #
+        "gluster_volumes": {
+            "default": {
+                "netvolume": {
+                    "property": "replica 3",
+                    "transport": "tcp,rdma",
+                    # of nodes that can fail before the volume will
+                    # become unaccessible.
+                    "tolerance": 2,
+                    # number of bricks need to be a multiple of this
+                    "multiple": 3,
+                },
+            },
+        },
+        # These parameters are required for every glusterfs volumes
+        "gluster_volumes_required_param": [
+            "property", "transport", "tolerance", "multiple"
+        ],
+        # To use glusterFS, you will configure the partitions parameter
+        # partitions: /dev/sd[^a]
+        # which is a regular expression calls out all partition
+        # that will be deployed with glusterfs
+    },
     # Options to run in glusterfs
     "launch-glusterfs-opt": "run",
 
@@ -279,7 +308,6 @@ default_config_parameters = {
         "user-synchronizer": "etcd_node_1",
         "job-insighter": "etcd_node_1",
     },
-
     "default_kube_labels_by_node_role": {
         'infra': {
             "infrastructure": "active",
@@ -294,23 +322,22 @@ default_config_parameters = {
             "user-synchronizer": "active",
             "alert-manager": "active",
             "beta.kubernetes.io/os": "linux"
-            },
+        },
         'worker': {
             "worker": "active",
             "beta.kubernetes.io/os": "linux",
             "repairmanageragent": "active"
-            },
+        },
         'mysqlserver': {
             "mysql-server": "active"
-            },
+        },
         'nfs': {
             "storagemanager": "active"
-            },
+        },
         'elasticsearch': {
             "elasticsearch": "active"
         },
     },
-
     "kube_services_2_start": [
         "nvidia-device-plugin",
         "flexvolume",
@@ -321,9 +348,7 @@ default_config_parameters = {
         "dashboard",
         "user-synchronizer",
     ],
-
     "kubemarks": ["rack", "sku"],
-
     "network": {
         "trusted-domains": {
             "*.redmond.corp.microsoft.com": True,
@@ -331,8 +356,6 @@ default_config_parameters = {
         },
         "container-network-iprange": "192.168.0.1/24",
     },
-
-
     "localdisk": {
         # The following pair of options control how local disk is formated and
         # mounted
@@ -342,7 +365,6 @@ default_config_parameters = {
 
     # optional hdfs_cluster_name: if not inherit cluster_name from cluster
     # "hdfs_cluster_name": cluster_name for HDFS
-
     "hdfsconfig": {
         # Launch options for formatting, etc..
         "formatoptions": "",
@@ -376,22 +398,25 @@ default_config_parameters = {
     "ubuntuconfig": {
         "version": "16.04.1",
         "16.04.2": {
-            "ubuntuImageUrl": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso",
-            "ubuntuImageName": "ubuntu-16.04.2-server-amd64.iso",
+            "ubuntuImageUrl":
+                "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso",
+            "ubuntuImageName":
+                "ubuntu-16.04.2-server-amd64.iso",
         },
         "16.04.1": {
-            "ubuntuImageUrl": "http://old-releases.ubuntu.com/releases/16.04.1/ubuntu-16.04.1-server-amd64.iso",
-            "ubuntuImageName": "ubuntu-16.04.1-server-amd64.iso",
+            "ubuntuImageUrl":
+                "http://old-releases.ubuntu.com/releases/16.04.1/ubuntu-16.04.1-server-amd64.iso",
+            "ubuntuImageName":
+                "ubuntu-16.04.1-server-amd64.iso",
         },
     },
-
     "acskubeconfig": "acs_kubeclusterconfig",
     "isacs": False,
     "acsagentsize": "Standard_NC12",
-
     "mountconfig": {
         "azurefileshare": {
-            "options": "vers=3.0,username=%s,password=%s,dir_mode=0777,file_mode=0777,serverino",
+            "options":
+                "vers=3.0,username=%s,password=%s,dir_mode=0777,file_mode=0777,serverino",
         },
         "glusterfs": {
             "options": "defaults,_netdev",
@@ -403,34 +428,35 @@ default_config_parameters = {
             "fstaboptions": "allow_other,usetrash,rw 2 0",
             "options": "rw -ousetrash -obig_writes -oinitchecks",
         },
-
     },
-
     "mountdescription": {
-        "azurefileshare": "Azure file storage",
-        "glusterfs": "GlusterFS (replicated distributed storage)",
-        "nfs": "NFS (remote file share)",
-        "hdfs": "Hadoop file system (replicated distribute storage).",
-        "local": "Local SSD. ",
-        "localHDD": "Local HDD. ",
-        "emptyDir": "Kubernetes emptyDir (folder will be erased after job termination).",
+        "azurefileshare":
+            "Azure file storage",
+        "glusterfs":
+            "GlusterFS (replicated distributed storage)",
+        "nfs":
+            "NFS (remote file share)",
+        "hdfs":
+            "Hadoop file system (replicated distribute storage).",
+        "local":
+            "Local SSD. ",
+        "localHDD":
+            "Local HDD. ",
+        "emptyDir":
+            "Kubernetes emptyDir (folder will be erased after job termination).",
     },
-
     "mountsupportedbycoreos": {
         "nfs": True,
         "local": True,
         "localHDD": True,
         "emptyDir": True,
     },
-
     "k8Sdaemon": {
         # Specify k8S daemon related policy, e.g., dnsPolicy here.
     },
-
     "mounthomefolder": "yes",
     # Mount point to be deployed to container.
     "deploymounts": [],
-
 
     # folder where automatic share script will be located
     "folder_auto_share": "/opt/auto_share",
@@ -442,7 +468,6 @@ default_config_parameters = {
     # "ubuntu": ubuntu cluster
     "platform-scripts": "ubuntu",
 
-
     # Default usergroup for the WebUI portal
     # Default setting will allow all Microsoft employees to access the cluster,
     # You should override this setting if you have concern.
@@ -451,7 +476,12 @@ default_config_parameters = {
         "CCSAdmins": {
             # The match is in C# Regex Language, please refer to :
             # https://msdn.microsoft.com/en-us/library/az24scfc(v=vs.110).aspx
-            "Allowed": ["hongzl@microsoft.com", "anbhu@microsoft.com", "jachzh@microsoft.com","zhexu@microsoft.com","dixu@microsoft.com","qixcheng@microsoft.com","jingzhao@microsoft.com","hayua@microsoft.com"],
+            "Allowed": [
+                "hongzl@microsoft.com", "anbhu@microsoft.com",
+                "jachzh@microsoft.com", "zhexu@microsoft.com",
+                "dixu@microsoft.com", "qixcheng@microsoft.com",
+                "jingzhao@microsoft.com", "hayua@microsoft.com"
+            ],
             "uid": "900000000-999999999",
             "gid": "508953967"
         },
@@ -477,9 +507,8 @@ default_config_parameters = {
             "gid": "508953967"
         },
     },
-
     "WebUIregisterGroups": ["MicrosoftUsers", "Live", "Gmail"],
-    "WebUIauthorizedGroups": [],  # [ "MicrosoftUsers", "Live", "Gmail" ],
+    "WebUIauthorizedGroups": [], # [ "MicrosoftUsers", "Live", "Gmail" ],
     "WebUIadminGroups": ["CCSAdmins"],
 
     # Selectively deploy (turn on) one or more authenticatin methods.
@@ -491,13 +520,12 @@ default_config_parameters = {
     # UserGroups for authentication.
     "workFolderAccessPoint": "/",
     "dataFolderAccessPoint": "/",
-
     "kube_configchanges": ["/opt/addons/kube-addons/weave.yaml"],
-    "kube_addons": ["/opt/addons/kube-addons/dashboard.yaml",
-                    "/opt/addons/kube-addons/dns-addon.yaml",
-                    "/opt/addons/kube-addons/kube-proxy.json",
-                    ],
-
+    "kube_addons": [
+        "/opt/addons/kube-addons/dashboard.yaml",
+        "/opt/addons/kube-addons/dns-addon.yaml",
+        "/opt/addons/kube-addons/kube-proxy.json",
+    ],
     "k8s-bld": "k8s-temp-bld",
     "k8s-gitrepo": "kubernetes/kubernetes",
     "k8s-gitbranch": "v1.9.1",
@@ -506,7 +534,6 @@ default_config_parameters = {
     "kube_custom_cri": False,
     "kube_custom_scheduler": False,
     "kubepresleep": 60,
-
     "Authentications": {
         "Live-login-windows": {
             "DisplayName": "Microsoft Account (live.com)",
@@ -546,7 +573,7 @@ default_config_parameters = {
             "AuthorityFormat": "https://login.microsoftonline.com/{0}",
             "RedirectUri": "",
             "GraphBaseEndpoint": "https://graph.windows.net",
-            "GraphApiVersion": "1.6",  # API version,
+            "GraphApiVersion": "1.6", # API version,
             "Scope": "User.Read",
             "Domains": ["live.com", "hotmail.com", "outlook.com"]
         },
@@ -558,7 +585,7 @@ default_config_parameters = {
             "AuthorityFormat": "https://login.windows.net/common",
             "RedirectUri": "",
             "GraphBaseEndpoint": "https://graph.windows.net",
-            "GraphApiVersion": "1.6",  # API version,
+            "GraphApiVersion": "1.6", # API version,
             # "Scope": "User.Read",
             "Domains": ["live.com", "hotmail.com", "outlook.com"]
         },
@@ -573,7 +600,7 @@ default_config_parameters = {
             "RedirectUri": "",
             "Scope": "User.Read",
             "GraphBaseEndpoint": "https://graph.windows.net",
-            "GraphApiVersion": "1.6",  # API version,
+            "GraphApiVersion": "1.6", # API version,
             "Domains": ["microsoft.com"]
         },
         "Live-Microsoft": {
@@ -584,7 +611,6 @@ default_config_parameters = {
             "AuthorityFormat": "https://login.microsoftonline.com/{0}",
             "Domains": ["live.com", "hotmail.com", "outlook.com"]
         },
-
         "Corp": {
             "DisplayName": "@microsoft.com corpnet sign in",
             "UseAadGraph": "false",
@@ -594,21 +620,25 @@ default_config_parameters = {
             "AuthorityFormat": "https://login.microsoftonline.com/{0}",
             "RedirectUri": "",
             "GraphBaseEndpoint": "https://graph.windows.net",
-            "GraphApiVersion": "1.6",  # API version,
+            "GraphApiVersion": "1.6", # API version,
             "Domains": ["microsoft.com"]
         },
         "Gmail": {
-            "DisplayName": "Gmail",
-            "Tenant": "dlws-auth",
-            "ClientId": "79875480060-jrs8a1rqe6a4kv82jh4d2nqgq8t6ap6k.apps.googleusercontent.com",
-            "ClientSecret": "L6XfKLzIbiy7jT7s416CBamz",
-            "AuthorityFormat": "https://accounts.google.com",
-            "Scope": "openid email",
+            "DisplayName":
+                "Gmail",
+            "Tenant":
+                "dlws-auth",
+            "ClientId":
+                "79875480060-jrs8a1rqe6a4kv82jh4d2nqgq8t6ap6k.apps.googleusercontent.com",
+            "ClientSecret":
+                "L6XfKLzIbiy7jT7s416CBamz",
+            "AuthorityFormat":
+                "https://accounts.google.com",
+            "Scope":
+                "openid email",
             "Domains": ["gmail.com"]
         },
-
     },
-
     "Dashboards": {
         "influxDB": {
             "dbName": "WebUI",
@@ -630,7 +660,10 @@ default_config_parameters = {
     # There are two docker registries, one for infrastructure (used for pre-deployment)
     # and one for worker docker (pontentially in cluser)
     # A set of infrastructure-dockers
-    "infrastructure-dockers": {"pxe": True, "pxe-ubuntu": True, },
+    "infrastructure-dockers": {
+        "pxe": True,
+        "pxe-ubuntu": True,
+    },
     "dockerprefix": "",
     "dockertag": "latest",
 
@@ -668,26 +701,63 @@ default_config_parameters = {
         },
         "external": {
             # These dockers are to be built by additional add ons.
-            "hyperkube": {"fullname":"gcr.io/google-containers/hyperkube:v1.15.2"},
-            "freeflow": {"fullname":"dlws/freeflow:0.18"},
-            "podinfra": {"fullname":"dlws/pause-amd64:3.0"},
-            "nvidiadriver": {"fullname":"dlws/nvidia_driver:375.20"},
-            "weave":{"fullname":"docker.io/weaveworks/weave-kube:2.5.2"},
-            "weave-npc":{"fullname":"docker.io/weaveworks/weave-npc:2.5.2"},
-            "k8s-dashboard":{"fullname":"dlws/kubernetes-dashboard-amd64:v1.5.1"},
-            "kube-dns":{"fullname":"dlws/k8s-dns-kube-dns-amd64:1.14.8"},
-            "kube-dnsmasq":{"fullname":"dlws/k8s-dns-dnsmasq-nanny-amd64:1.14.8"},
-            "kube-dns-sidecar":{"fullname":"dlws/k8s-dns-sidecar-amd64:1.14.8"},
-            "heapster":{"fullname":"dlws/heapster-amd64:v1.4.0"},
-            "etcd":{"fullname":"dlws/etcd:3.1.10"},
-            "mysql":{"fullname":"dlws/mysql:5.6"},
-            "phpmyadmin":{"fullname":"dlws/phpmyadmin:4.7.6"},
-            "elasticsearch":{"fullname":"dlws/elasticsearch:6.8.5"},
-            "elasticsearch-exporter":{"fullname":"dlws/elasticsearch-exporter:1.1.0"},
-            "kibana":{"fullname":"dlws/kibana:6.8.5"},
-            "fluentd-elasticsearch":{"fullname":"dlws/fluentd-elasticsearch:v2.0.2"},
-            "binstore":{"fullname":"dlws/binstore:v1.0"},
-
+            "hyperkube": {
+                "fullname": "gcr.io/google-containers/hyperkube:v1.15.2"
+            },
+            "freeflow": {
+                "fullname": "dlws/freeflow:0.18"
+            },
+            "podinfra": {
+                "fullname": "dlws/pause-amd64:3.0"
+            },
+            "nvidiadriver": {
+                "fullname": "dlws/nvidia_driver:375.20"
+            },
+            "weave": {
+                "fullname": "docker.io/weaveworks/weave-kube:2.5.2"
+            },
+            "weave-npc": {
+                "fullname": "docker.io/weaveworks/weave-npc:2.5.2"
+            },
+            "k8s-dashboard": {
+                "fullname": "dlws/kubernetes-dashboard-amd64:v1.5.1"
+            },
+            "kube-dns": {
+                "fullname": "dlws/k8s-dns-kube-dns-amd64:1.14.8"
+            },
+            "kube-dnsmasq": {
+                "fullname": "dlws/k8s-dns-dnsmasq-nanny-amd64:1.14.8"
+            },
+            "kube-dns-sidecar": {
+                "fullname": "dlws/k8s-dns-sidecar-amd64:1.14.8"
+            },
+            "heapster": {
+                "fullname": "dlws/heapster-amd64:v1.4.0"
+            },
+            "etcd": {
+                "fullname": "dlws/etcd:3.1.10"
+            },
+            "mysql": {
+                "fullname": "dlws/mysql:5.6"
+            },
+            "phpmyadmin": {
+                "fullname": "dlws/phpmyadmin:4.7.6"
+            },
+            "elasticsearch": {
+                "fullname": "dlws/elasticsearch:6.8.5"
+            },
+            "elasticsearch-exporter": {
+                "fullname": "dlws/elasticsearch-exporter:1.1.0"
+            },
+            "kibana": {
+                "fullname": "dlws/kibana:6.8.5"
+            },
+            "fluentd-elasticsearch": {
+                "fullname": "dlws/fluentd-elasticsearch:v2.0.2"
+            },
+            "binstore": {
+                "fullname": "dlws/binstore:v1.0"
+            },
         },
         "infrastructure": {
             "pxe-ubuntu": {},
@@ -697,7 +767,6 @@ default_config_parameters = {
         # config["dockers"]["container"]["name"]
         "container": {},
     },
-
     "cloud_config_nsg_rules": {
         "corpnet_dev_ports": "22 80 1443 3000 3306 5000 9091",
         "inter_connect_ports": "1443 2379 2382 3306 5000 10250 10255",
@@ -710,12 +779,14 @@ default_config_parameters = {
         # There is no udp port requirement for now
         #"udp_port_ranges": "25826",
         "inter_connect": {
-            "tcp_port_ranges": "22 1443 2379 2382 3306 5000 8086 9092 9114 9200 9300 10250 30000-49999",
+            "tcp_port_ranges":
+                "22 1443 2379 2382 3306 5000 8086 9092 9114 9200 9300 10250 30000-49999",
             # Need to white list dev machines to connect
             # "source_addresses_prefixes": [ "52.151.0.0/16"]
         },
         "dev_network": {
-            "tcp_port_ranges": "22 1443 2379 3306 5000 8086 5601 10250 10255 22222",
+            "tcp_port_ranges":
+                "22 1443 2379 3306 5000 8086 5601 10250 10255 22222",
             # Need to white list dev machines to connect
             # "source_addresses_prefixes": [ "52.151.0.0/16"]
         },
@@ -723,18 +794,21 @@ default_config_parameters = {
             "tcp_port_ranges": "10250",
         },
     },
-
     "nfs_client_CIDR": {
         "node_range": ["192.168.0.0/16"],
         "samba_range": [],
     },
-
-    "nfs_mnt_setup": [
-          {
-            "mnt_point": {"rootshare":{"curphysicalmountpoint":"/mntdlws/infranfs","filesharename":"/infradata/share","mountpoints":""}}}
-    ],
-    "vc_config":{
-        "VC-Default":["*"],
+    "nfs_mnt_setup": [{
+        "mnt_point": {
+            "rootshare": {
+                "curphysicalmountpoint": "/mntdlws/infranfs",
+                "filesharename": "/infradata/share",
+                "mountpoints": ""
+            }
+        }
+    }],
+    "vc_config": {
+        "VC-Default": ["*"],
     },
     "registry_credential": {},
     "priority": "regular",
@@ -859,20 +933,15 @@ scriptblocks = {
         "kubernetes start nginx",
     ],
     "add_worker": [
-        "sshkey install",
-        "runscriptonall ./scripts/prepare_vm_disk.sh",
-        "runscriptonall ./scripts/prepare_ubuntu.sh",
-        "mount",
-        "-y updateworker",
-        "-y kubernetes labels",
+        "sshkey install", "runscriptonall ./scripts/prepare_vm_disk.sh",
+        "runscriptonall ./scripts/prepare_ubuntu.sh", "mount",
+        "-y updateworker", "-y kubernetes labels",
         "-y kubernetes patchprovider aztools"
     ],
     "add_scaled_worker": [
         "runscriptonall ./scripts/prepare_vm_disk.sh",
-        "runscriptonscaleup ./scripts/prepare_ubuntu.sh",
-        "mount",
-        "-y updatescaledworker",
-        "-y kubernetes labels",
+        "runscriptonscaleup ./scripts/prepare_ubuntu.sh", "mount",
+        "-y updatescaledworker", "-y kubernetes labels",
         "-y kubernetes patchprovider aztools True"
     ],
     "redeploy": [

--- a/src/ClusterBootstrap/services/monitor/alert-manager.yaml
+++ b/src/ClusterBootstrap/services/monitor/alert-manager.yaml
@@ -40,6 +40,22 @@ spec:
           mountPath: /alertmanager
         - name: templates-volume
           mountPath: /etc/alertmanager/template
+      - name: email-sender
+        image: {{cnf["worker-dockerregistry"]}}/{{cnf["dockerprefix"]}}/email-sender:{{cnf["dockertag"]}}
+        command:
+          - 'python'
+          - '/email-sender/serve.py'
+          - '--host'
+          - '{{ cnf["alert-manager"]["email-sender"]["mq-host"] }}'
+          - '--mq_user'
+          - '{{ cnf["alert-manager"]["email-sender"]["mq-user"] }}'
+          - '--mq_pass'
+          - '{{ cnf["alert-manager"]["email-sender"]["mq-pass"] }}'
+          - '--port'
+          - '{{ cnf["alert-manager"]["email-sender"]["port"] }}'
+        ports:
+        - name: alert-manager
+          containerPort: {{ cnf["alert-manager"]["port"] }}
       {% if cnf["alert-manager"]["reaper"] %}
       - name: reaper
         image: {{cnf["worker-dockerregistry"]}}/{{cnf["dockerprefix"]}}/reaper:{{cnf["dockertag"]}}

--- a/src/dev-utils/start-rabbit-mq.sh
+++ b/src/dev-utils/start-rabbit-mq.sh
@@ -9,6 +9,7 @@ docker kill rabbitmq
 docker rm rabbitmq
 
 docker run -d \
+    --restart=always \
     --hostname rabbit1 \
     --name rabbitmq \
     --net=host \

--- a/src/dev-utils/start-rabbit-mq.sh
+++ b/src/dev-utils/start-rabbit-mq.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ $# -ne 3 ] ; then
+    echo Usage: $0 mq_user mq_pass data-dir >&2
+    exit 1
+fi
+
+docker kill rabbitmq
+docker rm rabbitmq
+
+docker run -d \
+    --hostname rabbit1 \
+    --name rabbitmq \
+    --net=host \
+    -v $3:/var/lib/rabbitmq/mnesia/ \
+    -e RABBITMQ_DEFAULT_USER=$1 \
+    -e RABBITMQ_DEFAULT_PASS=$2 \
+    rabbitmq:3

--- a/src/docker-images/email-sender/Dockerfile
+++ b/src/docker-images/email-sender/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7
 
-RUN pip3 install flask flask-cors pika
+RUN pip3 install pyyaml flask flask-cors pika
 
 COPY *.py /email-sender/

--- a/src/docker-images/email-sender/Dockerfile
+++ b/src/docker-images/email-sender/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.7
+
+RUN pip3 install flask flask-cors pika
+
+COPY *.py /email-sender/

--- a/src/docker-images/email-sender/email_sender.py
+++ b/src/docker-images/email-sender/email_sender.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse
+import faulthandler
+import signal
+import logging
+import smtplib
+import yaml
+import json
+
+import payload
+
+import pika
+
+logger = logging.getLogger(__name__)
+
+
+def register_stack_trace_dump():
+    faulthandler.register(signal.SIGTRAP, all_threads=True, chain=False)
+
+
+def load_smtp_config(path):
+    with open(path) as f:
+        content = yaml.full_load(f.read())["smtp"]
+
+    return content["smtp_url"], content["smtp_from"], content[
+        "smtp_auth_username"], content["smtp_auth_password"], content.get(
+            "default_cc")
+
+
+def run(args):
+    smtp_url, smtp_from, smtp_user, smtp_pass, default_cc = load_smtp_config(
+        args.smtp)
+
+    while True:
+        try:
+            with smtplib.SMTP(smtp_url) as smtp_conn:
+                smtp_conn.starttls()
+                smtp_conn.login(smtp_user, smtp_pass)
+
+                connection = pika.BlockingConnection(
+                    pika.ConnectionParameters(host=args.host))
+                channel = connection.channel()
+
+                channel.queue_declare(queue=args.queue, durable=True)
+                logger.info("waiting for messages")
+
+                def callback(ch, method, properties, body):
+                    logger.info("received %r" % body)
+                    try:
+                        jbody = json.loads(body)
+                        params = payload.Payload.deserialize(jbody)
+                        msg = params.to_email_message(smtp_from, default_cc)
+                    except Exception:
+                        logger.exception("error when parsing body %s, drop it",
+                                         body)
+                        # drop malformed message
+                        ch.basic_ack(delivery_tag=method.delivery_tag)
+                        return
+
+                    try:
+                        smtp_conn.send_message(msg)
+                        ch.basic_ack(delivery_tag=method.delivery_tag)
+                    except Exception:
+                        logger.exception("error when sending email %s", body)
+
+                channel.basic_qos(prefetch_count=500)
+                channel.basic_consume(queue=args.queue,
+                                      on_message_callback=callback)
+
+                channel.start_consuming()
+        except Exception:
+            logger.exception("catch exception when handling messages")
+
+
+if __name__ == "__main__":
+    register_stack_trace_dump()
+    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',
+                        level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--queue",
+                        help="queue name of rabbitmq",
+                        default="email")
+    parser.add_argument("--host", help="rabbitmq host", required=True)
+    parser.add_argument("--smtp", help="path to smtp config", required=True)
+    args = parser.parse_args()
+
+    sys.exit(run(args))

--- a/src/docker-images/email-sender/payload.py
+++ b/src/docker-images/email-sender/payload.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import json
+import email
+
+
+class Payload(object):
+    """ payload exchanged in queue and http """
+    def __init__(self, to, cc, bcc, subject, body):
+        self.to = to
+        self.cc = cc
+        self.bcc = bcc
+        self.subject = subject
+        self.body = body
+
+    def serialize(self):
+        return json.dumps({
+            "To": self.to,
+            "CC": self.cc,
+            "BCC": self.bcc,
+            "Subject": self.subject,
+            "Body": self.body,
+        })
+
+    @classmethod
+    def deserialize(cls, payload):
+        to = payload.get("To")
+        cc = payload.get("CC")
+        bcc = payload.get("BCC")
+        if to is None or cc is None:
+            raise RuntimeError("no To or CC or BCC provided %s" % (payload))
+
+        subject = payload.get("Subject")
+        body = payload.get("Body")
+        return cls(to, cc, bcc, subject, body)
+
+    def to_email_message(self, smtp_from, default_cc):
+        cc = self.cc or ""
+        if default_cc is not None:
+            cc += "," + default_cc
+
+        msg = email.message.EmailMessage()
+        msg["From"] = smtp_from
+        msg["To"] = self.to
+        msg["CC"] = cc
+        msg["BCC"] = self.bcc
+        msg["Subject"] = self.subject
+        msg.set_content(self.body)
+        return msg

--- a/src/docker-images/email-sender/serve.py
+++ b/src/docker-images/email-sender/serve.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+import json
+import logging
+
+import payload
+
+import pika
+
+import flask
+from flask import Flask
+from flask import request
+from flask import Response
+from flask_cors import CORS
+
+logger = logging.getLogger(__name__)
+
+
+def put_message(host, queue, payload):
+    connection = pika.BlockingConnection(pika.ConnectionParameters(host=host))
+    channel = connection.channel()
+
+    channel.queue_declare(queue=queue, durable=True)
+
+    channel.basic_publish(
+        exchange='',
+        routing_key='email',
+        body=payload,
+        properties=pika.BasicProperties(
+            delivery_mode=2, # make message persistent
+        ))
+    logger.info("put %r" % payload)
+    connection.close()
+
+
+def serve(args):
+    app = Flask(__name__)
+    CORS(app)
+
+    @app.route("/put_email", methods=["POST"])
+    def put_email():
+        params = request.get_json(force=True)
+
+        try:
+            data = payload.Payload.deserialize(params)
+            put_message(args.host, args.queue, data.serialize())
+        except Exception as e:
+            logger.exception("failed to process %s", params)
+            return Response(str(e), status=400)
+
+        return Response("ok", status=201)
+
+    app.run(host="0.0.0.0", port=args.port, debug=False, use_reloader=False)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',
+                        level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--queue",
+                        help="queue name of rabbitmq",
+                        default="email")
+    parser.add_argument("--host", help="rabbitmq host", required=True)
+    parser.add_argument("--port", help="port to listen", type=int, default=9095)
+    args = parser.parse_args()
+
+    serve(args)


### PR DESCRIPTION
The design for this is:

* start a [rabbitmq](https://www.rabbitmq.com/) server outside of CorpNet, maybe deployed along mysql server. I chose rabbitmq because it's easier to deploy than kafka and I once investigated it, [doc](https://gist.github.com/xudifsd/0f2aeff1cf443f7a1b47) in Chinese, its performance should be good for our scenario.
* build a docker image containing code in this PR to serve as both producer and consumer of the queue.
* deploy this image as sidecar of alert manager, redirect all current sending email calls to http call to this server, so the server will put messages to queue.
* also deploy this image inside CorpNet so we can consume data from queue to send out emails.

TODO:

- [x] add authorization to queue, because it will be public server
- [x] deploy along with alert manager
- [x] add scripts to install and deploy rabbitmq and consumer

TODO in other PRs:
* redirect all email sending to this server
* write a webhook for alert manager, because alert manager can only call this via webhook, and need a format transformer