### PR TITLE
Add GetJobRawLog API

### DIFF
--- a/src/ClusterManager/test/utils.py
+++ b/src/ClusterManager/test/utils.py
@@ -536,30 +536,16 @@ def block_until_state_in(rest_url, jid, states, timeout=300):
 
 
 def get_job_log(rest_url, email, jid):
-    cursor = None
-    job_logs = []
-    for _ in range(500): # avoid dead loop
-        args = {
-            "userName": email,
-            "jobId": jid,
-        }
-        if cursor is not None:
-            args['cursor'] = cursor
-        args = urllib.parse.urlencode(args)
-        url = urllib.parse.urljoin(rest_url, "/GetJobLog") + "?" + args
-        resp = requests.get(url)
-        if resp.status_code == 404:
-            break
-        resp_json = resp.json()
-        log = resp_json["log"]
-        cursor = resp_json["cursor"]
-        if isinstance(log, dict):
-            job_logs.extend(log.values())
-        else:
-            job_logs.append(log)
-        if cursor is None:
-            break
-    return '\n'.join(job_logs)
+    args = {
+        "userName": email,
+        "jobId": jid,
+    }
+    args = urllib.parse.urlencode(args)
+    url = urllib.parse.urljoin(rest_url, "/GetJobRawLog") + "?" + args
+    resp = requests.get(url)
+    if resp.status_code == 404:
+        return None
+    return resp.text
 
 
 def get_endpoints(rest_url, email, jid):

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -488,6 +488,21 @@ class GetJobLog(Resource):
         return JobRestAPIUtils.GetJobLog(userName, jobId, cursor)
 
 
+@app.route("/GetJobRawLog")
+def GetJobRawLog():
+    get_parser = reqparse.RequestParser()
+    get_parser.add_argument("jobId", required=True)
+    get_parser.add_argument("userName", required=True)
+    args = get_parser.parse_args()
+    jobId = args["jobId"]
+    userName = args["userName"]
+    response = JobRestAPIUtils.GetJobRawLog(userName, jobId)
+    if type(response) is int:
+        return Response(status=response, content_type="text/plain")
+    else:
+        return Response(response, content_type="text/plain")
+
+
 @api.resource("/GetJobStatus")
 class GetJobStatus(Resource):
     def __init__(self):

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -125,10 +125,10 @@ if config.get("logging") == 'azure_blob':
                         buffer += blob.content
                         start_range = end_range + 1
 
-                        while True:
+                        while len(buffer) > 0:
                             try:
                                 [head, buffer] = buffer.split(b'\n', 1)
-                            except ValueError:
+                            except ValueError:  # no '\n' in buffer so no enough items in returned list.
                                 break
 
                             try:

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -115,10 +115,11 @@ if config.get("logging") == 'azure_blob':
                 try:
                     buffer = b''
                     start_range = 0
-                    while start_range < blob.properties.content_length:
+                    content_length = blob.properties.content_length
+                    while start_range < content_length:
                         end_range = min(
                             start_range + CHUNK_SIZE - 1,
-                            blob.properties.content_length - 1)
+                            content_length - 1)
                         blob = append_blob_service.get_blob_to_bytes(
                             container_name, blob.name,
                             start_range=start_range,

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -102,13 +102,14 @@ if config.get("logging") == 'azure_blob':
         try:
             prefix = 'jobs.' + jobId
 
-            blobs = list(append_blob_service.list_blobs(container_name, prefix))
+            blobs = append_blob_service.list_blobs(container_name, prefix)
+            blobs = list(blobs)
 
             if len(blobs) == 0:
                 return None
                 yield
 
-            blobs = sorted(blobs, key=lambda blob: blob.properties.last_modified)
+            blobs = sorted(blobs, key=_get_blob_index)
 
             for blob in blobs:
                 try:
@@ -116,7 +117,7 @@ if config.get("logging") == 'azure_blob':
                     start_range = 0
                     while start_range < blob.properties.content_length:
                         end_range = min(
-                            start_range + CHUNK_SIZE,
+                            start_range + CHUNK_SIZE - 1,
                             blob.properties.content_length - 1)
                         blob = append_blob_service.get_blob_to_bytes(
                             container_name, blob.name,

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -30,7 +30,7 @@ sys.path.append(
                  "../ClusterManager"))
 
 from job_params_util import make_job_params
-from JobLogUtils import GetJobLog as UtilsGetJobLog
+import JobLogUtils
 from resource_stat import Gpu
 
 DEFAULT_JOB_PRIORITY = 100
@@ -740,7 +740,7 @@ def GetJobLog(userName, jobId, cursor=None, size=100):
                 except:
                     pass
             elif _get_job_log_enabled:
-                (pod_logs, cursor) = UtilsGetJobLog(jobId, cursor, size)
+                (pod_logs, cursor) = JobLogUtils.GetJobLog(jobId, cursor, size)
 
                 if _get_job_log_fallback:
                     if pod_logs is None or len(pod_logs.keys()) == 0:
@@ -773,6 +773,20 @@ def GetJobLog(userName, jobId, cursor=None, size=100):
         "log": {},
         "cursor": None,
     }
+
+
+def GetJobRawLog(userName, jobId):
+    dataHandler = DataHandler()
+    jobs = dataHandler.GetJob(jobId=jobId)
+    if len(jobs) == 1:
+        if jobs[0]["userName"] == userName or AuthorizationManager.HasAccess(
+                userName, ResourceType.VC, jobs[0]["vcName"],
+                Permission.Collaborator):
+            return JobLogUtils.GetJobRawLog(jobId)
+        else:
+            return 403
+    else:
+        return 404
 
 
 def GetClusterStatus():

--- a/src/utils/test_job_log_utils.py
+++ b/src/utils/test_job_log_utils.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from textwrap import dedent
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from azure.storage.blob import AppendBlobService, Blob
 
@@ -28,6 +28,11 @@ class TestAzureBlob(TestCase):
             blob.content = content
         for (key, value) in kwargs.items():
             setattr(blob.properties, key, value)
+        return blob
+
+    @staticmethod
+    def fill_blob(blob, content):
+        blob = Blob(blob.name, content=content, props=blob.properties)
         return blob
 
     @patch.object(AppendBlobService, 'get_blob_to_bytes')
@@ -83,3 +88,100 @@ class TestAzureBlob(TestCase):
                                              blob_name='jobs.' + self.JOB_ID +
                                              '.1',
                                              start_range=1024 * 1024)
+
+    @patch.object(AppendBlobService, 'get_blob_to_bytes')
+    @patch.object(AppendBlobService, 'list_blobs')
+    def test_get_job_raw_log(self, list_blobs, get_blob_to_bytes):
+        from JobLogUtils import GetJobRawLog
+
+        blobs = [
+            self.create_blob('jobs.{}'.format(self.JOB_ID),
+                             last_modified=datetime.min,
+                             content_length=int(4e6)),
+            self.create_blob('jobs.{}.2'.format(self.JOB_ID),
+                             last_modified=datetime.min,
+                             content_length=int(3e6)),
+            self.create_blob('jobs.{}.1'.format(self.JOB_ID),
+                             last_modified=datetime.min,
+                             content_length=int(2e6)),
+        ]
+        list_blobs.return_value = iter(blobs)
+
+        contents = [
+            r'''
+            {"log":''', r'''"content 1\n"}
+            {"log":"content ''', r'''2\n"}
+            {"log":"c''', r'''ontent 3\n"}
+            ''', r'''{"log":"content 4\n"}
+            {"log":"content 5''', r'''\n"}
+            ''', r'''{"log":"content 6\n"}
+            {"log":"content 7\n"''', r'''}
+            {"log":"content 8''', r'''\n"}
+            {"log":"content 9\n"}
+            '''
+        ]
+        get_blob_to_bytes.side_effect = [
+            self.fill_blob(blobs[0], contents[0].encode('utf-8')),
+            self.fill_blob(blobs[0], contents[1].encode('utf-8')),
+            self.fill_blob(blobs[0], contents[2].encode('utf-8')),
+            self.fill_blob(blobs[0], contents[3].encode('utf-8')),
+            self.fill_blob(blobs[2], contents[4].encode('utf-8')),
+            self.fill_blob(blobs[2], contents[5].encode('utf-8')),
+            self.fill_blob(blobs[1], contents[6].encode('utf-8')),
+            self.fill_blob(blobs[1], contents[7].encode('utf-8')),
+            self.fill_blob(blobs[1], contents[8].encode('utf-8')),
+        ]
+
+        logs = GetJobRawLog(self.JOB_ID)
+        self.assertListEqual(list(logs), [
+            'content 1\n',
+            'content 2\n',
+            'content 3\n',
+            'content 4\n',
+            'content 5\n',
+            'content 6\n',
+            'content 7\n',
+            'content 8\n',
+            'content 9\n',
+        ])
+
+        list_blobs.assert_called_once_with(_CONTAINER_NAME,
+                                           'jobs.' + self.JOB_ID)
+        get_blob_to_bytes.assert_has_calls([
+            call(_CONTAINER_NAME,
+                 'jobs.d175',
+                 start_range=0,
+                 end_range=1024 * 1024 * 1 - 1),
+            call(_CONTAINER_NAME,
+                 'jobs.d175',
+                 start_range=1024 * 1024 * 1,
+                 end_range=1024 * 1024 * 2 - 1),
+            call(_CONTAINER_NAME,
+                 'jobs.d175',
+                 start_range=1024 * 1024 * 2,
+                 end_range=1024 * 1024 * 3 - 1),
+            call(_CONTAINER_NAME,
+                 'jobs.d175',
+                 start_range=1024 * 1024 * 3,
+                 end_range=int(4e6) - 1),
+            call(_CONTAINER_NAME,
+                 'jobs.d175.1',
+                 start_range=0,
+                 end_range=1024 * 1024 * 1 - 1),
+            call(_CONTAINER_NAME,
+                 'jobs.d175.1',
+                 start_range=1024 * 1024 * 1,
+                 end_range=int(2e6) - 1),
+            call(_CONTAINER_NAME,
+                 'jobs.d175.2',
+                 start_range=0,
+                 end_range=1024 * 1024 * 1 - 1),
+            call(_CONTAINER_NAME,
+                 'jobs.d175.2',
+                 start_range=1024 * 1024 * 1,
+                 end_range=1024 * 1024 * 2 - 1),
+            call(_CONTAINER_NAME,
+                 'jobs.d175.2',
+                 start_range=1024 * 1024 * 2,
+                 end_range=int(3e6) - 1),
+        ])


### PR DESCRIPTION
Need to match #1133 when it is merged

Response is successfully chunked per line, to validate

```
$ curl -v http://domain:5001/GetJobRawLog\?jobId\=id\&userName\=user@domain --raw
*   Trying ip...
* TCP_NODELAY set
* Connected to domain () port 5001 (#0)
> GET /GetJobRawLog?jobId=id&userName=user@domain HTTP/1.1
> Host: domain:5001
> User-Agent: curl/7.52.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Thu, 21 May 2020 09:10:59 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Vary: Accept-Encoding
< Transfer-Encoding: chunked
< Content-Type: text/plain
<
4c
+ DLTS_RUNTIME_DIR=/dlts-runtime
+ cp -r /dlts-init/ssh_build /dlts-runtime

53
+ cp -r /dlts-init/ssh_config /dlts-runtime
+ cp /dlts-init/gpu_topo /dlts-runtime

2c
+ cp -r /dlts-init/install.sh /dlts-runtime

29
+ cp -r /dlts-init/runtime /dlts-runtime

25
+ python3 /dlts-init/runtime/sync.py

49
2020-05-15 00:56:50,123 - INFO - sync.py:187 - do not need to sync, skip

2f
+ chmod +x /dlts-runtime/status/job_command.sh

4a
+ runuser -s /bin/bash -l qixcheng -c /dlts-runtime/status/job_command.sh

0

* Curl_http_done: called premature == 0
* Connection #0 to host domain left intact
```