### PR TITLE
Restrict system envs to distributed jobs

### DIFF
--- a/src/ClusterBootstrap/deploy.py
+++ b/src/ClusterBootstrap/deploy.py
@@ -2938,7 +2938,7 @@ def map_old_config_to_cloud(nargs):
         use general config settings in example_dir
     """
     old_Keys_in_use = ["default_cpurequest", "default_cpulimit", "default_memoryrequest",
-        "grafana", "system_envs", "default_memorylimit"]
+        "grafana", "distributed_system_envs", "default_memorylimit"]
     old_keys_with_default = ["WebUIregisterGroups", "network", "elasticsearch", "Dashboards",
                              "DeployAuthentications", "WebUIauthorizedGroups", "webuiport",
                              "WebUIadminGroups", "infiniband_mounts"]

--- a/src/ClusterBootstrap/template/RestfulAPI/config.yaml
+++ b/src/ClusterBootstrap/template/RestfulAPI/config.yaml
@@ -65,8 +65,8 @@ local_fast_storage: {{cnf["local_fast_storage"]}}
 infiniband_mounts: {{cnf["infiniband_mounts"]}}
 vc_without_shared_storage: {{cnf["vc_without_shared_storage"]}}
 
-# Environment variables
-system_envs: {{cnf["system_envs"]}}
+# Environment variables for distributed jobs
+distributed_system_envs: {{cnf["distributed_system_envs"]}}
 
 enable_custom_registry_secrets: {{cnf["enable_custom_registry_secrets"]}}
 master_token: {{cnf["master_token"]}}

--- a/src/ClusterManager/job.py
+++ b/src/ClusterManager/job.py
@@ -270,11 +270,13 @@ class Job:
     def get_enable_custom_registry_secrets(self):
         return self._get_cluster_config("enable_custom_registry_secrets")
 
-    def get_system_envs(self):
-        system_envs = self._get_cluster_config("system_envs")
-        if system_envs is None or not isinstance(system_envs, dict):
-            system_envs = {}
-        return system_envs
+    def get_distributed_system_envs(self):
+        distributed_system_envs = \
+            self._get_cluster_config("distributed_system_envs")
+        if distributed_system_envs is None or \
+                not isinstance(distributed_system_envs, dict):
+            distributed_system_envs = {}
+        return distributed_system_envs
 
     def get_vc_node_hard_assignment(self):
         return self._get_cluster_config("vc_node_hard_assignment")

--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -106,14 +106,6 @@ class JobTemplate(object):
         # TODO: Make mountpoints independent of job.get_plugins
         params["mountpoints"] = [mp.to_dict() for mp in job.mountpoints]
 
-        # Set up system environment variables if any
-        system_envs = job.get_system_envs()
-        for env_name, env_val in system_envs.items():
-            params["envs"].append({
-                "name": env_name,
-                "value": env_val
-            })
-
         return params, None
 
     def generate_secrets(self, job):
@@ -353,5 +345,13 @@ class DistributeJobTemplate(JobTemplate):
             "name": "DLWS_WORKER_NUM",
             "value": str(params["numworker"])
         })
+
+        # Set up system environment variables if any
+        distributed_system_envs = job.get_distributed_system_envs()
+        for env_name, env_val in distributed_system_envs.items():
+            params["envs"].append({
+                "name": env_name,
+                "value": env_val
+            })
 
         return params, None

--- a/src/ClusterManager/test/test_distributed_job.py
+++ b/src/ClusterManager/test/test_distributed_job.py
@@ -596,7 +596,7 @@ def test_distributed_job_mountpoints(args):
 
 @utils.case()
 def test_distributed_job_system_envs(args):
-    envs = utils.load_system_envs(args)
+    envs = utils.load_distributed_system_envs(args)
 
     job_spec = utils.gen_default_job_description("distributed",
                                                  args.email,

--- a/src/ClusterManager/test/utils.py
+++ b/src/ClusterManager/test/utils.py
@@ -235,12 +235,13 @@ def load_infiniband_mounts(args):
     } for mp in mps]
 
 
-def load_system_envs(args):
+def load_distributed_system_envs(args):
     config = get_config(args.config)
-    system_envs = walk_json_safe(config, "system_envs")
-    if system_envs is None or not isinstance(system_envs, dict):
-        system_envs = {}
-    return system_envs
+    distributed_system_envs = walk_json_safe(config, "distributed_system_envs")
+    if distributed_system_envs is None or \
+            not isinstance(distributed_system_envs, dict):
+        distributed_system_envs = {}
+    return distributed_system_envs
 
 
 def mountpoint_in_volumes(mp, volumes):


### PR DESCRIPTION
Having environment variables `NCCL_IB_DISABLE=0 NCCL_SOCKET_IFNAME=ib0` in a regular job will cause NCCL to crash. This PR restricts populating system envs to only distributed jobs.

```
2020-05-19 21:30:21,177: INFO - utils.py:63@50067: spent 0:00:34.578380 in executing test case test_distributed_job.test_distributed_job_system_envs
2020-05-19 21:30:21,181: INFO - main.py:88@49952: spent 0:00:34.590200 in executing 2 cases ['test_distributed_job.test_distributed_job_system_envs', 'test_regular_job.test_regular_job_no_distributed_system_envs']
2020-05-19 21:30:21,182: INFO - main.py:90@49952: 0 failed
2020-05-19 21:30:21,182: INFO - main.py:91@49952: 0 unfinished
```