### PR TITLE
tolerate pressures in job-manager

### DIFF
--- a/src/ClusterBootstrap/services/jobmanager/jobmanager.yaml
+++ b/src/ClusterBootstrap/services/jobmanager/jobmanager.yaml
@@ -140,4 +140,10 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - key: node-role.kubernetes.io/master
-        effect: NoSchedule           
+        effect: NoSchedule
+      - key: node.kubernetes.io/memory-pressure
+        operator: "Exists"
+      - key: node.kubernetes.io/disk-pressure
+        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        operator: "Exists"


### PR DESCRIPTION
`  Warning  Evicted    <invalid>  kubelet  The node had condition: [DiskPressure].`