### PR TITLE
expose role-name and role-idx to endpoints

### DIFF
--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -277,6 +277,7 @@ class DistributeJobTemplate(JobTemplate):
         if "envs" not in pod:
             pod["envs"] = []
         pod["envs"].append({"name": "DLWS_ROLE_IDX", "value": pod["role_idx"]})
+        pod["envs"].append({"name": "DLTS_ROLE_IDX", "value": pod["role_idx"]})
 
         pod_yaml = self.template.render(job=pod)
         pod_obj = yaml.full_load(pod_yaml)
@@ -349,9 +350,6 @@ class DistributeJobTemplate(JobTemplate):
         # Set up system environment variables if any
         distributed_system_envs = job.get_distributed_system_envs()
         for env_name, env_val in distributed_system_envs.items():
-            params["envs"].append({
-                "name": env_name,
-                "value": env_val
-            })
+            params["envs"].append({"name": env_name, "value": env_val})
 
         return params, None


### PR DESCRIPTION
Expose `role-name` and `role-idx` to endpoints.

Do so by inferring from pod name. `endpoint_manager.py` will do this inferring and save to DB. To make already running jobs get such info, also inferring in `JobRestAPIUtils.py`, but should be removed in the future.