### PR TITLE
Dashboard: configurable job max retry count

### DIFF
--- a/src/dashboard/src/pages/Job/Tabs/Brief.tsx
+++ b/src/dashboard/src/pages/Job/Tabs/Brief.tsx
@@ -133,6 +133,19 @@ const Brief: FunctionComponent = () => {
           secondaryTypographyProps={{ component: 'div' }}
         />
       </ListItem>
+      {
+        job['jobParams']['max_retry_count'] !== undefined && (
+          <>
+            <Divider />
+            <ListItem>
+              <ListItemText
+                primary="Max Retry Count"
+                secondary={job['jobParams']['max_retry_count']}
+              />
+            </ListItem>
+          </>
+        )
+      }
     </List>
   );
 };

--- a/src/dashboard/src/pages/Submission/Training.tsx
+++ b/src/dashboard/src/pages/Submission/Training.tsx
@@ -325,6 +325,16 @@ const Training: React.ComponentClass = withRouter(({ history }) => {
         [{ name: "", value: "" }]));
   }, [environmentVariables]);
 
+  const [maxRetryCount, setMaxRetryCount] = React.useState(3);
+  const onMaxRetryCountChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      let value = event.target.valueAsNumber || 0;
+      if (value < 0) { value = 0; }
+      setMaxRetryCount(value);
+    },
+    [setMaxRetryCount]
+  )
+
   const [database, setDatabase] = React.useState(false);
   // const onDatabaseClick = React.useCallback(() => {
   //   setDatabase(true);
@@ -618,6 +628,7 @@ const Training: React.ComponentClass = withRouter(({ history }) => {
       hostNetwork : type === 'PSDistJob',
       isPrivileged : type === 'PSDistJob',
       plugins: plugins,
+      'max_retry_count': String(maxRetryCount),
     };
     let totalGpus = gpus;
     if (type === 'PSDistJob') {
@@ -1188,6 +1199,23 @@ const Training: React.ComponentClass = withRouter(({ history }) => {
                   </TableRow>
                 </TableBody>
               </Table>
+            </CardContent>
+            <CardContent>
+              <Typography component="div" variant="h6">Retry Policy</Typography>
+              <Grid container wrap="wrap" spacing={1}>
+                <Grid item xs={12}>
+                  <TextField
+                    type="number"
+                    error={maxRetryCount < 0}
+                    label="Max Retry Count"
+                    fullWidth
+                    variant="filled"
+                    inputProps={{ min: 0 }}
+                    value={maxRetryCount}
+                    onChange={onMaxRetryCountChange}
+                  />
+                </Grid>
+              </Grid>
             </CardContent>
           </Collapse>
           <Collapse in={database}>


### PR DESCRIPTION
FE support for #1169

### Training Job Submission page

Set default # to 3.

![image](https://user-images.githubusercontent.com/2500247/84742279-d4730980-afe2-11ea-9ab9-08080eab043e.png)

### Job Details Page

Currently only render the max retry count item if it is explicitly set in param because the backend default value is not suitable for old jobs.

![image](https://user-images.githubusercontent.com/2500247/84742458-08e6c580-afe3-11ea-9a40-d567083ee750.png)
