### PR TITLE
[DO NOT MERGE] No host network for ps

### DIFF
--- a/src/ClusterManager/endpoint_manager.py
+++ b/src/ClusterManager/endpoint_manager.py
@@ -142,6 +142,7 @@ def generate_service_selector(pod_name):
 
 def generate_node_port_service(job_id, pod_name, endpoint_id, name,
                                target_port):
+    # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
     endpoint = {
         "kind": "Service",
         "apiVersion": "v1",

--- a/src/ClusterManager/framework.py
+++ b/src/ClusterManager/framework.py
@@ -111,7 +111,7 @@ def gen_init_container(job, role):
     else:
         envs.append({"name": "LOGGING_LEVEL", "value": "INFO"})
 
-    if job.is_host_network:
+    if role.name != "ps" and job.is_host_network:
         envs.append({"name": "DLTS_HOST_NETWORK", "value": "enable"})
 
     return [{
@@ -271,7 +271,7 @@ def gen_container_envs(job, role):
     if role.resource.gpu_limit < 1:
         result.append({"name": "NVIDIA_VISIBLE_DEVICES", "value": ""})
 
-    if job.is_host_network:
+    if role.name != "ps" and job.is_host_network:
         result.append({"name": "DLWS_HOST_NETWORK", "value": "enable"})
         result.append({"name": "DLTS_HOST_NETWORK", "value": "enable"})
 
@@ -540,7 +540,7 @@ def gen_task_role(job, role):
     pod_spec = {
         "nodeSelector": node_selector,
         "restartPolicy": "Never",
-        "hostNetwork": job.is_host_network,
+        "hostNetwork": False if role.name == "ps" else job.is_host_network,
         "hostIPC": job.is_host_ipc,
         "imagePullSecrets": image_pull_secrets,
         "affinity": gen_affinity(job, role),

--- a/src/ClusterManager/test/test_distributed_job.py
+++ b/src/ClusterManager/test/test_distributed_job.py
@@ -205,8 +205,6 @@ sleep infinity"""
 @utils.case()
 def test_distributed_job_env(args):
     envs = {
-        "DLWS_HOST_NETWORK": "enable",
-        "DLTS_HOST_NETWORK": "enable",
         "DLWS_NUM_PS": "1",
         "DLTS_NUM_PS": "1",
         "DLWS_NUM_WORKER": "1",
@@ -263,6 +261,13 @@ def test_distributed_job_env(args):
             envs["DLTS_ROLE_NAME"] = role
             envs["DLWS_ROLE_IDX"] = idx
             envs["DLTS_ROLE_IDX"] = idx
+
+            if role == "ps":
+                envs.pop("DLWS_HOST_NETWORK", None)
+                envs.pop("DLTS_ROLE_NETWORK", None)
+            else:
+                envs["DLWS_HOST_NETWORK"] = "enable"
+                envs["DLTS_HOST_NETWORK"] = "enable"
 
             bash_cmd = ";".join([
                 "printf '%s=' ; printenv %s" % (key, key)

--- a/src/ClusterManager/test/test_distributed_job.py
+++ b/src/ClusterManager/test/test_distributed_job.py
@@ -264,7 +264,7 @@ def test_distributed_job_env(args):
 
             if role == "ps":
                 envs.pop("DLWS_HOST_NETWORK", None)
-                envs.pop("DLTS_ROLE_NETWORK", None)
+                envs.pop("DLTS_HOST_NETWORK", None)
             else:
                 envs["DLWS_HOST_NETWORK"] = "enable"
                 envs["DLTS_HOST_NETWORK"] = "enable"

--- a/src/ClusterManager/test/test_inference_job.py
+++ b/src/ClusterManager/test/test_inference_job.py
@@ -12,8 +12,6 @@ logger = logging.getLogger(__file__)
 @utils.case()
 def test_inference_job_running(args):
     envs = {
-        "DLWS_HOST_NETWORK": "",
-        "DLTS_HOST_NETWORK": "",
         "DLWS_NUM_GPU_PER_WORKER": "1",
         "DLTS_NUM_GPU_PER_WORKER": "1",
         "DLWS_VC_NAME": str(args.vc),

--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -133,7 +133,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    {% if job["hostNetwork"] %}
+    {% if jobRole != "ps" and job["hostNetwork"] %}
     - name: DLTS_HOST_NETWORK
       value: "enable"
     {% endif %}
@@ -251,7 +251,7 @@ spec:
       value: {{ job["vcName"] }}
     - name: DLTS_VC_NAME
       value: {{ job["vcName"] }}
-    {% if job["hostNetwork"] %}
+    {% if jobRole != "ps" and job["hostNetwork"] %}
     - name: DLWS_HOST_NETWORK
       value: "enable"
     - name: DLTS_HOST_NETWORK


### PR DESCRIPTION
This PR is to be debated.

`mpirun` fails to run on ps (CPU pod) after #790. `mpirun` uses localhost if it detects the target host has the same IP as where it is running.