### PR TITLE
Fix task net double counting in Grafana dashboard job-status

### DIFF
--- a/src/ClusterBootstrap/services/monitor/grafana-config-raw/job-status-dashboard.json
+++ b/src/ClusterBootstrap/services/monitor/grafana-config-raw/job-status-dashboard.json
@@ -47,7 +47,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1588910468210,
+  "iteration": 1589870609184,
   "links": [],
   "panels": [
     {
@@ -570,7 +570,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(task_net_in_byte{job_name=\"$job_name\"}[5m])) by (instance)",
+          "expr": "sum(rate(task_net_in_byte{job_name=\"$job_name\", role_name=~\"master|worker\"}[5m])) by (instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -578,7 +578,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(task_net_out_byte{job_name=\"$job_name\"}[5m])) by (instance)",
+          "expr": "sum(rate(task_net_out_byte{job_name=\"$job_name\", role_name=~\"master|worker\"}[5m])) by (instance)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} Outbound",
@@ -965,5 +965,5 @@
   "timezone": "browser",
   "title": "Job Status",
   "uid": "job-status",
-  "version": 2
+  "version": 1
 }


### PR DESCRIPTION
For a distributed job, ps is collocated with one of the workers. Since we use host machine network stats for distributed jobs, both ps and worker on the same machine will show the host machine's net traffic.
![image](https://user-images.githubusercontent.com/5781796/82294563-33514e80-9963-11ea-9f98-80bece4f8d23.png)

With this PR:
![image](https://user-images.githubusercontent.com/5781796/82294636-4bc16900-9963-11ea-965e-43fa5f814857.png)
