### PR TITLE
support set max running time for job

### DIFF
--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -364,8 +364,9 @@ def UpdateJobStatus(redis_conn,
         params = json.loads(base64decode(job["jobParams"]))
         max_time = params.get("maxTimeSec")
         if type(max_time) != int:
-            logger.info("unknown maxTimeSec %s for job %s", max_time,
-                        job["jobId"])
+            if max_time is not None:
+                logger.info("unknown maxTimeSec %s for job %s", max_time,
+                            job["jobId"])
         else:
             max_time = int(max_time)
             start_time = int(datetime.datetime.timestamp(job["lastUpdated"]))

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -322,7 +322,8 @@ def UpdateJobStatus(redis_conn,
 
         dataFields = {
             "jobStatusDetail": b64encode(json.dumps(detail)),
-            "jobStatus": "finished"
+            "jobStatus": "finished",
+            "lastUpdated": datetime.datetime.now().isoformat(),
         }
         conditionFields = {"jobId": job["jobId"]}
         dataHandler.UpdateJobTextFields(conditionFields, dataFields)
@@ -344,9 +345,12 @@ def UpdateJobStatus(redis_conn,
                 "message": "started at: {}".format(started_at)
             }]
 
+            last_updated = datetime.datetime.now()
+
             dataFields = {
                 "jobStatusDetail": b64encode(json.dumps(detail)),
-                "jobStatus": "running"
+                "jobStatus": "running",
+                "lastUpdated": last_updated.isoformat(),
             }
             conditionFields = {"jobId": job["jobId"]}
             dataHandler.UpdateJobTextFields(conditionFields, dataFields)
@@ -355,6 +359,27 @@ def UpdateJobStatus(redis_conn,
                     notify.new_job_state_change_message(job["userName"],
                                                         job["jobId"],
                                                         result.strip()))
+            job["lastUpdated"] = last_updated
+
+        params = json.loads(base64decode(job["jobParams"]))
+        max_time = params.get("maxTimeSec")
+        if type(max_time) != int:
+            logger.info("unknown maxTimeSec %s for job %s", max_time,
+                        job["jobId"])
+        else:
+            max_time = int(max_time)
+            start_time = int(datetime.datetime.timestamp(job["lastUpdated"]))
+            now = datetime.datetime.timestamp(datetime.datetime.now())
+            if start_time + max_time < now:
+                logger.info(
+                    "killing job %s for its running time exceed maxTimeSec %ss, start %s, now %s",
+                    job["jobId"], max_time, start_time, now)
+                dataFields = {
+                    "errorMsg": "running exceed pre-defined %ss" % (max_time),
+                }
+                conditionFields = {"jobId": job["jobId"]}
+                dataHandler.UpdateJobTextFields(conditionFields, dataFields)
+                launcher.kill_job(job["jobId"], "killed")
 
     elif result == "Failed":
         now = datetime.datetime.now()
@@ -380,7 +405,8 @@ def UpdateJobStatus(redis_conn,
         dataFields = {
             "jobStatusDetail": b64encode(json.dumps(detail)),
             "jobStatus": "failed",
-            "errorMsg": diagnostics
+            "errorMsg": diagnostics,
+            "lastUpdated": datetime.datetime.now().isoformat(),
         }
         conditionFields = {"jobId": job["jobId"]}
         dataHandler.UpdateJobTextFields(conditionFields, dataFields)

--- a/src/ClusterManager/test/test_regular_job.py
+++ b/src/ClusterManager/test/test_regular_job.py
@@ -962,6 +962,5 @@ def test_set_max_time_works(args):
         resp = utils.set_job_max_time(args.rest, args.email, job.jid, 1)
         assert resp.status_code == 200
 
-        assert state == "running"
         state = job.block_until_state_not_in({"running"}, timeout=30)
         assert state == "killed"

--- a/src/ClusterManager/test/utils.py
+++ b/src/ClusterManager/test/utils.py
@@ -497,8 +497,11 @@ class run_job(object):
         except Exception:
             logger.exception("failed to kill job %s", self.jid)
 
-    def block_until_state_not_in(self, states):
-        return block_until_state_not_in(self.rest_url, self.jid, states)
+    def block_until_state_not_in(self, states, timeout=300):
+        return block_until_state_not_in(self.rest_url,
+                                        self.jid,
+                                        states,
+                                        timeout=timeout)
 
 
 def block_until_state(rest_url, jid, not_in, states, timeout=300):
@@ -664,6 +667,7 @@ def kube_get_pods(config_path, namespace, label_selector):
                  namespace, api_response)
     return api_response.items
 
+
 def kube_get_deployment(config_path, namespace, name):
     k8s_config = build_k8s_config(config_path)
     api_client = ApiClient(configuration=k8s_config)
@@ -675,8 +679,9 @@ def kube_get_deployment(config_path, namespace, name):
         name=name,
     )
     logger.debug("%s got deployment from namespace %s: api_response", name,
-                namespace, api_response)
+                 namespace, api_response)
     return api_response
+
 
 def kube_delete_pod(config_path, namespace, pod_name):
     k8s_config = build_k8s_config(config_path)
@@ -740,3 +745,13 @@ def kube_pod_exec(config_path,
         logger.exception("exec on pod %s error. cmd: %s", pod_name,
                          exec_command)
         return [-1, str(err)]
+
+
+def set_job_max_time(rest_url, email, job_id, second):
+    args = urllib.parse.urlencode({
+        "userName": email,
+        "jobId": job_id,
+        "second": second,
+    })
+    url = urllib.parse.urljoin(rest_url, "/JobMaxTime") + "?" + args
+    return requests.post(url)

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -322,7 +322,8 @@ class ScaleJob(Resource):
         job_id = args["jobId"]
         username = args["userName"]
         resourcegpu = int(args["resourcegpu"])
-        msg, status_code = JobRestAPIUtils.scale_inference_job(username, job_id, resourcegpu)
+        msg, status_code = JobRestAPIUtils.scale_inference_job(
+            username, job_id, resourcegpu)
         if status_code != 200:
             return msg, status_code
 
@@ -1017,6 +1018,23 @@ class JobPriority(Resource):
         return generate_response(job_priorities)
 
 
+@api.resource("/JobMaxTime")
+class JobMaxTime(Resource):
+    def __init__(self):
+        self.post_parser = reqparse.RequestParser()
+        self.post_parser.add_argument("userName", required=True)
+        self.post_parser.add_argument("jobId", required=True)
+        self.post_parser.add_argument("second", type=int, required=True)
+
+    def post(self):
+        args = self.post_parser.parse_args()
+        username = args["userName"]
+        job_id = args["jobId"]
+        second = args["second"]
+
+        return JobRestAPIUtils.set_job_max_time(username, job_id, second)
+
+
 @api.resource("/Insight")
 class Insight(Resource):
     def __init__(self):
@@ -1044,8 +1062,8 @@ class Insight(Resource):
         username = args.get("userName")
         payload = request.get_json(force=True, silent=True)
 
-        resp, status_code = JobRestAPIUtils.set_job_insight(job_id, username,
-                                                            payload)
+        resp, status_code = JobRestAPIUtils.set_job_insight(
+            job_id, username, payload)
         if status_code != 200:
             return resp, status_code
         return generate_response(resp)

--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -328,7 +328,6 @@ class DataHandler(object):
                 ret.append(record)
         except Exception as e:
             logger.exception('ListStorages Exception: %s', str(e))
-            pass
         self.conn.commit()
         cursor.close()
         return ret
@@ -395,7 +394,27 @@ class DataHandler(object):
                 ret.append(rec)
         except Exception as e:
             logger.exception('Exception: %s', str(e))
-            pass
+        self.conn.commit()
+        cursor.close()
+        return ret
+
+    @record
+    def GetVC(self, vc_name):
+        cursor = self.conn.cursor()
+        query = """SELECT `quota`,`metadata`,`resourceQuota`,`resourceMetadata`
+                    FROM `%s` WHERE vcName = %s """ % (self.vctablename, "%s")
+        ret = {}
+        try:
+            cursor.execute(query, (vc_name,))
+            for quota, metadata, resource_quota, resource_metadata in cursor:
+                ret = {
+                    "quota": quota,
+                    "metadata": metadata,
+                    "resourceQuota": resource_quota,
+                    "resourceMetadata": resource_metadata
+                }
+        except Exception as e:
+            logger.exception('Exception: %s', str(e))
         self.conn.commit()
         cursor.close()
         return ret
@@ -571,7 +590,6 @@ class DataHandler(object):
                 ret.append(record)
         except Exception as e:
             logger.exception('Exception: %s', str(e))
-            pass
         self.conn.commit()
         cursor.close()
         return ret
@@ -1296,7 +1314,6 @@ class DataHandler(object):
                 ret = value
         except Exception as e:
             logger.exception('Exception: %s', str(e))
-            pass
         self.conn.commit()
         cursor.close()
         return ret


### PR DESCRIPTION
DRI can set VC with parameter like:
```json
{"P40":{"num_gpu_per_node":4}, "admin": {"job_max_time_second": 259200}}
```

Then restfulapi will check this field and add `maxTimeSec` to job parameter. job manager will check this field and compare with `lastUpdated` time, if time spend in Running exceed max time, the job manager will kill the job and replace `errorMsg` with some meaningful words.

This PR also expose an API so that only VC admin can call: `/JobMaxTime`. So that VC admin can adjust this value.

@Gerhut please help change front end:

* add a field display job's max time value by checking `maxTimeSec` field of job's parameter, if it's not exist, then maybe display +∞, otherwise maybe convert it into hour or day for easy display
* allow VC admin adjust this value, and call `/JobMaxTime` API. If this value is too small, then the job may be killed immediately.