### PR TITLE
delete jobs in smaller batch

### DIFF
--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -1651,6 +1651,25 @@ class DataHandler(object):
                 cursor.close()
         return ret
 
+    def get_old_inactive_jobs(self, days_ago):
+        sql = """SELECT jobId FROM jobs
+                WHERE `jobStatus` IN ('finished','failed','killed','error')
+                AND lastUpdated < NOW() - INTERVAL %s DAY
+                """ % (days_ago)
+        cursor = self.conn.cursor()
+        cursor.execute(sql)
+        result = list(map(lambda x: x[0], cursor))
+        cursor.close()
+        return result
+
+    def delete_jobs(self, jids):
+        cursor = self.conn.cursor()
+        for jid in jids:
+            sql = "DELETE FROM jobs WHERE jobId = %s"
+            cursor.execute(sql, (jid,))
+        self.conn.commit()
+        cursor.close()
+
     def __del__(self):
         logger.debug(
             "********************** deleted a DataHandler instance *******************"


### PR DESCRIPTION
Have tested in dev1 cluster. Ref #1138 

According to experiment on dumped data from a large table. Add index to `lastUpdated` doesn't help much, and the deletion process still takes minutes. So break this to two process:

1. get job id of old inactive jobs.
2. delete them in a smaller batch.

The read process takes 10s, and the whole write process takes 14 to 28 minutes, but with much shorter lock holding time, so will not interference normal read/write operations.

I have tested deletion time of different batch size:

* will take 20:22 if batch size is 1
* will take 14:02 if batch size is 50
* will take 14:41 if batch size is 100
* will take 28:31 if batch size is 1000