### PR TITLE
fix dcgm utils not mapped to correct gpu

### DIFF
--- a/src/docker-images/job-exporter/src/collector.py
+++ b/src/docker-images/job-exporter/src/collector.py
@@ -126,8 +126,9 @@ def gen_nvsm_total_gauge():
 
 
 def gen_nv_peer_mem_gauge():
-    return GaugeMetricFamily("nv_peer_mem_count",
-                             "count of active nv_peer_mem (GPUDirect) module. 0 or 1")
+    return GaugeMetricFamily(
+        "nv_peer_mem_count",
+        "count of active nv_peer_mem (GPUDirect) module. 0 or 1")
 
 
 class ResourceGauges(object):
@@ -186,11 +187,9 @@ class ResourceGauges(object):
                        "how much data Infiniband transmits",
                        self.task_labels_infiniband)
         self.add_gauge("task_ipoib_receive_bytes_total",
-                       "how much data IPoIB receives",
-                       self.task_labels_ipoib)
+                       "how much data IPoIB receives", self.task_labels_ipoib)
         self.add_gauge("task_ipoib_transmit_bytes_total",
-                       "how much data IPoIB transmits",
-                       self.task_labels_ipoib)
+                       "how much data IPoIB transmits", self.task_labels_ipoib)
 
     def add_task_and_service_gauge(self, name_tmpl, desc_tmpl):
         self.add_gauge(name_tmpl.format("task"), desc_tmpl.format("task"),
@@ -201,7 +200,7 @@ class ResourceGauges(object):
 
     def add_dcgm_metric(self, dcgm_metrics, labels):
         for metric_name in dcgm_metrics._fields:
-            if metric_name == "uuid":
+            if metric_name in ["uuid", "minor"]:
                 continue
             val = dcgm_metrics.__getattribute__(metric_name)
             if val == "N/A":
@@ -666,18 +665,8 @@ class ContainerCollector(Collector):
                 # is like GPU-dc0671b0-61a4-443e-f456-f8fa6359b788. The mapping
                 # from uuid to minor_number is get via nvidia-smi, and gpu_infos
                 # should have key of this uuid.
-                if id.isdigit():
+                if len(id) > 0:
                     gpu_ids.append(id)
-                elif id and gpu_infos is not None:
-                    # id is in form of UUID like
-                    if gpu_infos.get(id) is not None:
-                        gpu_ids.append(gpu_infos[id].minor)
-                    else:
-                        logger.warning("gpu uuid %s can not be found in map %s",
-                                       id, gpu_infos)
-                else:
-                    logger.warning("unknown gpu id %s, gpu_infos is %s", id,
-                                   gpu_infos)
 
         return gpu_ids, result_labels
 
@@ -742,10 +731,9 @@ class ContainerCollector(Collector):
                         continue
 
                     nvidia_gpu_status = gpu_infos[id]
-                    uuid = nvidia_gpu_status.uuid
                     labels = copy.deepcopy(container_labels)
-                    labels["minor_number"] = id
-                    labels["uuid"] = uuid
+                    labels["minor_number"] = nvidia_gpu_status.minor
+                    labels["uuid"] = nvidia_gpu_status.uuid
 
                     gauges.add_value("task_gpu_percent", labels,
                                      nvidia_gpu_status.gpu_util)
@@ -757,10 +745,9 @@ class ContainerCollector(Collector):
                     if dcgm_infos.get(id) is None:
                         continue
                     dcgm_metric = dcgm_infos[id] # will be type of DCGMMetrics
-                    uuid = dcgm_metric.uuid
                     labels = copy.deepcopy(container_labels)
-                    labels["minor_number"] = id
-                    labels["uuid"] = uuid
+                    labels["minor_number"] = dcgm_metric.minor
+                    labels["uuid"] = dcgm_metric.uuid
                     gauges.add_dcgm_metric(dcgm_metric, labels)
 
             if is_host_network:
@@ -1198,7 +1185,7 @@ class NvPeerMemCollector(Collector):
             return utils.exec_cmd(
                 ["chroot", "/host-fs", "service", "nv_peer_mem", "status"],
                 histogram=NvPeerMemCollector.cmd_histogram,
-                stderr=subprocess.STDOUT,  # also capture stderr output
+                stderr=subprocess.STDOUT, # also capture stderr output
                 timeout=NvPeerMemCollector.cmd_timeout)
         except subprocess.TimeoutExpired as e:
             logger.warning("service nv_peer_mem status timeout")
@@ -1207,8 +1194,9 @@ class NvPeerMemCollector(Collector):
                 logger.warning("nv_peer_mem service cannot be found")
                 return None
             else:
-                logger.warning("service nv_peer_mem status returns %d, output %s",
-                               e.returncode, e.output)
+                logger.warning(
+                    "service nv_peer_mem status returns %d, output %s",
+                    e.returncode, e.output)
         except Exception:
             logger.exception("call nv_peer_mem failed")
 
@@ -1216,7 +1204,6 @@ class NvPeerMemCollector(Collector):
 
 
 class LustreCollector(Collector):
-
     def __init__(self, name, sleep_time, atomic_ref, iteration_counter):
         Collector.__init__(self, name, sleep_time, atomic_ref,
                            iteration_counter)

--- a/src/docker-images/job-exporter/src/dcgm.py
+++ b/src/docker-images/job-exporter/src/dcgm.py
@@ -97,7 +97,7 @@ mapping = [
     #     "Total number of NVLink bandwidth counters for all lanes"),
 ]
 
-DCGMMetrics = collections.namedtuple("DCGMMetrics",
+DCGMMetrics = collections.namedtuple("DCGMMetrics", ["minor"] +
                                      list(map(lambda x: x[1], mapping)))
 
 
@@ -133,7 +133,7 @@ class DCGMHandler(object):
                     logger.exception("DCGMHandler.run got exception")
 
     def get_dcgm_metric(self):
-        metrics = {} # minor_number -> DCGMMetrics
+        metrics = {} # minor_number,uuid -> DCGMMetrics
         gauges = {} # gauge_name -> GaugeMetricFamily
 
         try:
@@ -161,7 +161,7 @@ class DCGMHandler(object):
                 part = line.split()
                 minor_number = part[0]
 
-                args = {}
+                args = {"minor": minor_number}
                 for i, (_, name, _) in enumerate(mapping):
                     value = part[i + 1]
                     args[name] = value
@@ -174,7 +174,8 @@ class DCGMHandler(object):
                     gauges[name].add_metric([minor_number, args["uuid"]],
                                             float(value))
 
-                metrics[minor_number] = DCGMMetrics(**args)
+                metrics[minor_number] = metrics[args["uuid"]] = DCGMMetrics(
+                    **args)
             return metrics, gauges
         except Exception:
             logger.exception("calling dcgmi failed")


### PR DESCRIPTION
Previous we use minor number to map dcgm metric to task. In some cases, minor number is not the same from dcgm and nvidia. This changed to use uuid to map.