### PR TITLE
restrict how many gpus can be used in interactive jobs

### DIFF
--- a/src/ClusterManager/cluster_test_utils.py
+++ b/src/ClusterManager/cluster_test_utils.py
@@ -531,6 +531,7 @@ class BaseTestClusterSetup(object):
             "preemptable_memory": Memory(),
             "gpuType": "P40",
             "gpu_usage": None,
+            "is_interactive": False,
         }
 
         pod2_status = {
@@ -550,6 +551,7 @@ class BaseTestClusterSetup(object):
             "preemptable_memory": Memory(),
             "gpuType": "",
             "gpu_usage": None,
+            "is_interactive": False,
         }
 
         pod3_status = {
@@ -569,6 +571,7 @@ class BaseTestClusterSetup(object):
             "preemptable_memory": Memory(),
             "gpuType": "P40",
             "gpu_usage": None,
+            "is_interactive": False,
         }
 
         pod4_status = {
@@ -588,6 +591,7 @@ class BaseTestClusterSetup(object):
             "preemptable_memory": Memory(),
             "gpuType": "P40",
             "gpu_usage": None,
+            "is_interactive": False,
         }
 
         pod5_status = {
@@ -607,6 +611,7 @@ class BaseTestClusterSetup(object):
             "preemptable_memory": Memory(),
             "gpuType": "P40",
             "gpu_usage": None,
+            "is_interactive": False,
         }
 
         return [pod1_status, pod2_status, pod3_status, pod4_status, pod5_status]
@@ -699,9 +704,7 @@ class BaseTestClusterSetup(object):
         user_status_preemptable.append({
             "userName": "user3",
             "userGPU": Gpu(),
-            "userCPU": Cpu({
-                "m_type2": 1
-            }),
+            "userCPU": Cpu({"m_type2": 1}),
             "userMemory": Memory(),
         })
         cs.user_status_preemptable = user_status_preemptable
@@ -891,20 +894,17 @@ class BaseTestClusterSetup(object):
         ]
         vc2_status.user_status = user_status
 
-        user_status_preemptable = [
-            {
-                "userName": "user1",
-                "userGPU": Gpu(),
-                "userCPU": Cpu(),
-                "userMemory": Memory(),
-            },
-            {
-                "userName": "user3",
-                "userGPU": Gpu(),
-                "userCPU": Cpu({"m_type2": 1}),
-                "userMemory": Memory(),
-            }
-        ]
+        user_status_preemptable = [{
+            "userName": "user1",
+            "userGPU": Gpu(),
+            "userCPU": Cpu(),
+            "userMemory": Memory(),
+        }, {
+            "userName": "user3",
+            "userGPU": Gpu(),
+            "userCPU": Cpu({"m_type2": 1}),
+            "userMemory": Memory(),
+        }]
         vc2_status.user_status_preemptable = user_status_preemptable
 
         # Set vc2 active job count

--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -166,11 +166,11 @@ def update_job_state_latency(redis_conn, job_id, state, event_time=None):
         set_job_status(redis_conn, job_id, job_status)
 
 
-def GetJobTotalGpu(jobParams):
-    numWorkers = 1
-    if "numpsworker" in jobParams:
-        numWorkers = int(jobParams["numpsworker"])
-    return int(jobParams["resourcegpu"]) * numWorkers
+def get_job_total_gpu(job_params):
+    num_workers = 1
+    if "numpsworker" in job_params:
+        num_workers = int(job_params["numpsworker"])
+    return int(job_params["resourcegpu"]) * num_workers
 
 
 @record
@@ -185,7 +185,7 @@ def ApproveJob(redis_conn, job, dataHandlerOri=None):
                                  event_time=job["jobTime"])
 
         jobParams = json.loads(b64decode(job["jobParams"]))
-        job_total_gpus = GetJobTotalGpu(jobParams)
+        job_total_gpus = get_job_total_gpu(jobParams)
 
         if dataHandlerOri is None:
             dataHandler = DataHandler()
@@ -239,7 +239,7 @@ def ApproveJob(redis_conn, job, dataHandlerOri=None):
                 if "preemptionAllowed" in running_jobParams and running_jobParams[
                         "preemptionAllowed"] is True:
                     continue
-                running_job_total_gpus = GetJobTotalGpu(running_jobParams)
+                running_job_total_gpus = get_job_total_gpu(running_jobParams)
                 running_gpus += running_job_total_gpus
 
             logger.info(

--- a/src/ClusterManager/node_manager.py
+++ b/src/ClusterManager/node_manager.py
@@ -40,18 +40,6 @@ def create_log(logdir='/var/log/dlworkspace'):
         logging.config.dictConfig(logging_config)
 
 
-def check_cluster_status_change(o_cluster_status, cluster_status):
-    if o_cluster_status is None:
-        return True
-
-    check_list = ["available_job_num", "gpu_used", "user_status", "node_status"]
-    for item in check_list:
-        if item not in o_cluster_status or item not in cluster_status or \
-                o_cluster_status[item] != cluster_status[item]:
-            return True
-    return False
-
-
 def get_cluster_status():
     """Update in DB and returns cluster status.
 

--- a/src/ClusterManager/test_cluster_status.py
+++ b/src/ClusterManager/test_cluster_status.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import os
+import logging
 import sys
 
-from unittest import TestCase
+import unittest
 from cluster_status import str2bool, ClusterStatus, ClusterStatusFactory
 from cluster_test_utils import BaseTestClusterSetup
 
@@ -11,7 +12,7 @@ sys.path.append(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "../utils"))
 
 
-class TestUtils(TestCase):
+class TestUtils(unittest.TestCase):
     def test_str2bool(self):
         self.assertTrue(str2bool("True"))
         self.assertTrue(str2bool("1"))
@@ -22,7 +23,7 @@ class TestUtils(TestCase):
         self.assertFalse(str2bool("0"))
 
 
-class TestClusterStatus(TestCase):
+class TestClusterStatus(unittest.TestCase):
     def test_to_dict(self):
         inclusion = [
             "gpu_capacity",
@@ -80,3 +81,11 @@ class TestClusterStatus(TestCase):
 
         t_cluster_status = test_cluster.cluster_status
         self.assertEqual(t_cluster_status, cs)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        format=
+        '%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s',
+        level=logging.DEBUG)
+    unittest.main()

--- a/src/ClusterManager/test_virtual_cluster_status.py
+++ b/src/ClusterManager/test_virtual_cluster_status.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import os
+import logging
 import sys
 
-from unittest import TestCase
+import unittest
 from cluster_status import ClusterStatus, ClusterStatusFactory
 from virtual_cluster_status import VirtualClusterStatus, \
     VirtualClusterStatusesFactory
@@ -13,7 +14,7 @@ sys.path.append(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "../utils"))
 
 
-class TestVirtualClusterStatus(TestCase):
+class TestVirtualClusterStatus(unittest.TestCase):
     def test_to_dict(self):
         inclusion = [
             "gpu_capacity",
@@ -80,3 +81,11 @@ class TestVirtualClusterStatus(TestCase):
 
         t_vc_statuses = test_cluster.vc_statuses
         self.assertEqual(t_vc_statuses, vc_statuses)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        format=
+        '%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s',
+        level=logging.DEBUG)
+    unittest.main()

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -1359,8 +1359,8 @@ def UpdateEndpoints(userName, jobId, requested_endpoints, interactive_ports):
                     allowed = True
                 else:
                     allowed = False
-                    reason = "Can not open interactive port as required %s GPU and %s GPUs are already in interactive usage, exceed limit of %s, you can ask admin to enable this endpoint if you do want" % (
-                        gpu_request, interactive_used, interactive_limit)
+                    reason = "Cannot open interactive endpoint. There are already %s interactive GPUs in the VC, request another %s exceeds the limit of %s. You can ask admin to enable the interactive endpoint." % (
+                        interactive_used, gpu_request, interactive_limit)
         if allowed:
             dataHandler.UpdateJobTextFields(
                 {"jobId": jobId}, {"endpoints": json.dumps(endpoints)})

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -31,6 +31,7 @@ sys.path.append(
 
 from job_params_util import make_job_params
 from JobLogUtils import GetJobLog as UtilsGetJobLog
+from resource_stat import Gpu
 
 DEFAULT_JOB_PRIORITY = 100
 USER_JOB_PRIORITY_RANGE = (100, 200)
@@ -56,17 +57,24 @@ vc_cache = TTLCache(maxsize=10240, ttl=DEFAULT_EXPIRATION)
 vc_cache_lock = Lock()
 
 
-def walk_json_field_safe(obj, *fields):
+def walk_json(obj, *fields, default=None):
     """ for example a=[{"a": {"b": 2}}]
-    walk_json_field_safe(a, 0, "a", "b") will get 2
-    walk_json_field_safe(a, 0, "not_exist") will get None
+    walk_json(a, 0, "a", "b") will get 2
+    walk_json(a, 0, "not_exist") will get None
     """
     try:
         for f in fields:
             obj = obj[f]
         return obj
     except:
-        return None
+        return default
+
+
+def get_job_total_gpu(job_params):
+    num_workers = 1
+    if "numpsworker" in job_params:
+        num_workers = int(job_params["numpsworker"])
+    return int(job_params["resourcegpu"]) * num_workers
 
 
 def base64encode(str_val):
@@ -295,9 +303,9 @@ def SubmitJob(jobParamsJsonStr):
 
     dataHandler = DataHandler()
 
-    vc_meta = walk_json_field_safe(dataHandler.GetVC(vc_name), "metadata")
+    vc_meta = walk_json(dataHandler.GetVC(vc_name), "metadata")
     vc_meta = {} if vc_meta is None else json.loads(vc_meta)
-    max_time = walk_json_field_safe(vc_meta, "admin", "job_max_time_second")
+    max_time = walk_json(vc_meta, "admin", "job_max_time_second")
     if max_time is not None:
         jobParams["maxTimeSec"] = max_time
 
@@ -1136,9 +1144,9 @@ def GetEndpoints(userName, jobId):
                                        ["ports"][0]["port"])
                         else:
                             port = int(
-                                walk_json_field_safe(endpoint,
+                                walk_json(endpoint,
                                     "endpointDescription", "spec", "ports", 0, "nodePort") or \
-                                walk_json_field_safe(endpoint,
+                                walk_json(endpoint,
                                     "endpointDescription", "spec", "ports", 0, "node_port")
                                             )
                         epItem["port"] = port
@@ -1152,6 +1160,15 @@ def GetEndpoints(userName, jobId):
     return ret
 
 
+def is_interactive(endpoints):
+    for end in endpoints.keys():
+        # if the job opened any endpoint except tensorboard, the job will
+        # be deemed as interactive
+        if not end.endswith("-tensorboard"):
+            return True
+    return False
+
+
 def UpdateEndpoints(userName, jobId, requested_endpoints, interactive_ports):
     dataHandler = DataHandler()
     try:
@@ -1161,17 +1178,23 @@ def UpdateEndpoints(userName, jobId, requested_endpoints, interactive_ports):
             msg = "Job %s cannot be found in database" % jobId
             logger.error(msg)
             return msg, 404
-        if job["userName"] != userName and (not AuthorizationManager.HasAccess(
-                userName, ResourceType.VC, job["vcName"], Permission.Admin)):
+
+        is_vc_admin = AuthorizationManager.HasAccess(userName, ResourceType.VC,
+                                                     job["vcName"],
+                                                     Permission.Admin)
+
+        if job["userName"] != userName and (not is_vc_admin):
             msg = "You are not authorized to enable endpoint for job %s" % jobId
             logger.error(msg)
             return msg, 403
 
         job_params = json.loads(base64decode(job["jobParams"]))
         job_type = job_params["jobtrainingtype"]
-        job_endpoints = {}
+        endpoints = {}
         if job["endpoints"] is not None:
-            job_endpoints = json.loads(job["endpoints"])
+            endpoints = json.loads(job["endpoints"])
+
+        is_interactive_before = is_interactive(endpoints)
 
         # get pods
         pod_names = []
@@ -1195,14 +1218,12 @@ def UpdateEndpoints(userName, jobId, requested_endpoints, interactive_ports):
         # username
         username = getAlias(job["userName"])
 
-        endpoints = job_endpoints
-
         if "ssh" in requested_endpoints:
             # setup ssh for each pod
             for pod_name in pod_names:
                 endpoint_id = "e-" + pod_name + "-ssh"
 
-                if endpoint_id in job_endpoints:
+                if endpoint_id in endpoints:
                     logger.debug("Endpoint %s exists. Skip.", endpoint_id)
                     continue
                 logger.debug("Endpoint %s does not exist. Add.", endpoint_id)
@@ -1230,7 +1251,7 @@ def UpdateEndpoints(userName, jobId, requested_endpoints, interactive_ports):
 
             endpoint_id = "e-" + jobId + "-ipython"
 
-            if endpoint_id not in job_endpoints:
+            if endpoint_id not in endpoints:
                 logger.debug("Endpoint %s does not exist. Add.", endpoint_id)
                 endpoint = {
                     "id": endpoint_id,
@@ -1257,7 +1278,7 @@ def UpdateEndpoints(userName, jobId, requested_endpoints, interactive_ports):
 
             endpoint_id = "e-" + jobId + "-tensorboard"
 
-            if endpoint_id not in job_endpoints:
+            if endpoint_id not in endpoints:
                 logger.debug("Endpoint %s does not exist. Add.", endpoint_id)
                 endpoint = {
                     "id": endpoint_id,
@@ -1284,7 +1305,7 @@ def UpdateEndpoints(userName, jobId, requested_endpoints, interactive_ports):
 
             endpoint_id = "e-" + jobId + "-port-" + \
                 str(interactive_port["podPort"])
-            if endpoint_id not in job_endpoints:
+            if endpoint_id not in endpoints:
                 logger.debug("Endpoint %s does not exist. Add.", endpoint_id)
                 endpoint = {
                     "id": endpoint_id,
@@ -1300,9 +1321,56 @@ def UpdateEndpoints(userName, jobId, requested_endpoints, interactive_ports):
             else:
                 logger.debug("Endpoint %s exists. Skip.", endpoint_id)
 
-        dataHandler.UpdateJobTextFields({"jobId": jobId},
-                                        {"endpoints": json.dumps(endpoints)})
-        return endpoints, 200
+        is_interactive_after = is_interactive(endpoints)
+        allowed = False
+        reason = None
+
+        # is_interactive_before | is_interactive_after |  allowed
+        #         F             |        F             |     T
+        #         F             |        T             |   check
+        #         T             |        F             | impossible
+        #         T             |        T             |     T
+
+        gpu_request = get_job_total_gpu(job_params)
+
+        if is_vc_admin or \
+                gpu_request == 0 or \
+                (not (is_interactive_before is False and is_interactive_after is True)):
+            allowed = True
+        else:
+            vc_meta = json.loads(
+                walk_json(dataHandler.GetVC(job["vcName"]),
+                          "metadata",
+                          default="{}"))
+            interactive_ratio = float(
+                walk_json(vc_meta, "admin", "interactive_ratio", default=100.0))
+
+            if interactive_ratio == 100.0:
+                allowed = True
+            else:
+                gpu_type = job_params["sku"]
+
+                status, _ = dataHandler.GetClusterStatus()
+                vc_status = walk_json(status, "vc_statuses", job["vcName"])
+                required = Gpu({gpu_type: gpu_request})
+                interactive_used = Gpu(
+                    walk_json(vc_status, "gpu_interactive_used", default={}))
+                capacity = Gpu(walk_json(vc_status, "gpu_capacity", default={}))
+                if (required +
+                        interactive_used) / capacity <= interactive_ratio:
+                    allowed = True
+                else:
+                    allowed = False
+                    reason = "Can not open interactive port as required %s GPU and there are already %s/%s GPU are interactive, exceed limit of %s, you can ask admin to enable if you do want" % (
+                        gpu_request, interactive_used, capacity,
+                        interactive_ratio)
+        if allowed:
+            dataHandler.UpdateJobTextFields(
+                {"jobId": jobId}, {"endpoints": json.dumps(endpoints)})
+            return endpoints, 200
+        else:
+            logger.error(reason)
+            return reason, 403
     except Exception as e:
         logger.error("Get endpoint exception, ex: %s", str(e))
     finally:

--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -1036,19 +1036,21 @@ class DataHandler(object):
         ret = []
         cursor = self.conn.cursor()
         try:
-            query = "SELECT `jobId`, `userName`, `vcName`, `jobParams`, `jobStatus` FROM `%s` WHERE `jobStatus` = 'scheduling' OR `jobStatus` = 'running'" % (
+            query = "SELECT `jobId`, `userName`, `vcName`, `jobParams`, `jobStatus`, `endpoints` FROM `%s` WHERE `jobStatus` = 'scheduling' OR `jobStatus` = 'running'" % (
                 self.jobtablename)
 
             cursor.execute(query)
             data = cursor.fetchall()
 
-            for (jobId, userName, vcName, jobParams, jobStatus) in data:
+            for (jobId, userName, vcName, jobParams, jobStatus,
+                 endpoints) in data:
                 record = {}
                 record["jobId"] = jobId
                 record["userName"] = userName
                 record["vcName"] = vcName
                 record["jobParams"] = jobParams
                 record["jobStatus"] = jobStatus
+                record["endpoints"] = endpoints
                 ret.append(record)
         except Exception as e:
             logger.exception('GetActiveJobList Exception: %s', str(e))

--- a/src/utils/resource_stat.py
+++ b/src/utils/resource_stat.py
@@ -328,6 +328,29 @@ class ResourceStat(object):
                     return False
             return True
 
+    def __le__(self, other):
+        if isinstance(other, numbers.Number):
+            for _, v in self.res.items():
+                if v > other:
+                    return False
+            return True
+        else:
+            if self.__class__ != other.__class__:
+                raise ValueError("Incompatible class %s and %s" %
+                                 (self.__class__, other.__class__))
+
+            # Pairwise compare
+            self_keys = set(self.res.keys())
+            other_keys = set(other.res.keys())
+            all_keys = self_keys.union(other_keys)
+
+            for k in all_keys:
+                self_v = self.res.get(k, 0)
+                other_v = other.res.get(k, 0)
+                if self_v > other_v:
+                    return False
+            return True
+
     def __eq__(self, other):
         if self.__class__ != other.__class__:
             return False


### PR DESCRIPTION
VC admin can add `admin` -> `interactive_limit` with an int value to restrict how many gpu can be used in interactive jobs.

We use endpoints to check if a job is interactive or not: if a job only opened a tensorflow or none endpoint, it will be deemed as non-interactive job, if a job opened other endpoints, it will be deemed as interactive job.

Also exposed following metrics:

* `job_manager_vc_{cpu,gpu,memory}_{capacity,used,preemptable_used,available,unschedulable,reserved}`
* `job_manager_vc_gpu_interactive_used`

Later TODO:

* expose if job is interactive of not

@Gerhut Impact on front end: post to `/endpoints` may return 403 along with plain text reason, you can display this reason to user directly.