### PR TITLE
remove cleaning old job code

### DIFF
--- a/src/ClusterManager/db_manager.py
+++ b/src/ClusterManager/db_manager.py
@@ -8,7 +8,6 @@ import sys
 import time
 import yaml
 
-
 from cluster_manager import setup_exporter_thread, \
     manager_iteration_histogram, \
     register_stack_trace_dump, \
@@ -55,33 +54,42 @@ def delete_old_cluster_status(days_ago):
 def delete_old_inactive_jobs(days_ago):
     table = "jobs"
     with DataHandler() as data_handler:
-        logger.info("Deleting inactive job records from table %s older than %s "
-                    "day(s)", table, days_ago)
+        logger.info(
+            "Deleting inactive job records from table %s older than %s "
+            "day(s)", table, days_ago)
 
-        cond = {
-            "jobStatus": ("IN", ["finished", "failed", "killed", "error"])
-        }
+        cond = {"jobStatus": ("IN", ["finished", "failed", "killed", "error"])}
         ret = data_handler.delete_rows_from_table_older_than_days(
             table, days_ago, col="lastUpdated", cond=cond)
         ret_status = "succeeded" if ret is True else "failed"
-        logger.info("Deleting inactive job records from table %s older than %s "
-                    "day(s) %s", table, days_ago, ret_status)
+        logger.info(
+            "Deleting inactive job records from table %s older than %s "
+            "day(s) %s", table, days_ago, ret_status)
+
+
+def sleep_with_update(time_to_sleep, fn):
+    for _ in range(int(time_to_sleep / 100)):
+        fn()
+        time.sleep(100)
 
 
 def run():
     register_stack_trace_dump()
     create_log()
+
+    update = lambda: update_file_modification_time("db_manager")
     while True:
-        update_file_modification_time("db_manager")
+        update()
 
         with manager_iteration_histogram.labels("db_manager").time():
             try:
                 delete_old_cluster_status(CLUSTER_STATUS_EXPIRY)
-                delete_old_inactive_jobs(JOBS_EXPIRY)
+                # query below is too time consuming since lastUpdated in job table is not indexed
+                # delete_old_inactive_jobs(JOBS_EXPIRY)
             except:
-                logger.exception("Deleting old cluster status failed",
-                                 exc_info=True)
-        time.sleep(86400)
+                logger.exception("Deleting old cluster status failed")
+
+        sleep_with_update(86400, update)
 
 
 if __name__ == '__main__':

--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -292,7 +292,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('AddStorage Exception: %s', str(e))
+            logger.exception('AddStorage Exception: %s', str(e))
             return False
 
     @record
@@ -306,7 +306,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('DeleteStorage Exception: %s', str(e))
+            logger.exception('DeleteStorage Exception: %s', str(e))
             return False
 
     @record
@@ -327,7 +327,7 @@ class DataHandler(object):
                 record["defaultMountPath"] = defaultMountPath
                 ret.append(record)
         except Exception as e:
-            logger.error('ListStorages Exception: %s', str(e))
+            logger.exception('ListStorages Exception: %s', str(e))
             pass
         self.conn.commit()
         cursor.close()
@@ -346,7 +346,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             return False
 
     def init_vc_sqls(self, config):
@@ -374,7 +374,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('AddVC Exception: %s', str(e))
+            logger.exception('AddVC Exception: %s', str(e))
             return False
 
     @record
@@ -394,7 +394,7 @@ class DataHandler(object):
                 }
                 ret.append(rec)
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             pass
         self.conn.commit()
         cursor.close()
@@ -411,7 +411,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('DeleteVC Exception: %s', str(e))
+            logger.exception('DeleteVC Exception: %s', str(e))
             return False
 
     @record
@@ -425,7 +425,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             return False
 
     @record
@@ -502,7 +502,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('UpdateAce Exception: %s', str(e))
+            logger.exception('UpdateAce Exception: %s', str(e))
             return False
 
     @record
@@ -517,7 +517,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             return False
 
     @record
@@ -533,7 +533,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             return False
 
     @record
@@ -549,7 +549,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('DeleteAce Exception: %s', str(e))
+            logger.exception('DeleteAce Exception: %s', str(e))
             return False
 
     @record
@@ -570,7 +570,7 @@ class DataHandler(object):
                 record["isDeny"] = isDeny
                 ret.append(record)
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             pass
         self.conn.commit()
         cursor.close()
@@ -594,7 +594,7 @@ class DataHandler(object):
                 record["isDeny"] = isDeny
                 ret.append(record)
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
         self.conn.commit()
         cursor.close()
         return ret
@@ -613,7 +613,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             return False
 
     @record
@@ -674,7 +674,7 @@ class DataHandler(object):
                 record["lastUpdated"] = lastUpdated
                 ret.append(record)
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
         self.conn.commit()
         cursor.close()
         return ret
@@ -745,7 +745,7 @@ class DataHandler(object):
                     ret["finishedJobs"].append(record)
             self.conn.commit()
         except Exception as e:
-            logger.error('GetJobListV2 Exception: %s', str(e))
+            logger.exception('GetJobListV2 Exception: %s', str(e))
         finally:
             if cursor is not None:
                 cursor.close()
@@ -858,9 +858,9 @@ class DataHandler(object):
 
             self.conn.commit()
         except:
-            logger.error("Exception in getting union job list. status %s",
-                         status,
-                         exc_info=True)
+            logger.exception("Exception in getting union job list. status %s",
+                             status,
+                             exc_info=True)
         finally:
             if cursor is not None:
                 cursor.close()
@@ -1033,7 +1033,7 @@ class DataHandler(object):
                 record["jobStatus"] = jobStatus
                 ret.append(record)
         except Exception as e:
-            logger.error('GetActiveJobList Exception: %s', str(e))
+            logger.exception('GetActiveJobList Exception: %s', str(e))
         self.conn.commit()
         cursor.close()
         return ret
@@ -1086,7 +1086,7 @@ class DataHandler(object):
                 ret.append(record)
             self.conn.commit()
         except Exception as e:
-            logger.error('GetJobV2 Exception: %s', str(e))
+            logger.exception('GetJobV2 Exception: %s', str(e))
         finally:
             if cursor is not None:
                 cursor.close()
@@ -1295,7 +1295,7 @@ class DataHandler(object):
             for (jobId, value) in cursor:
                 ret = value
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             pass
         self.conn.commit()
         cursor.close()
@@ -1321,7 +1321,7 @@ class DataHandler(object):
                 ret = dict(list(zip(columns, item)))
             self.conn.commit()
         except Exception as e:
-            logger.error('GetJobTextFields Exception: %s', str(e))
+            logger.exception('GetJobTextFields Exception: %s', str(e))
         finally:
             if cursor is not None:
                 cursor.close()
@@ -1362,7 +1362,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             return False
 
     @record
@@ -1378,7 +1378,7 @@ class DataHandler(object):
                 ret = json.loads(base64decode(value))
                 time = t
         except Exception as e:
-            logger.error('GetClusterStatus Exception: %s', str(e))
+            logger.exception('GetClusterStatus Exception: %s', str(e))
         self.conn.commit()
         cursor.close()
         return ret, time
@@ -1394,7 +1394,7 @@ class DataHandler(object):
             for (identityName, uid, public_key, private_key) in cursor:
                 ret.append((identityName, uid, public_key, private_key))
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
         self.conn.commit()
         cursor.close()
         return ret
@@ -1452,7 +1452,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             return False
 
     @record
@@ -1465,7 +1465,7 @@ class DataHandler(object):
             cursor.close()
             return True
         except Exception as e:
-            logger.error('Exception: %s', str(e))
+            logger.exception('Exception: %s', str(e))
             return False
 
     @record
@@ -1598,14 +1598,17 @@ class DataHandler(object):
 
             self.conn.commit()
         except:
-            logger.error("Exception in counting rows for table %s", table)
+            logger.exception("Exception in counting rows for table %s", table)
         finally:
             if cursor is not None:
                 cursor.close()
         return ret
 
-    def delete_rows_from_table_older_than_days(self, table, days_ago,
-                                               col="time", cond=None):
+    def delete_rows_from_table_older_than_days(self,
+                                               table,
+                                               days_ago,
+                                               col="time",
+                                               cond=None):
         cursor = None
         ret = False
         try:
@@ -1623,7 +1626,7 @@ class DataHandler(object):
             self.conn.commit()
             ret = True
         except:
-            logger.error(
+            logger.exception(
                 "Exception in deleting rows older than %s in col %s "
                 "for table %s", days_ago, col, table)
         finally:


### PR DESCRIPTION
The deleting query takes too long because we didn't index `lastUpdated` column of jobs table.

We can later do this by either index it or query all jobId out and delete them.

This long delete query will result out update job failed:
```
2020-05-26 02:18:53,844 - INFO - job_manager.py:304 - Job status: 79f79edd-96b6-4666-b380-67f9fa5e89f5 Succeeded
2020-05-26 02:19:46,377 - ERROR - MySQLDataHandler.py:1281 - failed to UpdateJobTextFields conditions {'jobId': '79f79e
dd-96b6-4666-b380-67f9fa5e89f5'}, data {'jobStatus': 'finished', 'jobStatusDetail': 'x'}
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/mysql/connector/connection_cext.py", line 489, in cmd_query
    raw_as_string=raw_as_string)
_mysql_connector.MySQLInterfaceError: Lock wait timeout exceeded; try restarting transaction

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "../utils/MySQLDataHandler.py", line 1275, in UpdateJobTextFields
    cursor.execute(sql, values)
  File "/usr/local/lib/python3.5/dist-packages/mysql/connector/cursor_cext.py", line 266, in execute
    raw_as_string=self._raw_as_string)
  File "/usr/local/lib/python3.5/dist-packages/mysql/connector/connection_cext.py", line 492, in cmd_query
    sqlstate=exc.sqlstate)
mysql.connector.errors.DatabaseError: 1205 (HY000): Lock wait timeout exceeded; try restarting transaction
```

```
---TRANSACTION 1604714425, ACTIVE 811 sec fetching rows
mysql tables in use 1, locked 1
54529 lock struct(s), heap size 4874448, 248928 row lock(s), undo log entries 51735
MySQL thread id 1139072470, OS thread handle 140373082511104, query id 9418009966 xxx updating
DELETE FROM jobs WHERE lastUpdated < NOW() - INTERVAL 180 DAY AND `jobStatus` IN ('finished','failed','killed','error')
---TRANSACTION 1604702461, ACTIVE 924 sec
49342 lock struct(s), heap size 4415696, 314854 row lock(s), undo log entries 3662
MySQL thread id 1139051414, OS thread handle 140373060392704, query id 9417840122 xxx
```