### PR TITLE
Dashboard/job insights

### DIFF
--- a/src/dashboard/src/pages/Job/Insight.tsx
+++ b/src/dashboard/src/pages/Job/Insight.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
   FunctionComponent,
-  SyntheticEvent,
+  memo,
   useCallback,
   useContext,
   useMemo,
@@ -30,115 +30,119 @@ import { formatDateDistance } from '../../utils/formats';
 import useRouteParams from './useRouteParams';
 import Context from './Context';
 
-const usePaperStyle = makeStyles(theme => createStyles({
-  root: (collapse: boolean) => collapse ? {
+const useMessagePaperStyle = makeStyles(theme => createStyles({
+  root: {
     display: 'flex',
-    alignItems: 'center',
-    marginBottom: theme.spacing(1),
-    padding: theme.spacing(1),
-  } : {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'stretch',
+    flexDirection: (expanded: boolean) => expanded ? 'column' : 'row',
+    alignItems: (expanded: boolean) => expanded ? 'stretch' : 'center',
     marginBottom: theme.spacing(1),
     padding: theme.spacing(1),
   },
 }));
 
-const useTypographyStyle = makeStyles(theme => createStyles({
-  root: (collapsed) => collapsed ? {
-    overflowX: 'hidden',
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis'
-  } : {},
-}));
+const LevelIcon: FunctionComponent<{ children: string }> = memo(({ children }) => {
+  const { palette } = useTheme();
 
-interface DiagnosticProps {
+  if (children === 'WARNING') {
+    return <Warning fontSize="small" htmlColor={palette.warning.main}/>;
+  } else { // 'INFO' by default
+    return <Info fontSize="small" htmlColor={palette.info.main}/>;
+  }
+}, ({ children: prevChildren }, { children: nextChildren }) => prevChildren === nextChildren);
+
+const ActionButton: FunctionComponent<{ children: string }> = ({ children }) => {
+  const { clusterId } = useRouteParams();
+  const { job } = useContext(Context);
+  const { pause, kill } = useActions(clusterId);
+
+  const handlePauseButtonClick = useCallback((event: unknown) => {
+    pause(job).onClick(event, job);
+  }, [pause, job]);
+  const handleKillButtonClick = useCallback((event: unknown) => {
+    kill(job).onClick(event, job);
+  }, [kill, job]);
+
+  if (/^https?:\/\//.test(children)) {
+    return <Button size="small" color="primary" href={children} target="_blank" rel="noopener noreferrer">Link</Button>
+  }
+  if (children === 'PauseJob') {
+    return <Button size="small" color="primary" onClick={handlePauseButtonClick}>Pause</Button>
+  }
+  if (children === 'KillJob') {
+    return <Button size="small" color="secondary" onClick={handleKillButtonClick}>Kill</Button>
+  }
+  return null;
+};
+
+interface CollapsedMessageProps {
+  level: string;
+  count: number;
+  onExpand(): void;
+  children: string;
+}
+
+const CollapsedMessage: FunctionComponent<CollapsedMessageProps> = ({ level, count, onExpand, children }) => {
+  const paperStyle = useMessagePaperStyle(false);
+  return (
+    <Paper variant="outlined" classes={paperStyle}>
+      <LevelIcon>{level}</LevelIcon>
+      <Typography
+        variant="body2"
+        noWrap
+        component={Box}
+        width="0px"
+        flex={1}
+        paddingLeft={1}
+        overflow="hidden"
+        textOverflow="ellipsis"
+      >
+        {children}
+      </Typography>
+      { count > 1 && (
+        <Typography variant="body2" component={Box} paddingRight={1}>
+          {`and ${count - 1} more`}
+        </Typography>
+      ) }
+      <Button size="small" color="primary" onClick={onExpand}>Expand</Button>
+    </Paper>
+  );
+};
+
+interface MessageProps {
   date: Date;
   level: string;
   action: string;
   children: string;
 }
 
-const Diagnostic: FunctionComponent<DiagnosticProps> = ({ date, level, action, children }) => {
-  const { clusterId } = useRouteParams();
-  const { job } = useContext(Context);
-  const { kill } = useActions(clusterId);
-  const { palette } = useTheme();
-
-  const [collapsed, setCollapsed] = useState(true);
-
-  const handleDetailsButtonClick = useCallback(() => {
-    setCollapsed(false);
-  }, [setCollapsed]);
-  const handleKillClick = useCallback((event: SyntheticEvent) => {
-    kill(job).onClick(event, job);
-  }, [kill, job]);
-
-  const icon = useMemo(() => {
-    if (level === 'WARNING') {
-      return <Warning fontSize="small" htmlColor={palette.warning.main}/>;
-    } else { // 'INFO' by default
-      return <Info fontSize="small" htmlColor={palette.info.main}/>;
-    }
-  }, [level, palette]);
-  const actionButton = useMemo(() => {
-    if (action === 'KillJob') {
-      return <Button size="small" color="secondary" onClick={handleKillClick}>Kill</Button>;
-    }
-  }, [action, handleKillClick]);
-
-  const paperStyle = usePaperStyle(collapsed);
-  const typographyStyle = useTypographyStyle(collapsed);
-
-  if (collapsed) {
-    return (
-      <Paper variant="outlined" classes={paperStyle}>
-        {icon}
+const Message: FunctionComponent<MessageProps> = ({ date, level, action, children }) => {
+  const paperStyle = useMessagePaperStyle(true);
+  return (
+    <Paper variant="outlined" classes={paperStyle}>
+      <Box display="flex" alignItems="flex-start">
+        <LevelIcon>{level}</LevelIcon>
         <Typography
           variant="body2"
           component={Box}
           width="0px"
           flex={1}
           paddingLeft={1}
-          classes={typographyStyle}
         >
           {children}
         </Typography>
-        <Button size="small" onClick={handleDetailsButtonClick}>Details</Button>
-      </Paper>
-    );
-  } else {
-    return (
-      <Paper variant="outlined" classes={paperStyle}>
-        <Box display="flex" alignItems="flex-start">
-          {icon}
-          <Typography
-            variant="body2"
-            component={Box}
-            width="0px"
-            flex={1}
-            paddingLeft={1}
-            classes={typographyStyle}
-          >
-            {children}
-          </Typography>
-        </Box>
-        <Box display="flex" alignItems="center" justifyContent="space-between" paddingTop={1}>
-          <Typography
-            variant="caption"
-          >
-            {formatDateDistance(date)}
-          </Typography>
-          {actionButton}
-        </Box>
-      </Paper>
-    );
-  }
-}
+      </Box>
+      <Box display="flex" alignItems="flex-end" justifyContent="space-between" paddingTop={1}>
+        <Typography variant="caption">{formatDateDistance(date)}</Typography>
+        <ActionButton>{action}</ActionButton>
+      </Box>
+    </Paper>
+  );
+};
 
 const Insight: FunctionComponent = () => {
   const { job } = useContext(Context);
+
+  const [collapsed, setCollapsed] = useState(true);
 
   const date = useMemo<Date>(() => {
     const timestamp = get(job, ['insight', 'timestamp'], NaN);
@@ -148,11 +152,30 @@ const Insight: FunctionComponent = () => {
     return get(job, ['insight', 'diagnostics'], []);
   }, [job]);
 
+  const handleExpand = useCallback(() => {
+    setCollapsed(false);
+  }, [setCollapsed]);
+
+  if (diagnostics.length === 0) {
+    return null;
+  }
+  if (collapsed) {
+    const [level, text] = diagnostics[0];
+    return (
+      <CollapsedMessage
+        level={level}
+        count={diagnostics.length}
+        onExpand={handleExpand}
+      >
+        {text}
+      </CollapsedMessage>
+    );
+  }
   return (
     <>
       {
         diagnostics.map(([level, text, action]: [string, string, string], index) => (
-          <Diagnostic key={index} date={date} level={level} action={action}>{text}</Diagnostic>
+          <Message key={index} date={date} level={level} action={action}>{text}</Message>
         ))
       }
     </>

--- a/src/dashboard/src/pages/Job/Insight.tsx
+++ b/src/dashboard/src/pages/Job/Insight.tsx
@@ -25,6 +25,7 @@ import {
 } from '@material-ui/icons';
 
 import useActions from '../../hooks/useActions';
+import { formatDateDistance } from '../../utils/formats';
 
 import useRouteParams from './useRouteParams';
 import Context from './Context';
@@ -38,7 +39,7 @@ const usePaperStyle = makeStyles(theme => createStyles({
   } : {
     display: 'flex',
     flexDirection: 'column',
-    alignItems: 'flex-end',
+    alignItems: 'stretch',
     marginBottom: theme.spacing(1),
     padding: theme.spacing(1),
   },
@@ -53,12 +54,13 @@ const useTypographyStyle = makeStyles(theme => createStyles({
 }));
 
 interface DiagnosticProps {
+  date: Date;
   level: string;
   action: string;
   children: string;
 }
 
-const Diagnostic: FunctionComponent<DiagnosticProps> = ({ level, action, children }) => {
+const Diagnostic: FunctionComponent<DiagnosticProps> = ({ date, level, action, children }) => {
   const { clusterId } = useRouteParams();
   const { job } = useContext(Context);
   const { kill } = useActions(clusterId);
@@ -109,7 +111,7 @@ const Diagnostic: FunctionComponent<DiagnosticProps> = ({ level, action, childre
   } else {
     return (
       <Paper variant="outlined" classes={paperStyle}>
-        <Box alignSelf="stretch" display="flex" alignItems="flex-start">
+        <Box display="flex" alignItems="flex-start">
           {icon}
           <Typography
             variant="body2"
@@ -122,7 +124,14 @@ const Diagnostic: FunctionComponent<DiagnosticProps> = ({ level, action, childre
             {children}
           </Typography>
         </Box>
-        {actionButton}
+        <Box display="flex" alignItems="center" justifyContent="space-between" paddingTop={1}>
+          <Typography
+            variant="caption"
+          >
+            {formatDateDistance(date)}
+          </Typography>
+          {actionButton}
+        </Box>
       </Paper>
     );
   }
@@ -131,6 +140,10 @@ const Diagnostic: FunctionComponent<DiagnosticProps> = ({ level, action, childre
 const Insight: FunctionComponent = () => {
   const { job } = useContext(Context);
 
+  const date = useMemo<Date>(() => {
+    const timestamp = get(job, ['insight', 'timestamp'], NaN);
+    return new Date(timestamp * 1000);
+  }, [job]);
   const diagnostics = useMemo<any[]>(() => {
     return get(job, ['insight', 'diagnostics'], []);
   }, [job]);
@@ -139,7 +152,7 @@ const Insight: FunctionComponent = () => {
     <>
       {
         diagnostics.map(([level, text, action]: [string, string, string], index) => (
-          <Diagnostic key={index} level={level} action={action}>{text}</Diagnostic>
+          <Diagnostic key={index} date={date} level={level} action={action}>{text}</Diagnostic>
         ))
       }
     </>

--- a/src/dashboard/src/pages/Job/Insight.tsx
+++ b/src/dashboard/src/pages/Job/Insight.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import {
   FunctionComponent,
+  useCallback,
   useContext,
   useMemo,
 } from 'react';
 
 import {
   Box,
+  Button,
   Paper,
   Typography,
   createStyles,
@@ -15,6 +17,9 @@ import {
 
 import { Info } from '@material-ui/icons';
 
+import useActions from '../../hooks/useActions';
+
+import useRouteParams from './useRouteParams';
 import Context from './Context';
 
 const usePaperStyle = makeStyles(theme => createStyles({
@@ -26,12 +31,23 @@ const usePaperStyle = makeStyles(theme => createStyles({
   },
 }))
 
-const Message: FunctionComponent<{ children: string }> = ({ children }) => {
+interface MessageProps {
+  job: any;
+  children: string;
+}
+
+const Message: FunctionComponent<MessageProps> = ({ children, job }) => {
+  const { clusterId } = useRouteParams();
+  const { support } = useActions(clusterId);
+  const handleSupportClick = useCallback((event: any) => {
+    support(job).onClick(event, job);
+  }, [support, job]);
   const paperStyle = usePaperStyle();
   return (
     <Paper variant="outlined" classes={paperStyle}>
       <Info fontSize="small" color="primary"/>
       <Typography variant="body2" component={Box} flex={1} paddingLeft={1}>{children}</Typography>
+      <Button size="small" color="primary" onClick={handleSupportClick}>support</Button>
     </Paper>
   );
 }
@@ -50,7 +66,7 @@ const Insight: FunctionComponent = () => {
     <>
       {
         messages.map((message, index) => (
-          <Message key={index}>{message}</Message>
+          <Message key={index} job={job}>{message}</Message>
         ))
       }
     </>

--- a/src/dashboard/src/pages/Job/Insight.tsx
+++ b/src/dashboard/src/pages/Job/Insight.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import {
+  FunctionComponent,
+  useContext,
+  useMemo,
+} from 'react';
+
+import {
+  Box,
+  Paper,
+  Typography,
+  createStyles,
+  makeStyles,
+} from '@material-ui/core'
+
+import { Info } from '@material-ui/icons';
+
+import Context from './Context';
+
+const usePaperStyle = makeStyles(theme => createStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: theme.spacing(1),
+    padding: theme.spacing(1),
+  },
+}))
+
+const Message: FunctionComponent<{ children: string }> = ({ children }) => {
+  const paperStyle = usePaperStyle();
+  return (
+    <Paper variant="outlined" classes={paperStyle}>
+      <Info fontSize="small" color="primary"/>
+      <Typography variant="body2" component={Box} flex={1} paddingLeft={1}>{children}</Typography>
+    </Paper>
+  );
+}
+
+const Insight: FunctionComponent = () => {
+  const { job } = useContext(Context);
+
+  const messages = useMemo(() => {
+    if (job == null) return [];
+    if (job['insight'] == null) return [];
+    if (!Array.isArray(job['insight']['messages'])) return [];
+    return job['insight']['messages'];
+  }, [job]);
+
+  return (
+    <>
+      {
+        messages.map((message, index) => (
+          <Message key={index}>{message}</Message>
+        ))
+      }
+    </>
+  );
+}
+
+export default Insight;

--- a/src/dashboard/src/pages/Job/Insight.tsx
+++ b/src/dashboard/src/pages/Job/Insight.tsx
@@ -104,7 +104,7 @@ const CollapsedMessage: FunctionComponent<CollapsedMessageProps> = ({ level, cou
           {`and ${count - 1} more`}
         </Typography>
       ) }
-      <Button size="small" color="primary" onClick={onExpand}>Expand</Button>
+      <Button size="small" color="primary" onClick={onExpand}>Show All</Button>
     </Paper>
   );
 };

--- a/src/dashboard/src/pages/Job/Insight.tsx
+++ b/src/dashboard/src/pages/Job/Insight.tsx
@@ -14,6 +14,7 @@ import {
   Box,
   Button,
   Paper,
+  Tooltip,
   Typography,
   createStyles,
   makeStyles,
@@ -132,7 +133,9 @@ const Message: FunctionComponent<MessageProps> = ({ date, level, action, childre
         </Typography>
       </Box>
       <Box display="flex" alignItems="flex-end" justifyContent="space-between" paddingTop={1}>
-        <Typography variant="caption">{formatDateDistance(date)}</Typography>
+        <Tooltip title={date.toLocaleString()} placement="right">
+          <Typography variant="caption">{formatDateDistance(date)}</Typography>
+        </Tooltip>
         <ActionButton>{action}</ActionButton>
       </Box>
     </Paper>

--- a/src/dashboard/src/pages/Job/index.tsx
+++ b/src/dashboard/src/pages/Job/index.tsx
@@ -109,7 +109,7 @@ const JobContent: FunctionComponent = () => {
       <Helmet title={`(${capitalize(job['jobStatus'])}) ${job['jobName']}`}/>
       <Container fixed maxWidth="lg">
         <Header manageable={manageable}/>
-        <Insight/>
+        {status === 'running' && <Insight/>}
         <Tabs manageable={manageable}/>
       </Container>
     </Context.Provider>

--- a/src/dashboard/src/pages/Job/index.tsx
+++ b/src/dashboard/src/pages/Job/index.tsx
@@ -21,6 +21,7 @@ import Loading from '../../components/Loading';
 import useRouteParams from './useRouteParams';
 import Context from './Context';
 import Header from './Header';
+import Insight from './Insight';
 import Tabs from './Tabs';
 
 const JobContent: FunctionComponent = () => {
@@ -108,6 +109,7 @@ const JobContent: FunctionComponent = () => {
       <Helmet title={`(${capitalize(job['jobStatus'])}) ${job['jobName']}`}/>
       <Container fixed maxWidth="lg">
         <Header manageable={manageable}/>
+        <Insight/>
         <Tabs manageable={manageable}/>
       </Container>
     </Context.Provider>


### PR DESCRIPTION
@Anbang-Hu sorry to revert your markdown efforts, I found it should be listed and deal message by message.

If necessary I will split the revert commit into a separated PR.

![image](https://user-images.githubusercontent.com/2500247/84624830-b212ba80-af14-11ea-9178-481f6dcd7afb.png)

- Currently the job insights "GPU idle" and "need more metrics" seems have different message levels (warn and info). They may have different styles for user if we can do that.
- It's better to give an action to user for each message, like "kill"(for gpu idle), "support"(maybe by default) or "dismiss"(cannot be persistent currently)

Expected fields:
- level
- message
- action

- [ ] drop the revert commit and rebase on the latest dev branch