### PR TITLE
Logging: fix incorrect time-based blob ordering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
     before_install:
       - cd src/utils
     install:
-      - pip install azure===4.0.0
+      - pip install -r ../ClusterManager/requirements.txt
     script:
       - python -m unittest discover .
   - language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
       - python -m unittest test_virtual_cluster_status.py
       - python -m unittest test_mountpoint.py
       - python -m unittest test_job_manager.py
+      - python -m unittest test_job_log_utils.py
   - language: python
     python: 3.6
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ matrix:
     python: 3.6
     before_install:
       - cd src/utils
+    install:
+      - pip install azure===4.0.0
     script:
       - python -m unittest discover .
   - language: python
@@ -52,7 +54,6 @@ matrix:
       - python -m unittest test_virtual_cluster_status.py
       - python -m unittest test_mountpoint.py
       - python -m unittest test_job_manager.py
-      - python -m unittest test_job_log_utils.py
   - language: python
     python: 3.6
     before_install:

--- a/src/docker-images/azure-blob-adapter/wsgi.py
+++ b/src/docker-images/azure-blob-adapter/wsgi.py
@@ -51,7 +51,7 @@ def application(request):
 
             blob_name = tag
 
-            while True:
+            for _ in range(10):
                 try:
                     append_blob_service.append_blob_from_bytes(
                         container_name=container_name,

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -29,6 +29,12 @@ if config.get("logging") == 'azure_blob':
 
     CHUNK_SIZE = 1024 * 1024  # Assume each line in log is no more then 1MB
 
+    def _get_blob_index(blob):
+        try:
+            return int(blob.name.split('.', 2)[2])
+        except (IndexError, ValueError):
+            return 0
+
     def GetJobLog(jobId, cursor=None, size=None):
         try:
             prefix = 'jobs.' + jobId
@@ -44,7 +50,7 @@ if config.get("logging") == 'azure_blob':
                 if len(blobs) == 0:
                     return ({}, None)
 
-                blob = max(blobs, key=lambda blob: blob.properties.last_modified)
+                blob = max(blobs, key=_get_blob_index)
                 start_range = max(0, blob.properties.content_length - CHUNK_SIZE)
                 chunk = append_blob_service.get_blob_to_bytes(
                     container_name=container_name,

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -29,12 +29,6 @@ if config.get("logging") == 'azure_blob':
 
     CHUNK_SIZE = 1024 * 1024  # Assume each line in log is no more then 1MB
 
-    def _get_blob_index(blob):
-        try:
-            return int(blob.name.split('.', 2)[2])
-        except (IndexError, ValueError):
-            return 0
-
     def GetJobLog(jobId, cursor=None, size=None):
         try:
             prefix = 'jobs.' + jobId
@@ -50,7 +44,7 @@ if config.get("logging") == 'azure_blob':
                 if len(blobs) == 0:
                     return ({}, None)
 
-                blob = max(blobs, key=_get_blob_index)
+                blob = max(blobs, key=lambda blob: blob.properties.last_modified)
                 start_range = max(0, blob.properties.content_length - CHUNK_SIZE)
                 chunk = append_blob_service.get_blob_to_bytes(
                     container_name=container_name,

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -29,6 +29,12 @@ if config.get("logging") == 'azure_blob':
 
     CHUNK_SIZE = 1024 * 1024  # Assume each line in log is no more then 1MB
 
+    def _get_blob_index(blob_name):
+        try:
+            return int(blob_name.split('.', 2)[2])
+        except (IndexError, ValueError):
+            return 0
+
     def GetJobLog(jobId, cursor=None, size=None):
         try:
             prefix = 'jobs.' + jobId
@@ -44,7 +50,7 @@ if config.get("logging") == 'azure_blob':
                 if len(blobs) == 0:
                     return ({}, None)
 
-                blob = max(blobs, key=lambda blob: blob.properties.last_modified)
+                blob = max(blobs, key=_get_blob_index)
                 start_range = max(0, blob.properties.content_length - CHUNK_SIZE)
                 chunk = append_blob_service.get_blob_to_bytes(
                     container_name=container_name,

--- a/src/utils/JobLogUtils.py
+++ b/src/utils/JobLogUtils.py
@@ -29,9 +29,9 @@ if config.get("logging") == 'azure_blob':
 
     CHUNK_SIZE = 1024 * 1024  # Assume each line in log is no more then 1MB
 
-    def _get_blob_index(blob_name):
+    def _get_blob_index(blob):
         try:
-            return int(blob_name.split('.', 2)[2])
+            return int(blob.name.split('.', 2)[2])
         except (IndexError, ValueError):
             return 0
 

--- a/src/utils/test_job_log_utils.py
+++ b/src/utils/test_job_log_utils.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+from textwrap import dedent
+from unittest import TestCase
+from unittest.mock import patch
+
+from azure.storage.blob import AppendBlobService, Blob
+
+from config import config
+
+_CONTAINER_NAME = 'mycontainer'
+
+
+@patch.dict(
+    config, {
+        'logging': 'azure_blob',
+        'azure_blob_log': {
+            'connection_string': 'UseDevelopmentStorage=true',
+            'container_name': _CONTAINER_NAME,
+        },
+    })
+class TestAzureBlob(TestCase):
+    JOB_ID = 'd175'
+
+    @staticmethod
+    def create_blob(name, content=None, **kwargs):
+        blob = Blob(name)
+        if content is not None:
+            blob.content = content
+        for (key, value) in kwargs.items():
+            setattr(blob.properties, key, value)
+        return blob
+
+    @patch.object(AppendBlobService, 'get_blob_to_bytes')
+    @patch.object(AppendBlobService, 'list_blobs')
+    def test_get_job_log(self, list_blobs, get_blob_to_bytes):
+        from JobLogUtils import GetJobLog
+
+        list_blobs.return_value = iter([
+            self.create_blob('jobs.' + self.JOB_ID,
+                             last_modified=datetime.min,
+                             content_length=1024 * 1024 * 2),
+        ])
+        get_blob_to_bytes.return_value = \
+            self.create_blob('jobs.' + self.JOB_ID, dedent(r'''}}}}
+            {"kubernetes":{"pod_name":"master"},"time":0,"log":"content\n"}
+            {{{{''').encode(encoding='utf-8'))
+
+        logs, cursor = GetJobLog(self.JOB_ID)
+        self.assertDictEqual(logs, {'master': "content\n"})
+        self.assertIsNone(cursor)
+
+        list_blobs.assert_called_once_with(container_name=_CONTAINER_NAME,
+                                           prefix='jobs.' + self.JOB_ID)
+        get_blob_to_bytes.assert_called_with(container_name=_CONTAINER_NAME,
+                                             blob_name='jobs.' + self.JOB_ID,
+                                             start_range=1024 * 1024)
+
+    @patch.object(AppendBlobService, 'get_blob_to_bytes')
+    @patch.object(AppendBlobService, 'list_blobs')
+    def test_get_job_log_with_multi_blobs(self, list_blobs, get_blob_to_bytes):
+        from JobLogUtils import GetJobLog
+
+        list_blobs.return_value = iter([
+            self.create_blob('jobs.' + self.JOB_ID,
+                             last_modified=datetime.min,
+                             content_length=1024 * 1024 * 2),
+            self.create_blob('jobs.' + self.JOB_ID + '.1',
+                             last_modified=datetime.min,
+                             content_length=1024 * 1024 * 2),
+        ])
+        get_blob_to_bytes.return_value = \
+            self.create_blob('jobs.' + self.JOB_ID, dedent(r'''}}}}
+            {"kubernetes":{"pod_name":"master"},"time":0,"log":"content\n"}
+            {{{{''').encode(encoding='utf-8'))
+
+        logs, cursor = GetJobLog(self.JOB_ID)
+        self.assertDictEqual(logs, {'master': "content\n"})
+        self.assertIsNone(cursor)
+
+        list_blobs.assert_called_once_with(container_name=_CONTAINER_NAME,
+                                           prefix='jobs.' + self.JOB_ID)
+        get_blob_to_bytes.assert_called_with(container_name=_CONTAINER_NAME,
+                                             blob_name='jobs.' + self.JOB_ID +
+                                             '.1',
+                                             start_range=1024 * 1024)


### PR DESCRIPTION
Since the `last_modified` field of blob is in seconds, it's found that the previous blob has the same last_modified as the next one. That makes the sort useless.