### PR TITLE
Dashboard/frontend/fixes

### DIFF
--- a/src/dashboard/src/components/CaptionColumnTitle.tsx
+++ b/src/dashboard/src/components/CaptionColumnTitle.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import {
+  FunctionComponent
+} from 'react';
+
+import {
+  Box,
+  Typography
+} from '@material-ui/core';
+
+interface Props {
+  caption?: string;
+}
+
+const ColumnTitle: FunctionComponent<Props> = ({ caption, children }) => (
+  <Box>
+    {children && <Typography variant="inherit" component="p">{children}</Typography>}
+    {caption && <Typography variant="caption" component="p">{caption}</Typography>}
+  </Box>
+)
+
+export default ColumnTitle;

--- a/src/dashboard/src/hooks/useBatchActions.ts
+++ b/src/dashboard/src/hooks/useBatchActions.ts
@@ -3,7 +3,7 @@ import { useSnackbar } from 'notistack';
 import { Action } from 'material-table';
 
 import useConfirm from './useConfirm';
-import { Check, Pause, PlayArrow } from '@material-ui/icons';
+import { Check, Clear, Pause, PlayArrow } from '@material-ui/icons';
 
 const APPROVABLE_STATUSES = [
   'unapproved'
@@ -162,7 +162,7 @@ const useBatchActions = (clusterId: string) => {
     const hidden = !Array.isArray(jobs) || jobs.some(job => KILLABLE_STATUSES.indexOf(job['jobStatus']) === -1);
     return {
       hidden,
-      icon: () => createElement(Pause),
+      icon: () => createElement(Clear),
       tooltip: 'Kill',
       onClick: onBatchKill
     }

--- a/src/dashboard/src/pages/Cluster/Users.tsx
+++ b/src/dashboard/src/pages/Cluster/Users.tsx
@@ -23,6 +23,7 @@ import {
 } from 'material-table';
 
 import SvgIconsMaterialTable from '../../components/SvgIconsMaterialTable';
+import CaptionColumnTitle from '../../components/CaptionColumnTitle';
 import TeamContext from '../../contexts/Team';
 import usePrometheus from '../../hooks/usePrometheus';
 import useTableData from '../../hooks/useTableData';
@@ -123,37 +124,34 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
         </Tooltip>
       )
   }, {
-    title: 'CPU',
+    title: <CaptionColumnTitle caption="Used (Preemptable)">CPU</CaptionColumnTitle>,
     field: 'status.cpu.used',
-    tooltip: 'Used (Preemptable)',
     render: ({ status }) => status && (
       <>
         {get(status, ['cpu', 'used'], 0)}
-        {`(${get(status, ['cpu', 'preemptable'], 0)})`}
+        {` (${get(status, ['cpu', 'preemptable'], 0)})`}
       </>
     ),
     searchable: false,
     width: 'auto'
   } as Column<any>, {
-    title: 'GPU',
+    title: <CaptionColumnTitle caption="Used (Preemptable)">GPU</CaptionColumnTitle>,
     field: 'status.gpu.used',
-    tooltip: 'Used (Preemptable)',
     render: ({ status }) => status && (
       <>
         {get(status, ['gpu', 'used'], 0)}
-        {`(${get(status, ['gpu', 'preemptable'], 0)})`}
+        {` (${get(status, ['gpu', 'preemptable'], 0)})`}
       </>
     ),
     searchable: false,
     width: 'auto'
   } as Column<any>, {
-    title: 'Memory',
+    title: <CaptionColumnTitle caption="Used (Preemptable)">Memory</CaptionColumnTitle>,
     field: 'status.memory.used',
-    tooltip: 'Used (Preemptable)',
     render: ({ status }) => status && (
       <>
         {formatBytes(get(status, ['memory', 'used'], 0))}
-        {`(${formatBytes(get(status, ['memory', 'preemptable'], 0))})`}
+        {` (${formatBytes(get(status, ['memory', 'preemptable'], 0))})`}
       </>
     ),
     searchable: false,
@@ -169,19 +167,13 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
     ),
     width: 'auto'
   } as Column<any>, {
-    title: 'Booked GPU Last 30 days',
+    title: <CaptionColumnTitle caption="Last 30 days">Booked GPU</CaptionColumnTitle>,
     field: 'gpu.booked',
     type: 'numeric',
     render: (data) => <>{humanHours(get(data, 'gpu.booked'))}</>,
     width: 'auto'
   } as Column<any>, {
-    title: 'Idle GPU Last 30 days',
-    field: 'gpu.idle',
-    type: 'numeric',
-    render: (data) => <>{humanHours(get(data, 'gpu.idle'))}</>,
-    width: 'auto'
-  } as Column<any>, {
-    title: 'Idle GPU % Last 30 days',
+    title: <CaptionColumnTitle caption="Last 30 days">Idle GPU (%)</CaptionColumnTitle>,
     field: 'gpu.idle',
     type: 'numeric',
     render: (data) => {
@@ -190,15 +182,21 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
       const booked = get(data, 'gpu.booked', 0);
       const idle = get(data, 'gpu.idle', 0);
 
-      if (booked === 0) return <>N/A</>;
+      if (booked === 0) return <>{humanHours(idle)}</>;
 
-      const ratio = idle / booked;
-      const percent = formatPercent(ratio, 1)
-      if (ratio > .5) {
-        return <Typography variant="inherit" color="error">{percent}</Typography>
+      const percent = (idle / booked) * 100;
+      if (percent > 50) {
+        return (
+          <>
+            {humanHours(idle)}
+            {" ("}
+            <Typography variant="inherit" color="error">{formatPercent(percent, 1)}%</Typography>
+            )
+          </>
+        );
       }
 
-      return <>{percent}</>;
+      return <>{humanHours(idle)}{" ("}{formatPercent(percent, 1)}%)</>;
     },
     width: 'auto'
   } as Column<any>]).current;

--- a/src/dashboard/src/pages/Clusters/useResourceColumns.tsx
+++ b/src/dashboard/src/pages/Clusters/useResourceColumns.tsx
@@ -10,6 +10,7 @@ import { More } from '@material-ui/icons';
 import { Column } from 'material-table';
 import { capitalize, get } from 'lodash';
 
+import CaptionColumnTitle from '../../components/CaptionColumnTitle';
 import { formatBytes, formatFloat } from '../../utils/formats';
 
 export type ResourceType = 'cpu' | 'gpu' | 'memory';
@@ -40,12 +41,14 @@ const useResourceColumns = (kinds: ResourceKind[]) => {
           <TableSortLabel
             active
             IconComponent={More}
+            direction="desc"
             onClick={() => setExpandedResourceType(type)}
           >
-            {title}
+            <CaptionColumnTitle caption="Used/Total">
+              {title}
+            </CaptionColumnTitle>
           </TableSortLabel>
         ),
-        tooltip: 'Expand',
         hidden: !expandable || expandedResourceType === type,
         headerStyle: { whiteSpace: 'nowrap', ...style },
         cellStyle: { whiteSpace: 'nowrap', ...style },
@@ -58,13 +61,15 @@ const useResourceColumns = (kinds: ResourceKind[]) => {
         ),
         sorting: false,
         searchable: false,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore: https://github.com/mbrn/material-table/pull/1659
         width: 'auto'
-      });
+      } as Column<any>);
       for (const kind of kinds) {
         columns.push({
-          title: `${title} ${capitalize(kind)}`,
+          title: (
+            <CaptionColumnTitle caption={capitalize(kind)}>
+              {title}
+            </CaptionColumnTitle>
+          ),
           type: 'numeric',
           field: `status.${type}.${kind}`,
           hidden: expandable && expandedResourceType !== type,
@@ -73,10 +78,8 @@ const useResourceColumns = (kinds: ResourceKind[]) => {
           ),
           headerStyle: style,
           cellStyle: style,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-          // @ts-ignore: https://github.com/mbrn/material-table/pull/1659
           width: 'auto'
-        });
+        } as Column<any>);
       }
     }
     return columns;


### PR DESCRIPTION
Refine table headers in cluster page

![image](https://user-images.githubusercontent.com/2500247/82019750-5ad1be00-96ba-11ea-9d31-da59b701a69e.png)
![image](https://user-images.githubusercontent.com/2500247/82019765-61f8cc00-96ba-11ea-9987-08756139e036.png)

It hangs the browser when using tooltip component, by Popper. Drop it and will have further investigation.