### PR TITLE
Dashboard: open samba folder with a click

### DIFF
--- a/src/dashboard/src/pages/Home/ClusterCard/DirectoryContent.tsx
+++ b/src/dashboard/src/pages/Home/ClusterCard/DirectoryContent.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
 } from '@material-ui/core';
 import {
-  FileCopyRounded,
+  OpenInNew,
 } from '@material-ui/icons';
 
 import copy from 'clipboard-copy';
@@ -37,7 +37,11 @@ const CopyableTextField: FunctionComponent<CopyableTextFieldProps> = ({ label, v
       input.current.select();
     }
   }, [input]);
-  const handleClick = React.useCallback(() => {
+  const handleClick = useCallback(() => {
+    const iframe = window.document.createElement('IFRAME')
+    iframe.setAttribute('src', `browse:${value}`)
+    window.document.documentElement.appendChild(iframe)
+    setTimeout(() => window.document.documentElement.removeChild(iframe), 100)
     copy(value);
     enqueueSnackbar('Successfully copied', { variant: 'success' });
   }, [value, enqueueSnackbar]);
@@ -57,7 +61,7 @@ const CopyableTextField: FunctionComponent<CopyableTextFieldProps> = ({ label, v
           <InputAdornment position="end">
             <Tooltip title="Copy" placement="right">
               <IconButton onClick={handleClick}>
-                <FileCopyRounded/>
+                <OpenInNew/>
               </IconButton>
             </Tooltip>
           </InputAdornment>

--- a/src/dashboard/src/pages/Home/ClusterCard/DirectoryContent.tsx
+++ b/src/dashboard/src/pages/Home/ClusterCard/DirectoryContent.tsx
@@ -59,7 +59,7 @@ const CopyableTextField: FunctionComponent<CopyableTextFieldProps> = ({ label, v
         readOnly: true,
         endAdornment: (
           <InputAdornment position="end">
-            <Tooltip title="Copy" placement="right">
+            <Tooltip title="Open or Copy" placement="right">
               <IconButton onClick={handleClick}>
                 <OpenInNew/>
               </IconButton>


### PR DESCRIPTION
## Usage

1. Download [this PowerShell script](https://github.com/Gerhut/browse/blob/master/browse.ps1) and put it in a stable location.
2. Run the script once to register the `browse:` URL protocol to open the rest part in `explorer.exe`. It will automatically enter Administrator mode if not.
3. Now it is able to open the samba directory in explorer with a click of the button next to the working directory, which navigates to `browse:file://samba/` -> `explorer.exe file://samba/`.

![image](https://user-images.githubusercontent.com/2500247/84912827-6b77b880-b0ec-11ea-88b3-357f817d71a3.png)
