### PR TITLE
Dashboard: Pure CPU frontend support

### DIFF
--- a/src/dashboard/server/api/validator/config.schema.json
+++ b/src/dashboard/server/api/validator/config.schema.json
@@ -52,6 +52,11 @@
               "title": "Samba endpoint of the cluster's data directory",
               "description": "Starting with file://, exclude the tailing slash",
               "type": "string"
+            },
+            "isPureCPU": {
+              "title": "Whether it is a pure CPU cluster",
+              "description": "Set to true if it is a pure CPU cluster.",
+              "type": "boolean"
             }
           }
         }

--- a/src/dashboard/src/pages/Cluster/Pods.tsx
+++ b/src/dashboard/src/pages/Cluster/Pods.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 
-import { filter, flatMap, map, set } from 'lodash';
+import { compact, filter, flatMap, map, set } from 'lodash';
 
 import {
   Button,
@@ -80,7 +80,7 @@ const Pods: FunctionComponent<Props> = ({ data: { config, workers } }) => {
     setFilterCurrentTeam((filterCurrentTeam) => !filterCurrentTeam)
   }, []);
 
-  const columns = useRef<Column<any>[]>([{
+  const columns = useRef<Column<any>[]>(compact([{
     field: 'id',
     render: ({ id, jobId }) => (
       <Tooltip title={`See Job ${jobId}`}>
@@ -107,7 +107,7 @@ const Pods: FunctionComponent<Props> = ({ data: { config, workers } }) => {
     field: 'cpu',
     type: 'numeric',
     width: 'auto'
-  }, {
+  }, !config['isPureCPU'] && {
     title: 'GPU',
     field: 'gpu',
     type: 'numeric',
@@ -118,12 +118,12 @@ const Pods: FunctionComponent<Props> = ({ data: { config, workers } }) => {
     type: 'numeric',
     render: ({ memory }) => <>{formatBytes(memory)}</>,
     width: 'auto'
-  }, {
+  }, !config['isPureCPU'] && {
     title: 'Assigned GPU Utilization',
     field: 'gpuMetrics.utilization',
     type: 'numeric',
     render: ({ gpuMetrics }) => gpuMetrics && gpuMetrics.utilization && <>{formatPercent(Number(gpuMetrics.utilization) / 100)}</>
-  }, {
+  }, !config['isPureCPU'] && {
     title: 'GPU Idle',
     field: 'gpuMetrics.idle',
     type: 'numeric',
@@ -132,7 +132,7 @@ const Pods: FunctionComponent<Props> = ({ data: { config, workers } }) => {
         {(gpuMetrics.idle || 0)}
       </Typography>
     )
-  }]).current;
+  }])).current;
   const options = useMemo<Options>(() => ({
     padding: "dense",
     paging: false,

--- a/src/dashboard/src/pages/Cluster/Users.tsx
+++ b/src/dashboard/src/pages/Cluster/Users.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState
 } from 'react';
-import { entries, find, get, keys, set, union } from 'lodash';
+import { compact, entries, find, get, keys, set, union } from 'lodash';
 
 import {
   Button,
@@ -137,7 +137,7 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
     setQuery(userName);
   }, [setQuery]);
 
-  const columns = useRef<Column<any>[]>([{
+  const columns = useRef<Column<any>[]>(compact([{
     field: 'id',
     render: (row) =>
       row.id === undefined
@@ -168,7 +168,7 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
     ),
     searchable: false,
     width: 'auto'
-  }, {
+  }, !config['isPureCPU'] && {
     title: <CaptionColumnTitle caption="Used (Preemptable)">GPU</CaptionColumnTitle>,
     field: 'status.gpu.used',
     render: ({ status }) => status && (
@@ -190,7 +190,7 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
     ),
     searchable: false,
     width: 'auto'
-  }, {
+  }, !config['isPureCPU'] && {
     title: 'GPU Idle',
     field: 'gpuMetrics.idle',
     type: 'numeric',
@@ -202,13 +202,13 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
       )
       : <>0</>,
     width: 'auto'
-  }, {
+  }, !config['isPureCPU'] && {
     title: <CaptionColumnTitle caption="Last 31 days">Booked GPU Hours</CaptionColumnTitle>,
     field: 'gpuMetrics.bookedLast31Days',
     type: 'numeric',
     render: (data) => <>{humanHours(get(data, 'gpuMetrics.bookedLast31Days'))}</>,
     width: 'auto'
-  }, {
+  }, !config['isPureCPU'] && {
     title: <CaptionColumnTitle caption="Last 31 days">Idle GPU Hours (%)</CaptionColumnTitle>,
     field: 'gpu.idleLast31Days',
     type: 'numeric',
@@ -235,7 +235,7 @@ const Users: FunctionComponent<Props> = ({ data: { config, users } }) => {
       return <>{humanHours(idle)}{" ("}{formatPercent(ratio, 1)})</>;
     },
     width: 'auto'
-  }]).current;
+  }])).current;
 
   const options = useRef<Options>({
     padding: 'dense',

--- a/src/dashboard/src/pages/Cluster/Workers.tsx
+++ b/src/dashboard/src/pages/Cluster/Workers.tsx
@@ -94,7 +94,7 @@ const Workers: FunctionComponent<Props> = ({ data: { config, types, workers } })
   const resourceKinds = useRef<ResourceKind[]>(
     ['total', 'unschedulable', 'used', 'preemptable', 'available']
   ).current;
-  const resourceColumns = useResourceColumns(resourceKinds);
+  const resourceColumns = useResourceColumns(resourceKinds, config['isPureCPU']);
   const columns = useMemo(() => {
     const columns: Column<any>[] = [{
       field: 'id',
@@ -124,14 +124,16 @@ const Workers: FunctionComponent<Props> = ({ data: { config, types, workers } })
       }
     }];
     columns.push(...resourceColumns);
-    columns.push({
-      title: 'GPU Utilization',
-      field: 'gpuUtilization',
-      type: 'numeric',
-      render: ({ gpuUtilization }) => <>{Number(gpuUtilization || 0).toFixed(2)}%</>
-    });
+    if (!config['isPureCPU']) {
+      columns.push({
+        title: 'GPU Utilization',
+        field: 'gpuUtilization',
+        type: 'numeric',
+        render: ({ gpuUtilization }) => <>{Number(gpuUtilization || 0).toFixed(2)}%</>
+      });
+    }
     return columns;
-  }, [resourceColumns, handleWorkerClick, linkStyles]);
+  }, [config, resourceColumns, handleWorkerClick, linkStyles]);
 
   const options = useRef<Options>({
     padding: 'dense',

--- a/src/dashboard/src/pages/Clusters/useResourceColumns.tsx
+++ b/src/dashboard/src/pages/Clusters/useResourceColumns.tsx
@@ -17,23 +17,26 @@ import { formatBytes, formatFloat } from '../../utils/formats';
 export type ResourceType = 'cpu' | 'gpu' | 'memory';
 export type ResourceKind = 'total' | 'unschedulable' | 'used' | 'preemptable' | 'available';
 
-const useResourceColumns = (kinds: ResourceKind[]) => {
+const useResourceColumns = (kinds: ResourceKind[], isPureCPU = false) => {
   const theme = useTheme();
 
-  const [expandedResourceType, setExpandedResourceType] = useState<ResourceType>('gpu');
+  const [expandedResourceType, setExpandedResourceType] = useState<ResourceType>(isPureCPU ? 'cpu' : 'gpu');
 
-  const typeColor = useMemo(() => ({
+  const typeColor = useMemo(() => (isPureCPU ? {
+    cpu: theme.palette.background.paper,
+    memory: theme.palette.background.paper,
+  } : {
     cpu: theme.palette.background.default,
     gpu: theme.palette.background.paper,
     memory: theme.palette.background.default,
-  }), [theme]);
+  }), [isPureCPU, theme]);
 
   const expandable = kinds.indexOf('used') > -1 && kinds.indexOf('total') > -1;
 
   return useMemo(() => {
     const columns: Column<any>[] = [];
 
-    for (const title of ['CPU', 'GPU', 'Memory']) {
+    for (const title of isPureCPU ? ['CPU', 'Memory'] : ['CPU', 'GPU', 'Memory']) {
       const type = title.toLowerCase() as ResourceType;
       const process = type === 'memory' ? formatBytes : formatFloat;
       const style = { backgroundColor: typeColor[type] };
@@ -84,7 +87,7 @@ const useResourceColumns = (kinds: ResourceKind[]) => {
       }
     }
     return columns;
-  }, [kinds, expandable, expandedResourceType, typeColor]);
+  }, [isPureCPU, kinds, expandable, expandedResourceType, typeColor]);
 };
 
 export default useResourceColumns;

--- a/src/dashboard/src/pages/Clusters/useResourceColumns.tsx
+++ b/src/dashboard/src/pages/Clusters/useResourceColumns.tsx
@@ -23,7 +23,7 @@ const useResourceColumns = (kinds: ResourceKind[], isPureCPU = false) => {
   const [expandedResourceType, setExpandedResourceType] = useState<ResourceType>(isPureCPU ? 'cpu' : 'gpu');
 
   const typeColor = useMemo(() => (isPureCPU ? {
-    cpu: theme.palette.background.paper,
+    cpu: theme.palette.background.default,
     memory: theme.palette.background.paper,
   } : {
     cpu: theme.palette.background.default,


### PR DESCRIPTION
Depends on #1176

Home: render nodes chart for pure CPU clusters.

![image](https://user-images.githubusercontent.com/2500247/84732985-a33d0e00-afcf-11ea-9278-b1d3802f1d38.png)

Cluster Details: remove GPU related columns for pure CPU clusters.