### PR TITLE
Dashboard: add URL hash to tabs

### DIFF
--- a/src/dashboard/src/hooks/useHashTab.ts
+++ b/src/dashboard/src/hooks/useHashTab.ts
@@ -1,0 +1,34 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  useLocation,
+  useHistory,
+} from 'react-router';
+
+const useHashTab = (...hashes: readonly string[]) => {
+  const hashesRef = useRef(hashes).current;
+
+  const { hash } = useLocation();
+  const { replace } = useHistory();
+  const cleanHash = useMemo(() => hash[0] === '#' ? hash.slice(1) : hash, [hash]);
+  const [index, setIndex] = useState<number>(
+    () => Math.max(hashesRef.indexOf(cleanHash), 0))
+
+  useEffect(() => {
+    const hashIndex = hashesRef.indexOf(cleanHash);
+    if (hashIndex !== -1) {
+      setIndex(hashIndex);
+    }
+  }, [hashesRef, cleanHash]);
+  useEffect(() => {
+    replace({ hash: hashesRef[index] });
+  }, [replace, hashesRef, index]);
+
+  return [index, setIndex] as const;
+};
+
+export default useHashTab;

--- a/src/dashboard/src/pages/Cluster/index.tsx
+++ b/src/dashboard/src/pages/Cluster/index.tsx
@@ -4,8 +4,7 @@ import {
   FunctionComponent,
   useCallback,
   useContext,
-  useEffect,
-  useState
+  useEffect
 } from 'react';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
@@ -25,6 +24,7 @@ import { useSnackbar } from 'notistack';
 
 import TeamContext from '../../contexts/Team';
 import Loading from '../../components/Loading';
+import useHashTab from '../../hooks/useHashTab';
 
 import { QueryProvider } from './QueryContext';
 import Users from './Users';
@@ -52,7 +52,7 @@ interface TabViewProps {
 }
 
 const TabView: FunctionComponent<TabViewProps> = ({ data }) => {
-  const [index, setIndex] = useState(0);
+  const [index, setIndex] = useHashTab('users', 'workers', 'storages', 'pods', 'metrics');
 
   const handleChange = useCallback((event: ChangeEvent<{}>, value: number) => {
     setIndex(value);

--- a/src/dashboard/src/pages/Job/Tabs/index.tsx
+++ b/src/dashboard/src/pages/Job/Tabs/index.tsx
@@ -3,8 +3,7 @@ import {
   FunctionComponent,
   ChangeEvent,
   useCallback,
-  useMemo,
-  useState
+  useMemo
 } from 'react';
 import {
   Paper,
@@ -12,6 +11,8 @@ import {
   Tab
 } from '@material-ui/core';
 import SwipeableViews from 'react-swipeable-views';
+
+import useHashTab from '../../../hooks/useHashTab';
 
 import Brief from './Brief';
 import Endpoints from './Endpoints';
@@ -23,7 +24,10 @@ const JobTabs: FunctionComponent<{ manageable: boolean }> = ({ manageable }) => 
     ? [Brief, Endpoints, Metrics, Console]
     : [Brief, Metrics, Console]
   , [manageable]);
-  const [index, setIndex] = useState(0);
+  const [index, setIndex] = useHashTab(
+    ...components.map(
+      Component =>
+        String(Component.displayName || Component.name).toLowerCase()));
   const onChange = useCallback((event: ChangeEvent<{}>, value: any) => {
     setIndex(value as number);
   }, [setIndex]);

--- a/src/dashboard/src/pages/Jobs/index.tsx
+++ b/src/dashboard/src/pages/Jobs/index.tsx
@@ -8,7 +8,8 @@ import {
 } from 'react';
 import {
   useHistory,
-  useParams
+  useLocation,
+  useParams,
 } from 'react-router-dom';
 import {
   Container,
@@ -79,6 +80,7 @@ const Jobs: FunctionComponent = () => {
   const { clusters } = useContext(ClustersContext);
 
   const history = useHistory();
+  const { hash } = useLocation();
   const { clusterId } = useParams<RouteParams>();
 
   const cluster = useMemo(() => {
@@ -86,8 +88,8 @@ const Jobs: FunctionComponent = () => {
   }, [clusters, clusterId]);
 
   const onClusterChange = useCallback((cluster: any) => {
-    history.replace(`/jobs/${cluster.id}`)
-  }, [history]);
+    history.replace({ pathname: `../${cluster.id}/`, hash });
+  }, [history, hash]);
 
   return (
     <Container fixed maxWidth="xl">

--- a/src/dashboard/src/pages/Jobs/index.tsx
+++ b/src/dashboard/src/pages/Jobs/index.tsx
@@ -4,8 +4,7 @@ import {
   FunctionComponent,
   useCallback,
   useContext,
-  useMemo,
-  useState
+  useMemo
 } from 'react';
 import {
   useHistory,
@@ -26,6 +25,7 @@ import ClustersContext from '../../contexts/Clusters';
 import ClusterSelector from '../../components/ClusterSelector';
 
 import Loading from '../../components/Loading';
+import useHashTab from '../../hooks/useHashTab';
 import ClusterContext from './ClusterContext';
 import MyJobs from './MyJobs';
 import AllJobs from './AllJobs';
@@ -35,7 +35,7 @@ interface RouteParams {
 }
 
 const TabView: FunctionComponent = () => {
-  const [index, setIndex] = useState(0);
+  const [index, setIndex] = useHashTab('my', 'all');
   const onChange = useCallback((event: ChangeEvent<{}>, value: any) => {
     setIndex(value as number);
   }, [setIndex]);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2500247/84757602-ed85b580-aff6-11ea-9c24-190a30f8c9b4.png)

This PR adds specific sharable URLs to each tab of

- Jobs List
- Job Details
- Cluster Details

Also, fixes a bug of tab reset when switching cluster in jobs list.