### PR TITLE
let repair manager use email-sender

### DIFF
--- a/src/ClusterBootstrap/template/RepairManager/email-config.yaml
+++ b/src/ClusterBootstrap/template/RepairManager/email-config.yaml
@@ -1,5 +1,10 @@
+{% if cnf['repair-manager']['email_sender_url'] %}
+email_sender_url: {{ cnf['repair-manager']['email_sender_url'] }}
+default_recepient: {{cnf['repair-manager']['default_recipients']}}
+{% else %}
 smtp_url: {{cnf['smtp']['smtp_url']}}
 login: {{cnf['smtp']['smtp_auth_username']}}
 password: {{cnf['smtp']['smtp_auth_password']}}
 sender: {{cnf['smtp']['smtp_from']}}
 default_recepient: {{cnf['smtp']['default_recipients']}}
+{% endif %}

--- a/src/RepairManager/actions/send_alert_action.py
+++ b/src/RepairManager/actions/send_alert_action.py
@@ -7,18 +7,11 @@ from utils import k8s_util
 
 
 class SendAlertAction(Action):
-
     def __init__(self, alert_handler):
         self.action_logger = logging.getLogger('activity')
         self.alert_handler = alert_handler
 
     def execute(self, message, dry_run=False, additional_log=None):
-        default_email = self.alert_handler.email_handler.config['default_recepient']
-        if 'To' not in message:
-            message['To'] = default_email
-        else:
-            message['CC'] = default_email
-
         if not dry_run:
             self.alert_handler.send_alert(message)
 
@@ -27,8 +20,8 @@ class SendAlertAction(Action):
         self.action_logger.info({
             "action": "send alert",
             "dry_run": dry_run,
-            "email_to": message['To'],
-            "email_cc": message['CC'],
-            "message": message['Subject'],
+            "email_to": message.to,
+            "email_cc": message.cc,
+            "message": message.subject,
             **additional_log
         })

--- a/src/RepairManager/rules/ecc_detect_error_rule.py
+++ b/src/RepairManager/rules/ecc_detect_error_rule.py
@@ -11,15 +11,13 @@ import requests
 import json
 import yaml
 import logging
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
 
 activity_log = logging.getLogger('activity')
 
 
 def _create_email_for_dris(nodes, action_status, jobs, cluster_name):
-    message = MIMEMultipart()
-    message['Subject'] = f'Repair Manager Alert [ECC ERROR] [{cluster_name}]'
+    subject = f'Repair Manager Alert [ECC ERROR] [{cluster_name}]'
+
     body = f'<p>Uncorrectable ECC Error found in cluster {cluster_name} on the following node(s):</p>'
     body += f'<table border="1"><tr><th>Node Name</th><th>Action Status</th></tr>'
     for node in action_status:
@@ -33,15 +31,14 @@ def _create_email_for_dris(nodes, action_status, jobs, cluster_name):
         <td>{', '.join(job_info['node_names'])}</td>
         <td>{job_info['vc_name']}</td></tr>'''
     body += '</table>'
-    message.attach(MIMEText(body, 'html'))
-    return message
+
+    return email_util.EmailMessage(None, None, subject, body, "html")
 
 
-def _create_email_for_job_owner(job_id, job_owner_email, node_names, job_link, 
-                                cluster_name, reboot_enabled, days_until_reboot):
-    message = MIMEMultipart()
-    message['Subject'] = f'Repair Manager Alert [ECC ERROR] [{job_id}]'
-    message['To'] = job_owner_email
+def _create_email_for_job_owner(job_id, job_owner_email, node_names, job_link,
+                                cluster_name, reboot_enabled,
+                                days_until_reboot):
+    subject = f'Repair Manager Alert [ECC ERROR] [{job_id}]'
     body = f'''<p>Uncorrectable ECC Error found in {cluster_name} cluster on following node(s):</p>
     <table border="1">'''
     for node in node_names:
@@ -55,12 +52,10 @@ def _create_email_for_job_owner(job_id, job_owner_email, node_names, job_link,
     else:
         body += f'''Node(s) will be rebooted soon for repair and all progress will be lost</p>'''
 
-    message.attach(MIMEText(body, 'html'))
-    return message
+    return email_util.EmailMessage(job_owner_email, None, subject, body, "html")
 
 
 class EccDetectErrorRule(Rule):
-
     def __init__(self, alert, config):
         self.rule = 'ecc_rule'
         self.config = config
@@ -69,22 +64,22 @@ class EccDetectErrorRule(Rule):
         self.node_info = {}
         self.alert = alert
 
-
     def load_ecc_config(self):
         with open('/etc/RepairManager/config/ecc-config.yaml', 'r') as file:
             return yaml.safe_load(file)
 
-
     def update_rule_cache_with_bad_nodes(self):
         for node_name in self.new_bad_nodes:
             cache_value = {
-                'time_found': datetime.utcnow().strftime(self.config['date_time_format']),
-                'instance': self.new_bad_nodes[node_name]
+                'time_found':
+                    datetime.utcnow().strftime(self.config['date_time_format']),
+                'instance':
+                    self.new_bad_nodes[node_name]
             }
             self.alert.update_rule_cache(self.rule, node_name, cache_value)
-    
-        logging.debug(f"rule_cache: {json.dumps(self.alert.rule_cache, default=str)}")
 
+        logging.debug(
+            f"rule_cache: {json.dumps(self.alert.rule_cache, default=str)}")
 
     def check_status(self):
         url = f"http://{self.config['prometheus']['ip']}:{self.config['prometheus']['port']}"
@@ -100,9 +95,11 @@ class EccDetectErrorRule(Rule):
                     address_map = k8s_util.get_node_address_info()
                     for ip in node_ips:
                         node_name = address_map[ip]
-                        if not self.alert.check_rule_cache(self.rule, node_name):
+                        if not self.alert.check_rule_cache(
+                                self.rule, node_name):
                             self.new_bad_nodes[node_name] = ip
-                    logging.info(f'Uncorrectable ECC metrics: {self.new_bad_nodes}')
+                    logging.info(
+                        f'Uncorrectable ECC metrics: {self.new_bad_nodes}')
                     return len(self.new_bad_nodes) > 0
                 else:
                     logging.debug('No uncorrectable ECC metrics found.')
@@ -113,7 +110,6 @@ class EccDetectErrorRule(Rule):
 
         return False
 
-
     def take_action(self):
         # cordon nodes
         cordon_dry_run = not self.ecc_config['enable_cordon']
@@ -121,8 +117,7 @@ class EccDetectErrorRule(Rule):
         for node_name in self.new_bad_nodes:
             cordon_action = CordonAction()
             action_status[node_name] = cordon_action.execute(
-                node_name=node_name,
-                dry_run=cordon_dry_run)
+                node_name=node_name, dry_run=cordon_dry_run)
 
         impacted_jobs = k8s_util.get_job_info_indexed_by_job_id(
             nodes=self.new_bad_nodes,
@@ -134,31 +129,33 @@ class EccDetectErrorRule(Rule):
             nodes=self.new_bad_nodes,
             action_status=action_status,
             jobs=impacted_jobs,
-            cluster_name=self.config['cluster_name']
-        )
+            cluster_name=self.config['cluster_name'])
         alert_action = SendAlertAction(self.alert)
-        alert_action.execute(dri_message, additional_log={"bad_nodes": self.new_bad_nodes})
+        alert_action.execute(dri_message,
+                             additional_log={"bad_nodes": self.new_bad_nodes})
 
         # send alert email to impacted job owners
         for job_id, job_info in impacted_jobs.items():
             job_owner_message = _create_email_for_job_owner(
                 job_id=job_id,
-                job_owner_email=f"{job_info['user_name']}@{self.config['job_owner_email_domain']}",
+                job_owner_email=
+                f"{job_info['user_name']}@{self.config['job_owner_email_domain']}",
                 node_names=job_info['node_names'],
                 job_link=job_info['job_link'],
                 cluster_name=self.config['cluster_name'],
                 reboot_enabled=self.ecc_config['enable_reboot'],
-                days_until_reboot=self.ecc_config.get('days_until_node_reboot', 5)
-            )
+                days_until_reboot=self.ecc_config.get('days_until_node_reboot',
+                                                      5))
             if not cordon_dry_run and self.ecc_config['enable_alert_job_owners']:
                 alert_dry_run = False
             else:
                 alert_dry_run = True
-            alert_action.execute(
-                message=job_owner_message,
-                dry_run=alert_dry_run,
-                additional_log={"job_id": job_id,
-                                "job_owner": job_info['user_name'],
-                                "nodes": job_info['node_names']})
+            alert_action.execute(message=job_owner_message,
+                                 dry_run=alert_dry_run,
+                                 additional_log={
+                                     "job_id": job_id,
+                                     "job_owner": job_info['user_name'],
+                                     "nodes": job_info['node_names']
+                                 })
 
         self.update_rule_cache_with_bad_nodes()

--- a/src/RepairManager/rules/ecc_reboot_node_rule.py
+++ b/src/RepairManager/rules/ecc_reboot_node_rule.py
@@ -12,11 +12,10 @@ from actions.reboot_node_action import RebootNodeAction
 from actions.uncordon_action import UncordonAction
 from datetime import datetime, timedelta, timezone
 from rules_abc import Rule
-from utils import prometheus_util, k8s_util
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+from utils import prometheus_util, k8s_util, email_util
 
 activity_log = logging.getLogger('activity')
+
 
 def _extract_node_boot_time_info(response):
     node_boot_times = {}
@@ -27,26 +26,25 @@ def _extract_node_boot_time_info(response):
                 instance = m["metric"]["instance"].split(":")[0]
                 boot_datetime = datetime.utcfromtimestamp(float(m["value"][1]))
                 node_boot_times[instance] = boot_datetime
-    
+
     return node_boot_times
 
 
-def _create_email_for_pause_resume_job(job_id, node_names, job_link, job_owner_email):
-    message = MIMEMultipart()
-    message['Subject'] = f'Repair Manager Alert [{job_id} paused/resumed]'
-    message['To'] = job_owner_email
+def _create_email_for_pause_resume_job(job_id, node_names, job_link,
+                                       job_owner_email):
+    subject = f'Repair Manager Alert [{job_id} paused/resumed]'
+
     body = f'''<p>As previously notified, the following node(s) require reboot due to uncorrectable ECC error:</p>
     <table border="1">'''
     for node in node_names:
         body += f'''<tr><td>{node}</td></tr>'''
     body += f'''</table><p>
     <p> Job <a href="{job_link}">{job_id}</a> has been paused/resumed so node(s) can be repaired.</p>'''
-    message.attach(MIMEText(body, 'html'))
-    return message
+
+    return email_util.EmailMessage(job_owner_email, None, subject, body, "html")
 
 
 class EccRebootNodeRule(Rule):
-
     def __init__(self, alert, config):
         self.rule = 'ecc_rule'
         self.alert = alert
@@ -80,14 +78,22 @@ class EccRebootNodeRule(Rule):
                 reboot_times = _extract_node_boot_time_info(reboot_data)
             bad_nodes = self.alert.get_rule_cache_keys(self.rule)
             for node in bad_nodes:
-                instance = self.alert.get_rule_cache(self.rule, node)["instance"]
-                time_found_string = self.alert.get_rule_cache(self.rule, node)["time_found"]
-                time_found_datetime = datetime.strptime(time_found_string, self.config['date_time_format'])
+                instance = self.alert.get_rule_cache(self.rule,
+                                                     node)["instance"]
+                time_found_string = self.alert.get_rule_cache(
+                    self.rule, node)["time_found"]
+                time_found_datetime = datetime.strptime(
+                    time_found_string, self.config['date_time_format'])
                 last_reboot_time = reboot_times[instance]
                 if last_reboot_time > time_found_datetime:
                     uncordon_action.execute(node, dry_run)
                     self.alert.remove_from_rule_cache(self.rule, node)
-                    activity_log.info({"action":"marked as resolved from incorrectable ecc error","node":node})
+                    activity_log.info({
+                        "action":
+                            "marked as resolved from incorrectable ecc error",
+                        "node":
+                            node
+                    })
         except:
             logging.exception(f'Error checking if nodes have rebooted')
 
@@ -95,12 +101,13 @@ class EccRebootNodeRule(Rule):
         # if no jobs are running on node, take action on node
         bad_nodes = self.alert.get_rule_cache_keys(self.rule)
         self.all_jobs_indexed_by_node = k8s_util.get_job_info_indexed_by_node(
-           nodes=bad_nodes,
-           portal_url=self.config['portal_url'],
-           cluster_name=self.config['cluster_name'])
+            nodes=bad_nodes,
+            portal_url=self.config['portal_url'],
+            cluster_name=self.config['cluster_name'])
         for node in bad_nodes:
             node_has_no_jobs = node not in self.all_jobs_indexed_by_node
-            node_reboot_pending = 'reboot_requested' in self.alert.get_rule_cache(self.rule, node)
+            node_reboot_pending = 'reboot_requested' in self.alert.get_rule_cache(
+                self.rule, node)
             if node_has_no_jobs and not node_reboot_pending:
                 logging.debug(f'node {node} has no running jobs')
                 self.nodes_ready_for_action.add(node)
@@ -109,11 +116,15 @@ class EccRebootNodeRule(Rule):
         # if configured time has elapsed since initial detection, take action on node
         bad_nodes = self.alert.get_rule_cache_keys(self.rule)
         for node in bad_nodes:
-            time_found_string = self.alert.rule_cache[self.rule][node]["time_found"]
-            time_found_datetime = datetime.strptime(time_found_string, self.config['date_time_format'])
-            delta = timedelta(days=self.ecc_config.get("days_until_node_reboot", 5))
+            time_found_string = self.alert.rule_cache[
+                self.rule][node]["time_found"]
+            time_found_datetime = datetime.strptime(
+                time_found_string, self.config['date_time_format'])
+            delta = timedelta(
+                days=self.ecc_config.get("days_until_node_reboot", 5))
             now = datetime.utcnow()
-            node_reboot_pending = 'reboot_requested' in self.alert.get_rule_cache(self.rule, node)
+            node_reboot_pending = 'reboot_requested' in self.alert.get_rule_cache(
+                self.rule, node)
             if now - time_found_datetime > delta and not node_reboot_pending:
                 logging.debug(f'Configured time has passed for node {node}')
                 self.nodes_ready_for_action.add(node)
@@ -132,7 +143,8 @@ class EccRebootNodeRule(Rule):
                         "job_link": job["job_link"]
                     }
                 else:
-                    self.jobs_ready_for_migration[job_id]["node_names"].append(node)
+                    self.jobs_ready_for_migration[job_id]["node_names"].append(
+                        node)
 
     def migrate_jobs_and_alert_job_owners(self, dry_run):
         alert_action = SendAlertAction(self.alert)
@@ -149,22 +161,26 @@ class EccRebootNodeRule(Rule):
 
             # migrate all jobs
             migrate_job = MigrateJobAction(rest_url, max_attempts)
-            success = migrate_job.execute(
-                job_id=job_id,
-                job_owner_email=job_owner_email,
-                wait_time=wait_time, 
-                dry_run=dry_run)
+            success = migrate_job.execute(job_id=job_id,
+                                          job_owner_email=job_owner_email,
+                                          wait_time=wait_time,
+                                          dry_run=dry_run)
 
             # alert job owners
             if success:
-                message = _create_email_for_pause_resume_job(job_id, node_names, job_link, job_owner_email)
-                alert_dry_run = dry_run or not self.ecc_config['enable_alert_job_owners']
-                alert_action.execute(
-                    message=message,
-                    dry_run=alert_dry_run,
-                    additional_log={"job_id":job_id,"job_owner":job_owner})
+                message = _create_email_for_pause_resume_job(
+                    job_id, node_names, job_link, job_owner_email)
+                alert_dry_run = dry_run or not self.ecc_config[
+                    'enable_alert_job_owners']
+                alert_action.execute(message=message,
+                                     dry_run=alert_dry_run,
+                                     additional_log={
+                                         "job_id": job_id,
+                                         "job_owner": job_owner
+                                     })
             else:
-                logging.warning(f"Could not pause/resume the following job: {job_id}")
+                logging.warning(
+                    f"Could not pause/resume the following job: {job_id}")
                 # skip rebooting the node this iteration
                 # and try again later
                 for node in node_names:
@@ -173,11 +189,12 @@ class EccRebootNodeRule(Rule):
     def reboot_bad_nodes(self, dry_run):
         reboot_action = RebootNodeAction()
         for node in self.nodes_ready_for_action:
-           success = reboot_action.execute(node, self.etcd_config, dry_run)
-           if success:
+            success = reboot_action.execute(node, self.etcd_config, dry_run)
+            if success:
                 # update reboot status so action is not taken again
                 cache_value = self.alert.get_rule_cache(self.rule, node)
-                cache_value['reboot_requested'] =  datetime.utcnow().strftime(self.config['date_time_format'])
+                cache_value['reboot_requested'] = datetime.utcnow().strftime(
+                    self.config['date_time_format'])
                 self.alert.update_rule_cache(self.rule, node, cache_value)
 
     def check_status(self):
@@ -187,7 +204,6 @@ class EccRebootNodeRule(Rule):
         self.check_for_nodes_with_no_jobs()
         self.check_if_nodes_are_due_for_reboot()
         return len(self.nodes_ready_for_action) > 0
-
 
     def take_action(self):
         dry_run = not self.ecc_config["enable_reboot"]

--- a/src/RepairManager/rules/nvidia_smi_latency_rule.py
+++ b/src/RepairManager/rules/nvidia_smi_latency_rule.py
@@ -12,27 +12,24 @@ import json
 import yaml
 import logging
 from cachetools import TTLCache
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
 
 activity_log = logging.getLogger('activity')
 
 
 def _create_email_for_dris(impacted_nodes, cluster_name):
-    message = MIMEMultipart()
-    message['Subject'] = f'Repair Manager Alert [NVIDIA SMI LATENCY TOO LARGE] [{cluster_name}]'
     body = '<p>95th nvidia-smi call latency is larger than 40s in the following nodes. ' \
     'Please check the GPU status.</p>'
     body += f'<table border="1"><tr><th>Node Name</th><th>Instance</th></tr>'
     for node in impacted_nodes:
         body += f'''<tr><td>{node}</td><td>{impacted_nodes[node]}</td></tr>'''
     body += '</table>'
-    message.attach(MIMEText(body, 'html'))
-    return message
+
+    subject = f'Repair Manager Alert [NVIDIA SMI LATENCY TOO LARGE] [{cluster_name}]'
+
+    return email_util.EmailMessage(None, None, subject, body, "html")
 
 
 class NvidiaSmiLatencyRule(Rule):
-
     def __init__(self, alert, config):
         self.rule = 'smi_latency_rule'
         self.config = config
@@ -41,36 +38,38 @@ class NvidiaSmiLatencyRule(Rule):
         self.node_info = {}
         self.alert = alert
 
-
     def load_latency_config(self):
         with open('/etc/RepairManager/config/latency-config.yaml', 'r') as file:
             return yaml.safe_load(file)
 
-
     def update_rule_cache_with_impacted_nodes(self):
         for node_name in self.impacted_nodes:
             cache_value = {
-                'time_found': datetime.utcnow().strftime(self.config['date_time_format']),
-                'instance': self.impacted_nodes[node_name]
+                'time_found':
+                    datetime.utcnow().strftime(self.config['date_time_format']),
+                'instance':
+                    self.impacted_nodes[node_name]
             }
             self.alert.update_rule_cache(self.rule, node_name, cache_value)
-    
-        logging.debug(f"rule_cache: {json.dumps(self.alert.rule_cache, default=str)}")
 
+        logging.debug(
+            f"rule_cache: {json.dumps(self.alert.rule_cache, default=str)}")
 
     def clean_expired_items_in_rule_cache(self):
         expired_nodes = []
         if self.rule in self.alert.rule_cache:
             for node in self.alert.rule_cache[self.rule]:
-                time_found_string = self.alert.rule_cache[self.rule][node]["time_found"]
-                time_found_datetime = datetime.strptime(time_found_string, self.config['date_time_format'])
-                alert_delta = timedelta(hours=self.latency_config.get("alert_expiry", 4))
+                time_found_string = self.alert.rule_cache[
+                    self.rule][node]["time_found"]
+                time_found_datetime = datetime.strptime(
+                    time_found_string, self.config['date_time_format'])
+                alert_delta = timedelta(
+                    hours=self.latency_config.get("alert_expiry", 4))
                 now = datetime.utcnow()
                 if now - time_found_datetime > alert_delta:
                     expired_nodes.append(node)
         for node in expired_nodes:
             self.alert.remove_from_rule_cache(self.rule, node)
-
 
     def check_status(self):
         self.clean_expired_items_in_rule_cache()
@@ -88,7 +87,8 @@ class NvidiaSmiLatencyRule(Rule):
                     address_map = k8s_util.get_node_address_info()
                     for ip in node_ips:
                         node_name = address_map[ip]
-                        if not self.alert.check_rule_cache(self.rule, node_name):
+                        if not self.alert.check_rule_cache(
+                                self.rule, node_name):
                             self.impacted_nodes[node_name] = ip
                     return len(self.impacted_nodes) > 0
                 else:
@@ -100,13 +100,12 @@ class NvidiaSmiLatencyRule(Rule):
 
         return False
 
-
     def take_action(self):
         dri_message = _create_email_for_dris(
             impacted_nodes=self.impacted_nodes,
-            cluster_name=self.config['cluster_name']
-        )
+            cluster_name=self.config['cluster_name'])
         alert_action = SendAlertAction(self.alert)
-        alert_action.execute(dri_message, additional_log={"impacted_nodes": self.impacted_nodes})
+        alert_action.execute(
+            dri_message, additional_log={"impacted_nodes": self.impacted_nodes})
 
         self.update_rule_cache_with_impacted_nodes()

--- a/src/RepairManager/test/test_ecc_detect_error_rule.py
+++ b/src/RepairManager/test/test_ecc_detect_error_rule.py
@@ -2,81 +2,73 @@ import os, sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import unittest
-import mock
+from unittest import mock
 import datetime
-from mock import call
 from rules import ecc_detect_error_rule
 from rules.ecc_detect_error_rule import EccDetectErrorRule
 from utils import k8s_util, rule_alert_handler, test_util
 
+
 def _mock_prometheus_ecc_data():
     mock_prometheus_ecc_data = {
-            "status":
-                "success",
-                "data": {
-                    "result": [{
-                        "metric": {
-                            "__name__": "nvidiasmi_ecc_error_count",
-                            "exporter_name": "job-exporter",
-                            "instance": "192.168.0.1:9102",
-                            "job": "serivce_exporter",
-                            "minor_number": "1",
-                            "scraped_from": "job-exporter-jmgn4",
-                            "type": "volatile_double"
-                        },
-                        "values": [
-                            [1578453042, "2"], [1578453042, "2"]  
-                        ]
-                    },
-                    {
-                        "metric": {
-                            "__name__": "nvidiasmi_ecc_error_count",
-                            "exporter_name": "job-exporter",
-                            "instance": "192.168.0.2:9102",
-                            "job": "serivce_exporter",
-                            "minor_number": "1",
-                            "scraped_from": "job-exporter-jmgn4",
-                            "type": "volatile_double"
-                        },
-                        "values": [
-                            [1578453042, "2"], [1578453042, "2"], [1578453042, "2"]
-                        ]
-                    }]
-                }
+        "status": "success",
+        "data": {
+            "result": [{
+                "metric": {
+                    "__name__": "nvidiasmi_ecc_error_count",
+                    "exporter_name": "job-exporter",
+                    "instance": "192.168.0.1:9102",
+                    "job": "serivce_exporter",
+                    "minor_number": "1",
+                    "scraped_from": "job-exporter-jmgn4",
+                    "type": "volatile_double"
+                },
+                "values": [[1578453042, "2"], [1578453042, "2"]]
+            }, {
+                "metric": {
+                    "__name__": "nvidiasmi_ecc_error_count",
+                    "exporter_name": "job-exporter",
+                    "instance": "192.168.0.2:9102",
+                    "job": "serivce_exporter",
+                    "minor_number": "1",
+                    "scraped_from": "job-exporter-jmgn4",
+                    "type": "volatile_double"
+                },
+                "values": [[1578453042, "2"], [1578453042, "2"],
+                           [1578453042, "2"]]
+            }]
         }
+    }
     return mock_prometheus_ecc_data
 
-class TestEccDetectErrorRule(unittest.TestCase):
 
+class TestEccDetectErrorRule(unittest.TestCase):
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     @mock.patch('utils.k8s_util.list_node')
     @mock.patch('requests.get')
-    @mock.patch('rules.ecc_detect_error_rule.EccDetectErrorRule.load_ecc_config')
-    def test_check_status_ecc_error_detected(self, 
-            mock_load_ecc_config,
-            mock_request_get,
-            mock_list_node,
-            mock_rule_alert_handler_load_config,
-            mock_email_handler):
+    @mock.patch('rules.ecc_detect_error_rule.EccDetectErrorRule.load_ecc_config'
+               )
+    def test_check_status_ecc_error_detected(
+        self, mock_load_ecc_config, mock_request_get, mock_list_node,
+        mock_rule_alert_handler_load_config, mock_email_handler):
 
         mock_rule_config = test_util.mock_rule_config()
         mock_rule_alert_handler_load_config.return_value = mock_rule_config
         mock_load_ecc_config.return_value = test_util.mock_ecc_config()
         mock_rule_alert_handler = rule_alert_handler.RuleAlertHandler()
-        mock_request_get.return_value.json.return_value = _mock_prometheus_ecc_data()
-        mock_list_node.return_value = test_util.mock_v1_node_list([
-            {
-                "instance": "192.168.0.1",
-                "node_name": "mock-worker-one"
-            },
-            {
-                "instance": "192.168.0.2",
-                "node_name": "mock-worker-two"
-            }
-        ])
+        mock_request_get.return_value.json.return_value = _mock_prometheus_ecc_data(
+        )
+        mock_list_node.return_value = test_util.mock_v1_node_list([{
+            "instance": "192.168.0.1",
+            "node_name": "mock-worker-one"
+        }, {
+            "instance": "192.168.0.2",
+            "node_name": "mock-worker-two"
+        }])
 
-        ecc_rule_instance = EccDetectErrorRule(mock_rule_alert_handler, mock_rule_config)
+        ecc_rule_instance = EccDetectErrorRule(mock_rule_alert_handler,
+                                               mock_rule_config)
         check_status_response = ecc_rule_instance.check_status()
 
         self.assertTrue(check_status_response)
@@ -84,18 +76,15 @@ class TestEccDetectErrorRule(unittest.TestCase):
         self.assertTrue("mock-worker-one" in ecc_rule_instance.new_bad_nodes)
         self.assertTrue("mock-worker-two" in ecc_rule_instance.new_bad_nodes)
 
-    
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     @mock.patch('utils.k8s_util.list_node')
     @mock.patch('requests.get')
-    @mock.patch('rules.ecc_detect_error_rule.EccDetectErrorRule.load_ecc_config')
-    def test_check_status_ecc_error_node_already_detected(self, 
-            mock_load_ecc_config,
-            mock_request_get,
-            mock_list_node,
-            mock_rule_alert_handler_load_config,
-            mock_email_handler):
+    @mock.patch('rules.ecc_detect_error_rule.EccDetectErrorRule.load_ecc_config'
+               )
+    def test_check_status_ecc_error_node_already_detected(
+        self, mock_load_ecc_config, mock_request_get, mock_list_node,
+        mock_rule_alert_handler_load_config, mock_email_handler):
 
         mock_rule_config = test_util.mock_rule_config()
         mock_rule_alert_handler_load_config.return_value = mock_rule_config
@@ -110,63 +99,58 @@ class TestEccDetectErrorRule(unittest.TestCase):
                 }
             }
         }
-        mock_request_get.return_value.json.return_value = _mock_prometheus_ecc_data()
-        mock_list_node.return_value = test_util.mock_v1_node_list([
-            {
-                "instance": "192.168.0.1",
-                "node_name": "mock-worker-one"
-            },
-            {
-                "instance": "192.168.0.2",
-                "node_name": "mock-worker-two"
-            }
-        ])
+        mock_request_get.return_value.json.return_value = _mock_prometheus_ecc_data(
+        )
+        mock_list_node.return_value = test_util.mock_v1_node_list([{
+            "instance": "192.168.0.1",
+            "node_name": "mock-worker-one"
+        }, {
+            "instance": "192.168.0.2",
+            "node_name": "mock-worker-two"
+        }])
 
-        ecc_rule_instance = EccDetectErrorRule(mock_rule_alert_handler, mock_rule_config)
+        ecc_rule_instance = EccDetectErrorRule(mock_rule_alert_handler,
+                                               mock_rule_config)
         check_status_response = ecc_rule_instance.check_status()
 
         self.assertTrue(check_status_response)
         self.assertEqual(len(ecc_rule_instance.new_bad_nodes), 1)
         self.assertTrue("mock-worker-two" in ecc_rule_instance.new_bad_nodes)
 
-
     @mock.patch('utils.k8s_util.get_node_address_info')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler')
     @mock.patch('utils.k8s_util.list_node')
     @mock.patch('requests.get')
-    @mock.patch('rules.ecc_detect_error_rule.EccDetectErrorRule.load_ecc_config')
-    def test_check_status_ecc_error_not_found(self, 
-            mock_load_ecc_config,
-            mock_request_get,
-            mock_list_node,
-            mock_rule_alert_handler,
-            mock_get_node_address_info):
+    @mock.patch('rules.ecc_detect_error_rule.EccDetectErrorRule.load_ecc_config'
+               )
+    def test_check_status_ecc_error_not_found(self, mock_load_ecc_config,
+                                              mock_request_get, mock_list_node,
+                                              mock_rule_alert_handler,
+                                              mock_get_node_address_info):
         mock_load_ecc_config.return_value = test_util.mock_ecc_config()
 
-        mock_request_get.return_value.json.return_value = test_util.mock_empty_prometheus_metric_data()
+        mock_request_get.return_value.json.return_value = test_util.mock_empty_prometheus_metric_data(
+        )
 
-        ecc_rule_instance = EccDetectErrorRule(mock_rule_alert_handler, test_util.mock_rule_config())
+        ecc_rule_instance = EccDetectErrorRule(mock_rule_alert_handler,
+                                               test_util.mock_rule_config())
         check_status_response = ecc_rule_instance.check_status()
 
         self.assertFalse(check_status_response)
         self.assertEqual(len(ecc_rule_instance.new_bad_nodes), 0)
-
 
     @mock.patch('rules.ecc_detect_error_rule._create_email_for_job_owner')
     @mock.patch('rules.ecc_detect_error_rule._create_email_for_dris')
     @mock.patch('rules.ecc_detect_error_rule.k8s_util.cordon_node')
     @mock.patch('utils.k8s_util.list_namespaced_pod')
     @mock.patch('utils.email_util.EmailHandler')
-    @mock.patch('rules.ecc_detect_error_rule.EccDetectErrorRule.load_ecc_config')
+    @mock.patch('rules.ecc_detect_error_rule.EccDetectErrorRule.load_ecc_config'
+               )
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_take_action(self,
-            mock_load_rule_config,
-            mock_load_ecc_config,
-            mock_email_handler,
-            mock_pod_list,
-            mock_cordon_node,
-            mock_create_email_for_dris,
-            mock_create_email_for_job_owner):
+    def test_take_action(self, mock_load_rule_config, mock_load_ecc_config,
+                         mock_email_handler, mock_pod_list, mock_cordon_node,
+                         mock_create_email_for_dris,
+                         mock_create_email_for_job_owner):
         mock_rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = mock_rule_config
         mock_load_ecc_config.return_value = test_util.mock_ecc_config()
@@ -178,32 +162,27 @@ class TestEccDetectErrorRule(unittest.TestCase):
             "mock-worker-two": "192.168.0.2"
         }
 
-        mock_pod_list.return_value = test_util.mock_v1_pod_list([
-            {
-                "job_name": "87654321-wxyz",
-                "user_name": "user1",
-                "vc_name": "vc1",
-                "node_name": "mock-worker-one"
-            },
-            {
-                "job_name": "12345678-abcd",
-                "user_name": "user2",
-                "vc_name": "vc2",
-                "node_name": "mock-worker-one"
-            },
-            {
-                "job_name": "12345678-abcd",
-                "user_name": "user2",
-                "vc_name": "vc2",
-                "node_name": "mock-worker-two"
-            },
-            {
-                "job_name": "99999999-efgh",
-                "user_name": "user3",
-                "vc_name": "vc3",
-                "node_name": "mock-worker-three"
-            }
-        ])
+        mock_pod_list.return_value = test_util.mock_v1_pod_list([{
+            "job_name": "87654321-wxyz",
+            "user_name": "user1",
+            "vc_name": "vc1",
+            "node_name": "mock-worker-one"
+        }, {
+            "job_name": "12345678-abcd",
+            "user_name": "user2",
+            "vc_name": "vc2",
+            "node_name": "mock-worker-one"
+        }, {
+            "job_name": "12345678-abcd",
+            "user_name": "user2",
+            "vc_name": "vc2",
+            "node_name": "mock-worker-two"
+        }, {
+            "job_name": "99999999-efgh",
+            "user_name": "user3",
+            "vc_name": "vc3",
+            "node_name": "mock-worker-three"
+        }])
 
         ecc_rule_instance.take_action()
 
@@ -213,9 +192,13 @@ class TestEccDetectErrorRule(unittest.TestCase):
 
         self.assertTrue("ecc_rule" in alert.rule_cache)
         self.assertTrue("mock-worker-one" in alert.rule_cache["ecc_rule"])
-        self.assertEqual("192.168.0.1", alert.rule_cache["ecc_rule"]["mock-worker-one"]["instance"])
+        self.assertEqual(
+            "192.168.0.1",
+            alert.rule_cache["ecc_rule"]["mock-worker-one"]["instance"])
         self.assertTrue("mock-worker-two" in alert.rule_cache["ecc_rule"])
-        self.assertEqual("192.168.0.2", alert.rule_cache["ecc_rule"]["mock-worker-two"]["instance"])
+        self.assertEqual(
+            "192.168.0.2",
+            alert.rule_cache["ecc_rule"]["mock-worker-two"]["instance"])
 
 
 if __name__ == '__main__':

--- a/src/RepairManager/test/test_ecc_reboot_node_rule.py
+++ b/src/RepairManager/test/test_ecc_reboot_node_rule.py
@@ -2,10 +2,11 @@ import os, sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import unittest
-import mock
+from unittest import mock
 from datetime import datetime, timedelta, timezone
 from rules import ecc_reboot_node_rule
 from utils import rule_alert_handler, test_util
+
 
 def _mock_prometheus_node_boot_time_response(node_boot_times):
     mock_response = {
@@ -20,10 +21,10 @@ def _mock_prometheus_node_boot_time_response(node_boot_times):
         metric = {
             "metric": {
                 "__name__": "node_boot_time_seconds",
-                            "exporter_name": "node-exporter",
-                            "instance": f"{node_ip}:9090",
-                            "job": "serivce_exporter",
-                            "scraped_from": "node-exporter"
+                "exporter_name": "node-exporter",
+                "instance": f"{node_ip}:9090",
+                "job": "serivce_exporter",
+                "scraped_from": "node-exporter"
             },
             "value": [1580517453.696, node_boot_times[node_ip]]
         }
@@ -31,22 +32,26 @@ def _mock_prometheus_node_boot_time_response(node_boot_times):
 
     return mock_response
 
-class TestEccRebootNodeRule(unittest.TestCase):
 
+class TestEccRebootNodeRule(unittest.TestCase):
     def test_extract_node_boot_time_info(self):
         mock_datetime_one = datetime.utcnow()
-        mock_timestamp_one = mock_datetime_one.replace(tzinfo=timezone.utc).timestamp()
+        mock_timestamp_one = mock_datetime_one.replace(
+            tzinfo=timezone.utc).timestamp()
 
         mock_datetime_two = datetime.utcnow() + timedelta(days=1)
-        mock_timestamp_two = str(mock_datetime_two.replace(tzinfo=timezone.utc).timestamp())
+        mock_timestamp_two = str(
+            mock_datetime_two.replace(tzinfo=timezone.utc).timestamp())
 
         node_boot_times = {
             "192.168.0.1": str(mock_timestamp_one),
             "192.168.0.2": str(mock_timestamp_two)
         }
-        prometheus_resp = _mock_prometheus_node_boot_time_response(node_boot_times)
+        prometheus_resp = _mock_prometheus_node_boot_time_response(
+            node_boot_times)
 
-        result_boot_times = ecc_reboot_node_rule._extract_node_boot_time_info(prometheus_resp)
+        result_boot_times = ecc_reboot_node_rule._extract_node_boot_time_info(
+            prometheus_resp)
 
         self.assertTrue("192.168.0.1" in result_boot_times)
         self.assertEqual(mock_datetime_one, result_boot_times["192.168.0.1"])
@@ -54,20 +59,17 @@ class TestEccRebootNodeRule(unittest.TestCase):
         self.assertTrue("192.168.0.2" in result_boot_times)
         self.assertEqual(mock_datetime_two, result_boot_times["192.168.0.2"])
 
-
     @mock.patch('utils.k8s_util.list_namespaced_pod')
     @mock.patch('requests.get')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_check_status_node_due_for_reboot(self,
-            mock_load_rule_config,
-            mock_email_handler,
-            mock_load_ecc_config,
-            mock_load_etcd_config,
-            mock_request_get,
-            mock_pod_list):
+    def test_check_status_node_due_for_reboot(self, mock_load_rule_config,
+                                              mock_email_handler,
+                                              mock_load_ecc_config,
+                                              mock_load_etcd_config,
+                                              mock_request_get, mock_pod_list):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
@@ -85,50 +87,55 @@ class TestEccRebootNodeRule(unittest.TestCase):
         rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
         rule_alert_handler_instance.rule_cache["ecc_rule"] = {
             "node1": {
-                "time_found": time_five_days_ago.strftime(rule_config['date_time_format']),
-                "instance": "192.168.0.1"
+                "time_found":
+                    time_five_days_ago.strftime(rule_config['date_time_format']
+                                               ),
+                "instance":
+                    "192.168.0.1"
             }
         }
 
         # reboot is due to be rebooted (exceeded configured deadline), should trigger take action
         node_boot_times = {
-            "192.168.0.1": str(time_six_days_ago.replace(tzinfo=timezone.utc).timestamp())
+            "192.168.0.1":
+                str(time_six_days_ago.replace(tzinfo=timezone.utc).timestamp())
         }
-        mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(node_boot_times)
-        
-        # at least one job running on the node
-        mock_pod_list.return_value = test_util.mock_v1_pod_list([
-            {
-                "job_name": "87654321-wxyz",
-                "user_name": "user1",
-                "vc_name": "vc1",
-                "node_name": "node1"
-            }
-        ])
+        mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(
+            node_boot_times)
 
-        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
+        # at least one job running on the node
+        mock_pod_list.return_value = test_util.mock_v1_pod_list([{
+            "job_name": "87654321-wxyz",
+            "user_name": "user1",
+            "vc_name": "vc1",
+            "node_name": "node1"
+        }])
+
+        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(
+            rule_alert_handler_instance, rule_config)
         response = ecc_reboot_node_rule_instance.check_status()
 
         self.assertTrue(response)
-        self.assertEqual(1, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
-        self.assertTrue("node1" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
-        self.assertEqual(1, len(ecc_reboot_node_rule_instance.jobs_ready_for_migration))
-        self.assertTrue("87654321-wxyz" in ecc_reboot_node_rule_instance.jobs_ready_for_migration)
+        self.assertEqual(
+            1, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
+        self.assertTrue(
+            "node1" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        self.assertEqual(
+            1, len(ecc_reboot_node_rule_instance.jobs_ready_for_migration))
+        self.assertTrue("87654321-wxyz" in
+                        ecc_reboot_node_rule_instance.jobs_ready_for_migration)
 
-    
     @mock.patch('utils.k8s_util.list_namespaced_pod')
     @mock.patch('requests.get')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_check_status_no_jobs_running(self,
-            mock_load_rule_config,
-            mock_email_handler,
-            mock_load_ecc_config,
-            mock_load_etcd_config,
-            mock_request_get,
-            mock_pod_list):
+    def test_check_status_no_jobs_running(self, mock_load_rule_config,
+                                          mock_email_handler,
+                                          mock_load_ecc_config,
+                                          mock_load_etcd_config,
+                                          mock_request_get, mock_pod_list):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
@@ -144,28 +151,35 @@ class TestEccRebootNodeRule(unittest.TestCase):
         rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
         rule_alert_handler_instance.rule_cache["ecc_rule"] = {
             "node1": {
-                "time_found": time_two_days_ago.strftime(rule_config['date_time_format']),
-                "instance": "192.168.0.1"
+                "time_found":
+                    time_two_days_ago.strftime(rule_config['date_time_format']),
+                "instance":
+                    "192.168.0.1"
             }
         }
 
         # node not due to be rebooted
         node_boot_times = {
-            "192.168.0.1": str(time_two_days_ago.replace(tzinfo=timezone.utc).timestamp())
+            "192.168.0.1":
+                str(time_two_days_ago.replace(tzinfo=timezone.utc).timestamp())
         }
-        mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(node_boot_times)
+        mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(
+            node_boot_times)
 
         # no pods running on node, should trigger take action
         mock_pod_list.return_value = test_util.mock_v1_pod_list([])
 
-        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
+        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(
+            rule_alert_handler_instance, rule_config)
         response = ecc_reboot_node_rule_instance.check_status()
 
-
         self.assertTrue(response)
-        self.assertEqual(1, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
-        self.assertTrue("node1" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
-        self.assertEqual(0, len(ecc_reboot_node_rule_instance.jobs_ready_for_migration))
+        self.assertEqual(
+            1, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
+        self.assertTrue(
+            "node1" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        self.assertEqual(
+            0, len(ecc_reboot_node_rule_instance.jobs_ready_for_migration))
 
     @mock.patch('rules.ecc_detect_error_rule.k8s_util.uncordon_node')
     @mock.patch('utils.k8s_util.list_namespaced_pod')
@@ -174,14 +188,10 @@ class TestEccRebootNodeRule(unittest.TestCase):
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_check_status_node_rebooted_after_detection(self,
-            mock_load_rule_config,
-            mock_email_handler,
-            mock_load_ecc_config,
-            mock_load_etcd_config,
-            mock_request_get,
-            mock_pod_list,
-            mock_uncordon_node):
+    def test_check_status_node_rebooted_after_detection(
+        self, mock_load_rule_config, mock_email_handler, mock_load_ecc_config,
+        mock_load_etcd_config, mock_request_get, mock_pod_list,
+        mock_uncordon_node):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
@@ -199,8 +209,10 @@ class TestEccRebootNodeRule(unittest.TestCase):
         rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
         rule_alert_handler_instance.rule_cache["ecc_rule"] = {
             "node1": {
-                "time_found": time_one_days_ago.strftime(rule_config['date_time_format']),
-                "instance": "192.168.0.1"
+                "time_found":
+                    time_one_days_ago.strftime(rule_config['date_time_format']),
+                "instance":
+                    "192.168.0.1"
             }
         }
 
@@ -208,18 +220,20 @@ class TestEccRebootNodeRule(unittest.TestCase):
         node_boot_times = {
             "192.168.0.1": str(now.replace(tzinfo=timezone.utc).timestamp())
         }
-        mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(node_boot_times)
+        mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(
+            node_boot_times)
 
         mock_pod_list.return_value = test_util.mock_v1_pod_list([])
 
-        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
+        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(
+            rule_alert_handler_instance, rule_config)
         response = ecc_reboot_node_rule_instance.check_status()
 
-
         self.assertFalse(response)
-        self.assertEqual(0, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
-        self.assertTrue("node1" not in rule_alert_handler_instance.rule_cache["ecc_rule"])
-
+        self.assertEqual(
+            0, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
+        self.assertTrue(
+            "node1" not in rule_alert_handler_instance.rule_cache["ecc_rule"])
 
     @mock.patch('utils.k8s_util.list_namespaced_pod')
     @mock.patch('requests.get')
@@ -227,13 +241,11 @@ class TestEccRebootNodeRule(unittest.TestCase):
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_check_status_no_action_needed(self,
-        mock_load_rule_config,
-        mock_email_handler,
-        mock_load_etcd_config,
-        mock_load_ecc_config,
-        mock_request_get,
-        mock_pod_list):
+    def test_check_status_no_action_needed(self, mock_load_rule_config,
+                                           mock_email_handler,
+                                           mock_load_etcd_config,
+                                           mock_load_ecc_config,
+                                           mock_request_get, mock_pod_list):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
@@ -252,41 +264,50 @@ class TestEccRebootNodeRule(unittest.TestCase):
         rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
         rule_alert_handler_instance.rule_cache["ecc_rule"] = {
             "node1": {
-                "time_found": time_two_days_ago.strftime(rule_config['date_time_format']),
-                "instance": "192.168.0.1"
+                "time_found":
+                    time_two_days_ago.strftime(rule_config['date_time_format']),
+                "instance":
+                    "192.168.0.1"
             },
             # this node already has a reboot attempt, so should not trigger take action
             "node2": {
-                "time_found": time_three_days_ago.strftime(rule_config['date_time_format']),
-                "instance": "192.168.0.2",
-                "reboot_requested": time_two_days_ago.strftime(rule_config['date_time_format'])
+                "time_found":
+                    time_three_days_ago.strftime(rule_config['date_time_format']
+                                                ),
+                "instance":
+                    "192.168.0.2",
+                "reboot_requested":
+                    time_two_days_ago.strftime(rule_config['date_time_format'])
             }
         }
 
         # both nodes have not been rebooted after initial detection
         node_boot_times = {
-            "192.168.0.1": str(time_three_days_ago.replace(tzinfo=timezone.utc).timestamp()),
-            "192.168.0.2": str(time_six_days_ago.replace(tzinfo=timezone.utc).timestamp())
+            "192.168.0.1":
+                str(
+                    time_three_days_ago.replace(
+                        tzinfo=timezone.utc).timestamp()),
+            "192.168.0.2":
+                str(time_six_days_ago.replace(tzinfo=timezone.utc).timestamp())
         }
-        mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(node_boot_times)
+        mock_request_get.return_value.json.return_value = _mock_prometheus_node_boot_time_response(
+            node_boot_times)
 
         # at least one job running on the node
-        mock_pod_list.return_value = test_util.mock_v1_pod_list([
-            {
-                "job_name": "87654321-wxyz",
-                "user_name": "user1",
-                "vc_name": "vc1",
-                "node_name": "node1"
-            }
-        ])
+        mock_pod_list.return_value = test_util.mock_v1_pod_list([{
+            "job_name": "87654321-wxyz",
+            "user_name": "user1",
+            "vc_name": "vc1",
+            "node_name": "node1"
+        }])
 
-        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
+        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(
+            rule_alert_handler_instance, rule_config)
         response = ecc_reboot_node_rule_instance.check_status()
 
-
         self.assertFalse(response)
-        self.assertEqual(0, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
-
+        self.assertEqual(
+            0, len(ecc_reboot_node_rule_instance.nodes_ready_for_action))
 
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
@@ -295,14 +316,11 @@ class TestEccRebootNodeRule(unittest.TestCase):
     @mock.patch('requests.put')
     @mock.patch('rules.ecc_reboot_node_rule._create_email_for_pause_resume_job')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_take_action(self, 
-        mock_load_rule_config,
-        mock_create_email_for_pause_resume_job,
-        mock_put_requests,
-        mock_get_requests,
-        mock_email_handler,
-        mock_load_etcd_config,
-        mock_load_ecc_config):
+    def test_take_action(self, mock_load_rule_config,
+                         mock_create_email_for_pause_resume_job,
+                         mock_put_requests, mock_get_requests,
+                         mock_email_handler, mock_load_etcd_config,
+                         mock_load_ecc_config):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
@@ -315,92 +333,120 @@ class TestEccRebootNodeRule(unittest.TestCase):
 
         mock_get_requests.return_value.json.side_effect = [
             # job 1
-            {"result": "Success, job paused."},
-            {"errorMsg": None,
-            "jobStatus": "paused",
-            "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"},
-            {"result": "Success, job resumed."},
-            # job 2
-            {"result": "Success, job paused."},
-            {"errorMsg": None,
-            "jobStatus": "paused",
-            "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"},
-            {"result": "Success, job resumed."},
-            # job 3
-            {"result": "Success, job paused."},
-            {"errorMsg": None,
-            "jobStatus": "paused",
-            "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"},
-            {"result": "Success, job resumed."}
-        ]
-
-        mock_put_requests.return_value.json.side_effect = [
             {
-                "action": "set",
-                "node": {
-                    "key": "/mock-worker-one/reboot",
-                    "value": "True",
-                    "modifiedIndex": 39,
-                    "createdIndex": 39
-                }
+                "result": "Success, job paused."
             },
             {
-                "action": "set",
-                "node": {
-                    "key": "/mock-worker-three/reboot",
-                    "value": "True",
-                    "modifiedIndex": 39,
-                    "createdIndex": 39
-                }
-            }]
+                "errorMsg": None,
+                "jobStatus": "paused",
+                "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"
+            },
+            {
+                "result": "Success, job resumed."
+            },
+            # job 2
+            {
+                "result": "Success, job paused."
+            },
+            {
+                "errorMsg": None,
+                "jobStatus": "paused",
+                "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"
+            },
+            {
+                "result": "Success, job resumed."
+            },
+            # job 3
+            {
+                "result": "Success, job paused."
+            },
+            {
+                "errorMsg": None,
+                "jobStatus": "paused",
+                "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"
+            },
+            {
+                "result": "Success, job resumed."
+            }
+        ]
+
+        mock_put_requests.return_value.json.side_effect = [{
+            "action": "set",
+            "node": {
+                "key": "/mock-worker-one/reboot",
+                "value": "True",
+                "modifiedIndex": 39,
+                "createdIndex": 39
+            }
+        }, {
+            "action": "set",
+            "node": {
+                "key": "/mock-worker-three/reboot",
+                "value": "True",
+                "modifiedIndex": 39,
+                "createdIndex": 39
+            }
+        }]
 
         rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
         rule_alert_handler_instance.rule_cache["ecc_rule"] = {
-            "mock-worker-one": {"instance": "192.168.0.1:9090"},
-            "mock-worker-two": {"instance": "192.168.0.2:9090"},
-            "mock-worker-three": {"instance": "192.168.0.3:9090"}
+            "mock-worker-one": {
+                "instance": "192.168.0.1:9090"
+            },
+            "mock-worker-two": {
+                "instance": "192.168.0.2:9090"
+            },
+            "mock-worker-three": {
+                "instance": "192.168.0.3:9090"
+            }
         }
 
         ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(
             rule_alert_handler_instance, rule_config)
         ecc_reboot_node_rule_instance.nodes_ready_for_action = [
-            "mock-worker-one", "mock-worker-three"]
+            "mock-worker-one", "mock-worker-three"
+        ]
         ecc_reboot_node_rule_instance.jobs_ready_for_migration = {
-            "87654321-wxyz":
-                {
-                    "user_name": "user1",
-                    "vc_name": "vc1",
-                    "node_names": ["mock-worker-one"],
-                    "job_link": "/job-link-1"
-                },
+            "87654321-wxyz": {
+                "user_name": "user1",
+                "vc_name": "vc1",
+                "node_names": ["mock-worker-one"],
+                "job_link": "/job-link-1"
+            },
             "12345678-abcd": {
-                    "user_name": "user2",
-                    "vc_name": "vc2",
-                    "node_names": ["mock-worker-one"],
-                    "job_link": "/job-link-2"
-                },
+                "user_name": "user2",
+                "vc_name": "vc2",
+                "node_names": ["mock-worker-one"],
+                "job_link": "/job-link-2"
+            },
             "99999999-efgh": {
-                    "user_name": "user3",
-                    "vc_name": "vc3",
-                    "node_names": ["mock-worker-three"],
-                    "job_link": "/job-link-3"
-                }
+                "user_name": "user3",
+                "vc_name": "vc3",
+                "node_names": ["mock-worker-three"],
+                "job_link": "/job-link-3"
+            }
         }
 
         ecc_reboot_node_rule_instance.take_action()
 
         self.assertEqual(3, mock_create_email_for_pause_resume_job.call_count)
-        self.assertEqual(3, len(rule_alert_handler_instance.rule_cache["ecc_rule"]))
+        self.assertEqual(
+            3, len(rule_alert_handler_instance.rule_cache["ecc_rule"]))
         # node should have successfully rebooted
-        self.assertTrue("mock-worker-one" in rule_alert_handler_instance.rule_cache["ecc_rule"])
-        self.assertTrue("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-one"])
+        self.assertTrue("mock-worker-one" in
+                        rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertTrue("reboot_requested" in rule_alert_handler_instance.
+                        rule_cache["ecc_rule"]["mock-worker-one"])
         # no action was taken on this node (not in ready for action list)
-        self.assertTrue("mock-worker-two" in rule_alert_handler_instance.rule_cache["ecc_rule"])
-        self.assertFalse("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-two"])
+        self.assertTrue("mock-worker-two" in
+                        rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertFalse("reboot_requested" in rule_alert_handler_instance.
+                         rule_cache["ecc_rule"]["mock-worker-two"])
         # node should have successfully rebooted
-        self.assertTrue("mock-worker-three" in rule_alert_handler_instance.rule_cache["ecc_rule"])
-        self.assertTrue("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-three"])
-    
+        self.assertTrue("mock-worker-three" in
+                        rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertTrue("reboot_requested" in rule_alert_handler_instance.
+                        rule_cache["ecc_rule"]["mock-worker-three"])
 
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
@@ -408,13 +454,11 @@ class TestEccRebootNodeRule(unittest.TestCase):
     @mock.patch('requests.get')
     @mock.patch('requests.put')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_take_action_pause_failed(self, 
-        mock_load_rule_config,
-        mock_put_requests,
-        mock_get_requests,
-        mock_email_load_config,
-        mock_load_ecc_config,
-        mock_load_etcd_config):
+    def test_take_action_pause_failed(self, mock_load_rule_config,
+                                      mock_put_requests, mock_get_requests,
+                                      mock_email_load_config,
+                                      mock_load_ecc_config,
+                                      mock_load_etcd_config):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
@@ -425,38 +469,46 @@ class TestEccRebootNodeRule(unittest.TestCase):
         mock_load_ecc_config.return_value = test_util.mock_ecc_config()
         mock_load_ecc_config.return_value["alert_job_owners"] = True
 
-        mock_get_requests.return_value.json.return_value = {"result": "Sorry, something went wrong."}
+        mock_get_requests.return_value.json.return_value = {
+            "result": "Sorry, something went wrong."
+        }
 
         rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
         rule_alert_handler_instance.rule_cache["ecc_rule"] = {
-            "mock-worker-one": {"instance": "192.168.0.1:9090"},
-            "mock-worker-two": {"instance": "192.168.0.2:9090"},
-            "mock-worker-three": {"instance": "192.168.0.3:9090"},
-            "mock-worker-four": {"instance": "192.168.0.4:9090"}
+            "mock-worker-one": {
+                "instance": "192.168.0.1:9090"
+            },
+            "mock-worker-two": {
+                "instance": "192.168.0.2:9090"
+            },
+            "mock-worker-three": {
+                "instance": "192.168.0.3:9090"
+            },
+            "mock-worker-four": {
+                "instance": "192.168.0.4:9090"
+            }
         }
 
-        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(rule_alert_handler_instance, rule_config)
+        ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(
+            rule_alert_handler_instance, rule_config)
         ecc_reboot_node_rule_instance.nodes_ready_for_action = [
-            "mock-worker-one", 
-            "mock-worker-two",
-            "mock-worker-three",
+            "mock-worker-one", "mock-worker-two", "mock-worker-three",
             "mock-worker-four"
         ]
         ecc_reboot_node_rule_instance.jobs_ready_for_migration = {
-            "87654321-wxyz":
-                {
-                    "user_name": "user1",
-                    "vc_name": "vc1",
-                    "node_names": ["mock-worker-one"],
-                    "job_link": "/job-link-1"
-                },
-                # distributed job
-                "12345678-abcd": {
-                    "user_name": "user2",
-                    "vc_name": "vc1",
-                    "node_names": ["mock-worker-two", "mock-worker-three"],
-                    "job_link": "/job-link-2"
-                }
+            "87654321-wxyz": {
+                "user_name": "user1",
+                "vc_name": "vc1",
+                "node_names": ["mock-worker-one"],
+                "job_link": "/job-link-1"
+            },
+            # distributed job
+            "12345678-abcd": {
+                "user_name": "user2",
+                "vc_name": "vc1",
+                "node_names": ["mock-worker-two", "mock-worker-three"],
+                "job_link": "/job-link-2"
+            }
         }
 
         mock_put_requests.return_value.json.return_value = {
@@ -471,21 +523,33 @@ class TestEccRebootNodeRule(unittest.TestCase):
 
         ecc_reboot_node_rule_instance.take_action()
         # node should be skipped since job migration failed
-        self.assertTrue("mock-worker-one" in rule_alert_handler_instance.rule_cache["ecc_rule"])
-        self.assertFalse("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-one"])
-        self.assertFalse("mock-worker-one" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        self.assertTrue("mock-worker-one" in
+                        rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertFalse("reboot_requested" in rule_alert_handler_instance.
+                         rule_cache["ecc_rule"]["mock-worker-one"])
+        self.assertFalse("mock-worker-one" in
+                         ecc_reboot_node_rule_instance.nodes_ready_for_action)
         # node should be skipped since job migration failed (distributed job)
-        self.assertTrue("mock-worker-two" in rule_alert_handler_instance.rule_cache["ecc_rule"])
-        self.assertFalse("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-two"])
-        self.assertFalse("mock-worker-two" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        self.assertTrue("mock-worker-two" in
+                        rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertFalse("reboot_requested" in rule_alert_handler_instance.
+                         rule_cache["ecc_rule"]["mock-worker-two"])
+        self.assertFalse("mock-worker-two" in
+                         ecc_reboot_node_rule_instance.nodes_ready_for_action)
         # node should be skipped since job migration failed (distributed job)
-        self.assertTrue("mock-worker-three" in rule_alert_handler_instance.rule_cache["ecc_rule"])
-        self.assertFalse("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-three"])
-        self.assertFalse("mock-worker-three" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        self.assertTrue("mock-worker-three" in
+                        rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertFalse("reboot_requested" in rule_alert_handler_instance.
+                         rule_cache["ecc_rule"]["mock-worker-three"])
+        self.assertFalse("mock-worker-three" in
+                         ecc_reboot_node_rule_instance.nodes_ready_for_action)
         # node should be successfully rebooted (had no jobs to migrate)
-        self.assertTrue("mock-worker-four" in rule_alert_handler_instance.rule_cache["ecc_rule"])
-        self.assertTrue("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-four"])
-        self.assertTrue("mock-worker-four" in ecc_reboot_node_rule_instance.nodes_ready_for_action)
+        self.assertTrue("mock-worker-four" in
+                        rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertTrue("reboot_requested" in rule_alert_handler_instance.
+                        rule_cache["ecc_rule"]["mock-worker-four"])
+        self.assertTrue("mock-worker-four" in
+                        ecc_reboot_node_rule_instance.nodes_ready_for_action)
 
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_ecc_config')
     @mock.patch('rules.ecc_reboot_node_rule.EccRebootNodeRule.load_etcd_config')
@@ -494,14 +558,12 @@ class TestEccRebootNodeRule(unittest.TestCase):
     @mock.patch('requests.put')
     @mock.patch('rules.ecc_reboot_node_rule._create_email_for_pause_resume_job')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_take_action_reboot_failed(self, 
-        mock_load_rule_config,
-        mock_create_email_for_pause_resume_job,
-        mock_put_requests,
-        mock_get_requests,
-        mock_email_handler,
-        mock_load_etcd_config,
-        mock_load_ecc_config):
+    def test_take_action_reboot_failed(self, mock_load_rule_config,
+                                       mock_create_email_for_pause_resume_job,
+                                       mock_put_requests, mock_get_requests,
+                                       mock_email_handler,
+                                       mock_load_etcd_config,
+                                       mock_load_ecc_config):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
@@ -514,23 +576,41 @@ class TestEccRebootNodeRule(unittest.TestCase):
 
         mock_get_requests.return_value.json.side_effect = [
             # job 1
-            {"result": "Success, job paused."},
-            {"errorMsg": None,
-            "jobStatus": "paused",
-            "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"},
-            {"result": "Success, job resumed."},
+            {
+                "result": "Success, job paused."
+            },
+            {
+                "errorMsg": None,
+                "jobStatus": "paused",
+                "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"
+            },
+            {
+                "result": "Success, job resumed."
+            },
             # job 2
-            {"result": "Success, job paused."},
-            {"errorMsg": None,
-            "jobStatus": "paused",
-            "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"},
-            {"result": "Success, job resumed."},
+            {
+                "result": "Success, job paused."
+            },
+            {
+                "errorMsg": None,
+                "jobStatus": "paused",
+                "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"
+            },
+            {
+                "result": "Success, job resumed."
+            },
             # job 3
-            {"result": "Success, job paused."},
-            {"errorMsg": None,
-            "jobStatus": "paused",
-            "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"},
-            {"result": "Success, job resumed."}
+            {
+                "result": "Success, job paused."
+            },
+            {
+                "errorMsg": None,
+                "jobStatus": "paused",
+                "jobTime": "Thu, 30 Jan 2020 23:43:00 GMT"
+            },
+            {
+                "result": "Success, job resumed."
+            }
         ]
 
         mock_put_requests.return_value.json.side_effect = [
@@ -548,50 +628,61 @@ class TestEccRebootNodeRule(unittest.TestCase):
                 "error_code": 100,
                 "message": "Something went wrong",
                 "cause": "Unable to open connection"
-            }]
+            }
+        ]
 
         rule_alert_handler_instance = rule_alert_handler.RuleAlertHandler()
         rule_alert_handler_instance.rule_cache["ecc_rule"] = {
-            "mock-worker-one": {"instance": "192.168.0.1:9090"},
-            "mock-worker-three": {"instance": "192.168.0.3:9090"}
+            "mock-worker-one": {
+                "instance": "192.168.0.1:9090"
+            },
+            "mock-worker-three": {
+                "instance": "192.168.0.3:9090"
+            }
         }
 
         ecc_reboot_node_rule_instance = ecc_reboot_node_rule.EccRebootNodeRule(
             rule_alert_handler_instance, rule_config)
         ecc_reboot_node_rule_instance.nodes_ready_for_action = [
-            "mock-worker-one", "mock-worker-three"]
+            "mock-worker-one", "mock-worker-three"
+        ]
         ecc_reboot_node_rule_instance.jobs_ready_for_migration = {
-            "87654321-wxyz":
-                {
-                    "user_name": "user1",
-                    "vc_name": "vc1",
-                    "node_names": ["mock-worker-one"],
-                    "job_link": "/job-link-1"
-                },
+            "87654321-wxyz": {
+                "user_name": "user1",
+                "vc_name": "vc1",
+                "node_names": ["mock-worker-one"],
+                "job_link": "/job-link-1"
+            },
             "12345678-abcd": {
-                    "user_name": "user2",
-                    "vc_name": "vc2",
-                    "node_names": ["mock-worker-one"],
-                    "job_link": "/job-link-2"
-                },
+                "user_name": "user2",
+                "vc_name": "vc2",
+                "node_names": ["mock-worker-one"],
+                "job_link": "/job-link-2"
+            },
             "99999999-efgh": {
-                    "user_name": "user3",
-                    "vc_name": "vc3",
-                    "node_names": ["mock-worker-three"],
-                    "job_link": "/job-link-3"
-                }
+                "user_name": "user3",
+                "vc_name": "vc3",
+                "node_names": ["mock-worker-three"],
+                "job_link": "/job-link-3"
+            }
         }
 
         ecc_reboot_node_rule_instance.take_action()
 
         self.assertEqual(3, mock_create_email_for_pause_resume_job.call_count)
-        self.assertEqual(2, len(rule_alert_handler_instance.rule_cache["ecc_rule"]))
+        self.assertEqual(
+            2, len(rule_alert_handler_instance.rule_cache["ecc_rule"]))
         # reboot successful for this node
-        self.assertTrue("mock-worker-one" in rule_alert_handler_instance.rule_cache["ecc_rule"])
-        self.assertTrue("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-one"])
+        self.assertTrue("mock-worker-one" in
+                        rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertTrue("reboot_requested" in rule_alert_handler_instance.
+                        rule_cache["ecc_rule"]["mock-worker-one"])
         # reboot failed for this node
-        self.assertTrue("mock-worker-three" in rule_alert_handler_instance.rule_cache["ecc_rule"])
-        self.assertFalse("reboot_requested" in rule_alert_handler_instance.rule_cache["ecc_rule"]["mock-worker-three"])
+        self.assertTrue("mock-worker-three" in
+                        rule_alert_handler_instance.rule_cache["ecc_rule"])
+        self.assertFalse("reboot_requested" in rule_alert_handler_instance.
+                         rule_cache["ecc_rule"]["mock-worker-three"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/RepairManager/test/test_k8s_util.py
+++ b/src/RepairManager/test/test_k8s_util.py
@@ -1,5 +1,5 @@
 import unittest
-import mock
+from unittest import mock
 from utils import k8s_util
 from kubernetes.client.models.v1_node import V1Node
 from kubernetes.client.models.v1_node_list import V1NodeList
@@ -10,12 +10,14 @@ from kubernetes.client.models.v1_pod import V1Pod
 from kubernetes.client.models.v1_object_meta import V1ObjectMeta
 from kubernetes.client.models.v1_pod_spec import V1PodSpec
 
+
 def _mock_v1_node(internal_ip, hostname):
     node = V1Node()
     address_ip = V1NodeAddress(internal_ip, "InternalIP")
     address_hostname = V1NodeAddress(hostname, "Hostname")
     node.status = V1NodeStatus(addresses=[address_ip, address_hostname])
     return node
+
 
 def _mock_v1_pod(jobId, userName, vcName, nodeName):
     pod = V1Pod()
@@ -30,8 +32,8 @@ def _mock_v1_pod(jobId, userName, vcName, nodeName):
     pod.spec.node_name = nodeName
     return pod
 
-class TestK8sUtil(unittest.TestCase):
 
+class TestK8sUtil(unittest.TestCase):
     @mock.patch('utils.k8s_util.list_namespaced_pod')
     def test_get_job_info_indexed_by_job_id(self, mock_list_namespaced_pod):
         pod_one = _mock_v1_pod("87654321-wxyz", "user1", "vc1", "node1")
@@ -47,16 +49,17 @@ class TestK8sUtil(unittest.TestCase):
         self.assertTrue("87654321-wxyz" in job_response)
         self.assertEqual(1, len(job_response["87654321-wxyz"]["node_names"]))
         self.assertTrue("node1" in job_response["87654321-wxyz"]["node_names"])
-        self.assertEqual("https://dlts.domain.com/job/vc1/cluster1/87654321-wxyz",
-         job_response["87654321-wxyz"]["job_link"])
+        self.assertEqual(
+            "https://dlts.domain.com/job/vc1/cluster1/87654321-wxyz",
+            job_response["87654321-wxyz"]["job_link"])
 
         self.assertTrue("12345678-abcd" in job_response)
         self.assertEqual(2, len(job_response["12345678-abcd"]["node_names"]))
         self.assertTrue("node1" in job_response["12345678-abcd"]["node_names"])
         self.assertTrue("node2" in job_response["12345678-abcd"]["node_names"])
-        self.assertEqual("https://dlts.domain.com/job/vc2/cluster1/12345678-abcd", 
-        job_response["12345678-abcd"]["job_link"])
-
+        self.assertEqual(
+            "https://dlts.domain.com/job/vc2/cluster1/12345678-abcd",
+            job_response["12345678-abcd"]["job_link"])
 
     @mock.patch('utils.k8s_util.list_namespaced_pod')
     def test_get_job_info_indexed_by_node(self, mock_list_namespaced_pod):
@@ -67,8 +70,9 @@ class TestK8sUtil(unittest.TestCase):
         mock_pod_list = V1PodList(items=[pod_one, pod_two, pod_three, pod_four])
         mock_list_namespaced_pod.return_value = mock_pod_list
 
-        job_response = k8s_util.get_job_info_indexed_by_node(
-            ["node1", "node2"], "dlts.domain.com", "cluster1")
+        job_response = k8s_util.get_job_info_indexed_by_node(["node1", "node2"],
+                                                             "dlts.domain.com",
+                                                             "cluster1")
 
         self.assertEqual(2, len(job_response))
 
@@ -77,23 +81,25 @@ class TestK8sUtil(unittest.TestCase):
         self.assertTrue("87654321-wxyz" in job_response["node1"][0]["job_id"])
         self.assertTrue("user1" in job_response["node1"][0]["user_name"])
         self.assertTrue("vc1" in job_response["node1"][0]["vc_name"])
-        self.assertEqual("https://dlts.domain.com/job/vc1/cluster1/87654321-wxyz",
-        job_response["node1"][0]["job_link"])
+        self.assertEqual(
+            "https://dlts.domain.com/job/vc1/cluster1/87654321-wxyz",
+            job_response["node1"][0]["job_link"])
 
         self.assertTrue("12345678-abcd" in job_response["node1"][1]["job_id"])
         self.assertTrue("user2" in job_response["node1"][1]["user_name"])
         self.assertTrue("vc2" in job_response["node1"][1]["vc_name"])
-        self.assertEqual("https://dlts.domain.com/job/vc2/cluster1/12345678-abcd",
-        job_response["node1"][1]["job_link"])
+        self.assertEqual(
+            "https://dlts.domain.com/job/vc2/cluster1/12345678-abcd",
+            job_response["node1"][1]["job_link"])
 
         self.assertTrue("node2" in job_response)
         self.assertEqual(1, len(job_response["node2"]))
         self.assertTrue("12345678-abcd" in job_response["node2"][0]["job_id"])
         self.assertTrue("user2" in job_response["node2"][0]["user_name"])
         self.assertTrue("vc2" in job_response["node2"][0]["vc_name"])
-        self.assertEqual("https://dlts.domain.com/job/vc2/cluster1/12345678-abcd",
-        job_response["node2"][0]["job_link"])
-
+        self.assertEqual(
+            "https://dlts.domain.com/job/vc2/cluster1/12345678-abcd",
+            job_response["node2"][0]["job_link"])
 
     @mock.patch('utils.k8s_util.list_node')
     def test_get_node_address_info(self, mock_list_node):
@@ -108,7 +114,6 @@ class TestK8sUtil(unittest.TestCase):
         self.assertEqual(address_info['192.168.0.1'], "mock-worker-one")
         self.assertTrue('192.168.0.2' in address_info)
         self.assertEqual(address_info['192.168.0.2'], "mock-worker-two")
-
 
     @mock.patch('utils.k8s_util.list_node')
     def test_get_node_address_info_empty(self, mock_list_node):

--- a/src/RepairManager/test/test_nvidia_smi_latency_rule.py
+++ b/src/RepairManager/test/test_nvidia_smi_latency_rule.py
@@ -2,79 +2,75 @@ import os, sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import unittest
-import mock
+from unittest import mock
 from datetime import datetime, timedelta, timezone
-from mock import call
 from rules import nvidia_smi_latency_rule
 from rules.nvidia_smi_latency_rule import NvidiaSmiLatencyRule
 from utils import k8s_util, rule_alert_handler, test_util
+
 
 def _mock_prometheus_latency_data():
     mock_prometheus_latency_data = {
         "status": "success",
         "data": {
-            "resultType": "vector", "result": [
-                {
-                    "metric": {
-                        "instance": "192.168.0.1:9102"
-                    },
-                    "values": [[1584389568, "62.4"], 
-                               [1584389868, "62.4"]]
-                }
-            ]
+            "resultType":
+                "vector",
+            "result": [{
+                "metric": {
+                    "instance": "192.168.0.1:9102"
+                },
+                "values": [[1584389568, "62.4"], [1584389868, "62.4"]]
+            }]
         }
     }
     return mock_prometheus_latency_data
 
-class TestNvidiaSmiLatencyRule(unittest.TestCase):
 
+class TestNvidiaSmiLatencyRule(unittest.TestCase):
     @mock.patch('rules.ecc_detect_error_rule._create_email_for_dris')
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     @mock.patch('utils.k8s_util.list_node')
     @mock.patch('requests.get')
-    @mock.patch('rules.nvidia_smi_latency_rule.NvidiaSmiLatencyRule.load_latency_config')
-    def test_check_status_large_latency_detected(self, 
-            mock_load_latency_config,
-            mock_request_get,
-            mock_list_node,
-            mock_rule_alert_handler_load_config,
-            mock_email_handler,
-            mock_create_email_for_dris):
+    @mock.patch(
+        'rules.nvidia_smi_latency_rule.NvidiaSmiLatencyRule.load_latency_config'
+    )
+    def test_check_status_large_latency_detected(
+        self, mock_load_latency_config, mock_request_get, mock_list_node,
+        mock_rule_alert_handler_load_config, mock_email_handler,
+        mock_create_email_for_dris):
 
         mock_rule_config = test_util.mock_rule_config()
         mock_rule_alert_handler_load_config.return_value = mock_rule_config
         mock_load_latency_config.return_value = test_util.mock_latency_config()
         mock_rule_alert_handler = rule_alert_handler.RuleAlertHandler()
-        mock_request_get.return_value.json.return_value = _mock_prometheus_latency_data()
-        mock_list_node.return_value = test_util.mock_v1_node_list([
-            {
-                "instance": "192.168.0.1",
-                "node_name": "mock-worker-one"
-            },
-            {
-                "instance": "192.168.0.2",
-                "node_name": "mock-worker-two"
-            }
-        ])
+        mock_request_get.return_value.json.return_value = _mock_prometheus_latency_data(
+        )
+        mock_list_node.return_value = test_util.mock_v1_node_list([{
+            "instance": "192.168.0.1",
+            "node_name": "mock-worker-one"
+        }, {
+            "instance": "192.168.0.2",
+            "node_name": "mock-worker-two"
+        }])
 
-        latency_rule_instance = NvidiaSmiLatencyRule(mock_rule_alert_handler, mock_rule_config)
+        latency_rule_instance = NvidiaSmiLatencyRule(mock_rule_alert_handler,
+                                                     mock_rule_config)
         check_status_response = latency_rule_instance.check_status()
 
         self.assertTrue(check_status_response)
         self.assertEqual(len(latency_rule_instance.impacted_nodes), 1)
-        self.assertTrue("mock-worker-one" in latency_rule_instance.impacted_nodes)
-
+        self.assertTrue(
+            "mock-worker-one" in latency_rule_instance.impacted_nodes)
 
     @mock.patch('rules.nvidia_smi_latency_rule._create_email_for_dris')
     @mock.patch('utils.email_util.EmailHandler')
-    @mock.patch('rules.nvidia_smi_latency_rule.NvidiaSmiLatencyRule.load_latency_config')
+    @mock.patch(
+        'rules.nvidia_smi_latency_rule.NvidiaSmiLatencyRule.load_latency_config'
+    )
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_take_action(self,
-            mock_load_rule_config,
-            mock_load_ecc_config,
-            mock_email_handler,
-            mock_create_email_for_dris):
+    def test_take_action(self, mock_load_rule_config, mock_load_ecc_config,
+                         mock_email_handler, mock_create_email_for_dris):
         mock_rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = mock_rule_config
         mock_load_ecc_config.return_value = test_util.mock_latency_config()
@@ -91,21 +87,27 @@ class TestNvidiaSmiLatencyRule(unittest.TestCase):
         self.assertEqual(1, mock_create_email_for_dris.call_count)
 
         self.assertTrue("smi_latency_rule" in alert.rule_cache)
-        self.assertTrue("mock-worker-one" in alert.rule_cache["smi_latency_rule"])
-        self.assertEqual("192.168.0.1", alert.rule_cache["smi_latency_rule"]["mock-worker-one"]["instance"])
-        self.assertTrue("mock-worker-two" in alert.rule_cache["smi_latency_rule"])
-        self.assertEqual("192.168.0.2", alert.rule_cache["smi_latency_rule"]["mock-worker-two"]["instance"])
-
+        self.assertTrue(
+            "mock-worker-one" in alert.rule_cache["smi_latency_rule"])
+        self.assertEqual(
+            "192.168.0.1",
+            alert.rule_cache["smi_latency_rule"]["mock-worker-one"]["instance"])
+        self.assertTrue(
+            "mock-worker-two" in alert.rule_cache["smi_latency_rule"])
+        self.assertEqual(
+            "192.168.0.2",
+            alert.rule_cache["smi_latency_rule"]["mock-worker-two"]["instance"])
 
     @mock.patch('requests.get')
-    @mock.patch('rules.nvidia_smi_latency_rule.NvidiaSmiLatencyRule.load_latency_config')
+    @mock.patch(
+        'rules.nvidia_smi_latency_rule.NvidiaSmiLatencyRule.load_latency_config'
+    )
     @mock.patch('utils.email_util.EmailHandler')
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
-    def test_clean_expired_items_in_rule_cache(self,
-            mock_load_rule_config,
-            mock_email_handler,
-            mock_ecc_config,
-            mock_request_get):
+    def test_clean_expired_items_in_rule_cache(self, mock_load_rule_config,
+                                               mock_email_handler,
+                                               mock_ecc_config,
+                                               mock_request_get):
 
         rule_config = test_util.mock_rule_config()
         mock_load_rule_config.return_value = rule_config
@@ -120,20 +122,28 @@ class TestNvidiaSmiLatencyRule(unittest.TestCase):
         alert = rule_alert_handler.RuleAlertHandler()
         alert.rule_cache["smi_latency_rule"] = {
             "node1": {
-                "time_found": time_four_hours_ago.strftime(rule_config['date_time_format']),
-                "instance": "192.168.0.1"
+                "time_found":
+                    time_four_hours_ago.strftime(rule_config['date_time_format']
+                                                ),
+                "instance":
+                    "192.168.0.1"
             },
             "node2": {
-                "time_found": time_one_hours_ago.strftime(rule_config['date_time_format']),
-                "instance": "192.168.0.2"
+                "time_found":
+                    time_one_hours_ago.strftime(rule_config['date_time_format']
+                                               ),
+                "instance":
+                    "192.168.0.2"
             }
         }
 
-        smi_latency_rule_instance = nvidia_smi_latency_rule.NvidiaSmiLatencyRule(alert, rule_config)
+        smi_latency_rule_instance = nvidia_smi_latency_rule.NvidiaSmiLatencyRule(
+            alert, rule_config)
         smi_latency_rule_instance.clean_expired_items_in_rule_cache()
 
         self.assertEqual(1, len(alert.rule_cache))
         self.assertTrue("node2" in alert.rule_cache["smi_latency_rule"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/RepairManager/test/test_rule_alert_handler.py
+++ b/src/RepairManager/test/test_rule_alert_handler.py
@@ -2,23 +2,23 @@ import os, sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import unittest
-import mock
+from unittest import mock
 from pathlib import Path
 from utils import rule_alert_handler
+
 
 def _clean_up_dump_file(rule_cache_dump_file):
     dump_file = Path(rule_cache_dump_file)
     if dump_file.is_file():
         os.remove(rule_cache_dump_file)
 
+
 def _mock_rule_config():
-    mock_rule_config = {
-        "restore_from_rule_cache_dump": False
-    }
+    mock_rule_config = {"restore_from_rule_cache_dump": False}
     return mock_rule_config
 
-class TestRuleAlertHandler(unittest.TestCase):
 
+class TestRuleAlertHandler(unittest.TestCase):
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     @mock.patch('utils.email_util.EmailHandler')
     def test_update_rule_cache(self, mock_email_handler, mock_config):
@@ -30,12 +30,15 @@ class TestRuleAlertHandler(unittest.TestCase):
         cache_key = "test_key"
         cache_value = "test_value"
 
-        rule_alert_handler_instance.update_rule_cache(rule, cache_key, cache_value)
+        rule_alert_handler_instance.update_rule_cache(rule, cache_key,
+                                                      cache_value)
 
         self.assertTrue(rule in rule_alert_handler_instance.rule_cache)
-        self.assertTrue(cache_key in rule_alert_handler_instance.rule_cache[rule])
-        self.assertEqual(cache_value, rule_alert_handler_instance.rule_cache[rule][cache_key])
-
+        self.assertTrue(
+            cache_key in rule_alert_handler_instance.rule_cache[rule])
+        self.assertEqual(
+            cache_value,
+            rule_alert_handler_instance.rule_cache[rule][cache_key])
 
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     @mock.patch('utils.email_util.EmailHandler')
@@ -54,7 +57,6 @@ class TestRuleAlertHandler(unittest.TestCase):
         self.assertTrue(rule in rule_alert_handler_instance.rule_cache)
         self.assertEqual(0, len(rule_alert_handler_instance.rule_cache[rule]))
 
-
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     @mock.patch('utils.email_util.EmailHandler')
     def test_get_rule_cache(self, mock_email_handler, mock_config):
@@ -70,9 +72,9 @@ class TestRuleAlertHandler(unittest.TestCase):
         result = rule_alert_handler_instance.get_rule_cache(rule, cache_key)
         self.assertEqual(result, cache_value)
 
-        result = rule_alert_handler_instance.get_rule_cache(rule, "should not exist")
+        result = rule_alert_handler_instance.get_rule_cache(
+            rule, "should not exist")
         self.assertEqual(result, None)
-
 
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     @mock.patch('utils.email_util.EmailHandler')
@@ -89,9 +91,9 @@ class TestRuleAlertHandler(unittest.TestCase):
         result = rule_alert_handler_instance.check_rule_cache(rule, cache_key)
         self.assertTrue(result)
 
-        result = rule_alert_handler_instance.check_rule_cache(rule, "should not exist")
+        result = rule_alert_handler_instance.check_rule_cache(
+            rule, "should not exist")
         self.assertFalse(result)
-
 
     @mock.patch('utils.rule_alert_handler.RuleAlertHandler.load_config')
     @mock.patch('utils.email_util.EmailHandler')
@@ -104,16 +106,18 @@ class TestRuleAlertHandler(unittest.TestCase):
         keys = rule_alert_handler_instance.get_rule_cache_keys(rule)
         self.assertEqual(len(keys), 0)
 
-        rule_alert_handler_instance.update_rule_cache(rule, "test_key1", "test_value1")
-        rule_alert_handler_instance.update_rule_cache(rule, "test_key2", "test_value2")
-        rule_alert_handler_instance.update_rule_cache(rule, "test_key3", "test_value3")
+        rule_alert_handler_instance.update_rule_cache(rule, "test_key1",
+                                                      "test_value1")
+        rule_alert_handler_instance.update_rule_cache(rule, "test_key2",
+                                                      "test_value2")
+        rule_alert_handler_instance.update_rule_cache(rule, "test_key3",
+                                                      "test_value3")
 
         keys = rule_alert_handler_instance.get_rule_cache_keys(rule)
         self.assertEqual(len(keys), 3)
         self.assertTrue("test_key1" in keys)
         self.assertTrue("test_key2" in keys)
         self.assertTrue("test_key3" in keys)
-
 
 
 if __name__ == '__main__':

--- a/src/RepairManager/utils/email_util.py
+++ b/src/RepairManager/utils/email_util.py
@@ -1,32 +1,109 @@
 import smtplib
 import logging
 import yaml
-import datetime
+import time
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENCODING = "utf-8"
+
+
+class EmailMessage(object):
+    def __init__(self, to, cc, subject, body, body_type):
+        self.to = to # , seperated list of receipt or None
+        self.cc = cc # , seperated list of receipt or None
+        self.subject = subject # plain text
+        self.body = body # plain or html text
+        self.body_type = body_type # "plain" or "html"
+
+    def to_json(self, default_recepient):
+        result = {
+            "Subject": self.subject,
+            "Body": self.body,
+            "BodyType": self.body_type,
+        }
+        if self.to is None:
+            result["To"] = default_recepient
+        else:
+            result["CC"] = default_recepient
+        return result
+
+    def to_mime_message(self, default_recepient):
+        msg = MIMEMultipart()
+        if self.to is None:
+            msg["To"] = default_recepient
+        else:
+            msg["CC"] = default_recepient
+        msg["Subject"] = self.subject
+        body = MIMEText(self.body.encode(DEFAULT_ENCODING),
+                        self.body_type,
+                        _charset=DEFAULT_ENCODING)
+        msg.attach(body)
+        return msg
+
 
 class EmailHandler():
-
     def __init__(self):
-        self.config=self.load_config()
+        self.config = self.load_config()
+        self.default_recepient = self.config["default_recepient"]
 
     def load_config(self):
         with open('/etc/RepairManager/config/email-config.yaml', 'r') as file:
             return yaml.safe_load(file)
 
-    def send(self, message):
-        message['From'] = self.config['sender']
+    def _send_via_smtp(self, message):
+        msg = message.to_mime_message(self.default_recepient)
+        msg['From'] = self.config['sender']
 
         try:
             with smtplib.SMTP(self.config['smtp_url']) as server:
                 server.starttls()
                 server.login(self.config['login'], self.config['password'])
                 server.send_message(message)
-                logging.info(f"Email sent to {message['To']}: {message['Subject']}")
+                logger.info(
+                    f"Email sent to {message['To']}: {message['Subject']}")
         except smtplib.SMTPAuthenticationError:
-            logging.warning('The server didn\'t accept the user\\password combination.')
+            logger.warning(
+                'The server didn\'t accept the user\\password combination.')
         except smtplib.SMTPServerDisconnected:
-            logging.warning('Server unexpectedly disconnected')
+            logger.warning('Server unexpectedly disconnected')
         except smtplib.SMTPException as e:
-            logging.exception('SMTP error occurred: ' + str(e))
+            logger.exception('SMTP error occurred: ' + str(e))
+
+    def _send_via_email_sender(self, message):
+        msg = message.to_json(self.default_recepient)
+        succ = False
+        resp = None
+
+        for _ in range(3):
+            try:
+                resp = requests.post(self.config["email_sender_url"],
+                                     json=msg,
+                                     timeout=3)
+                if resp.status_code == 201:
+                    succ = True
+                    break
+            except requests.exceptions.Timeout:
+                time.sleep(1)
+            except Exception:
+                logger.exception("failed to post to email_sender, retry")
+                time.sleep(1)
+
+        if not succ:
+            logger.error(
+                "failed to post email to email_sender %s, code %s, resp %s. Drop email %s",
+                self.config["email_sender_url"],
+                None if resp is None else resp.status_code, resp, msg)
+
+    def send(self, message):
+        if self.config.get("email_sender_url") is not None:
+            self._send_via_email_sender(message)
+        elif self.config.get("smtp_url") is not None:
+            self._send_via_smtp(message)
+        else:
+            logger.warning("no email method configured, drop message %s",
+                           message.to_json(self.default_recepient))

--- a/src/RepairManager/utils/rule_alert_handler.py
+++ b/src/RepairManager/utils/rule_alert_handler.py
@@ -7,21 +7,17 @@ from utils import email_util
 
 
 class RuleAlertHandler():
-
     def __init__(self):
         self.email_handler = email_util.EmailHandler()
         self.config = self.load_config()
         self.rule_cache = self.load_rule_cache()
 
-
     def load_config(self):
         with open('/etc/RepairManager/config/rule-config.yaml', 'r') as file:
             return yaml.safe_load(file)
 
-
     def send_alert(self, message):
         self.email_handler.send(message)
-
 
     # check if a key exists in a specified rule dict
     def check_rule_cache(self, rule, cache_key):
@@ -30,7 +26,6 @@ class RuleAlertHandler():
                 return True
         return False
 
-
     # retrieve the value for a key in specified a rule dict
     def get_rule_cache(self, rule, cache_key):
         if rule in self.rule_cache:
@@ -38,12 +33,11 @@ class RuleAlertHandler():
                 return self.rule_cache[rule][cache_key]
         return None
 
-
     # add or update key/values for a specified rule dict
     def update_rule_cache(self, rule, cache_key, cache_value):
         if rule not in self.rule_cache:
             self.rule_cache[rule] = {}
-        
+
         self.rule_cache[rule][cache_key] = cache_value
 
         if 'rule_cache_dump' in self.config:
@@ -58,14 +52,12 @@ class RuleAlertHandler():
                 if 'rule_cache_dump' in self.config:
                     self.dump_rule_cache()
 
-
     # retrieve the entire key set for a specified rule dict
     def get_rule_cache_keys(self, rule):
         if rule in self.rule_cache:
             return list(self.rule_cache[rule].keys())
         else:
             return []
-
 
     # dump the entire rule cache into a file
     def dump_rule_cache(self):
@@ -83,5 +75,3 @@ class RuleAlertHandler():
                 with open(dump_file_path) as fh:
                     rule_cache = json.load(fh)
         return rule_cache
-
-


### PR DESCRIPTION
Use `EmailMessage` to represent email message internally, and convert needed format when actually sending, if configured `email_sender_url` will convert to json and send to email sender. If not will convert to `MIMEMultipart` and send via smtp.

Needs following config:
```
repair-manager:
  email_sender_url: http://localhost:9095/put_email
  default_recipients: abc@microsoft.com
```