### PR TITLE
support vc edit vc metadata

### DIFF
--- a/src/ClusterManager/job_manager.py
+++ b/src/ClusterManager/job_manager.py
@@ -654,8 +654,8 @@ def mark_schedulable_non_preemptable_jobs(jobs_info, cluster_schedulable,
                 cluster_schedulable -= job_resource
                 job_info["allowed"] = True
                 logger.info(
-                    "Allow non-preemptable job %s from %s to run, job resource %s",
-                    job_id, vc_name, job_resource)
+                    "Allow non-preemptable job %s from %s to run, job resource %s, policy %s",
+                    job_id, vc_name, job_resource, scheduling_policy)
             elif stop_schedulings.get(vc_name) is None:
                 reason = "resource not enough, required %s, vc schedulable %s, cluster schedulable %s" % (
                     job_resource, vc_schedulable, cluster_schedulable)
@@ -663,8 +663,9 @@ def mark_schedulable_non_preemptable_jobs(jobs_info, cluster_schedulable,
                 logger.info(
                     "Disallow non-preemptable job %s from vc %s to run."
                     "resource not enough, required %s. "
-                    "cluster schedulable %s, vc schedulables %s", job_id,
-                    vc_name, job_resource, cluster_schedulable, vc_schedulable)
+                    "cluster schedulable %s, vc schedulables %s, policy %s",
+                    job_id, vc_name, job_resource, cluster_schedulable,
+                    vc_schedulable, scheduling_policy)
                 # prevent later non preemptable job from scheduling
                 stop_schedulings[vc_name] = job_info
             else:
@@ -685,14 +686,14 @@ def mark_schedulable_non_preemptable_jobs(jobs_info, cluster_schedulable,
                 cluster_schedulable -= job_resource
                 job_info["allowed"] = True
                 logger.info(
-                    "Allow non-preemptable job %s from %s to run, job resource %s",
-                    job_id, vc_name, job_resource)
+                    "Allow non-preemptable job %s from %s to run, job resource %s, policy %s",
+                    job_id, vc_name, job_resource, scheduling_policy)
             else:
                 logger.info(
                     "Disallow non-preemptable job %s from vc %s to run."
-                    "Requiring %s, vc_schedulable %s, cluster_schedulable %s",
+                    "Requiring %s, vc_schedulable %s, cluster_schedulable %s, policy %s",
                     job_id, vc_name, job_resource, vc_schedulable,
-                    cluster_schedulable)
+                    cluster_schedulable, scheduling_policy)
 
 
 def mark_schedulable_preemptable_jobs(jobs_info, cluster_schedulable):
@@ -772,7 +773,8 @@ def take_job_actions(data_handler, redis_conn, launcher, jobs):
         # Support following scheduling_policy:
         # * FIFO: This policy allows big job blocks small jobs, might cause low GPU utils
         # * RF: Runnable first: sort according to submission time and priority, submit jobs not exceeding quota
-        vc_scheduling_policies[vc["vcName"]] = walk_json(vc,
+        metadata = json.loads(vc["metadata"])
+        vc_scheduling_policies[vc["vcName"]] = walk_json(metadata,
                                                          "admin",
                                                          "scheduling_policy",
                                                          default="RF")

--- a/src/docker-images/RestfulAPI/Dockerfile
+++ b/src/docker-images/RestfulAPI/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.2/b
         mv kubectl /usr/local/bin
 
 RUN pip3 install setuptools wheel
-RUN pip3 install mysql-connector-python flask flask-restful requests tzlocal DBUtils mysqlclient
+RUN pip3 install mysql-connector-python flask flask-restful flask-cors requests tzlocal DBUtils mysqlclient
 
 RUN usermod -a -G sudo www-data
 RUN echo "\nwww-data ALL=(ALL) NOPASSWD:ALL\n" > /etc/sudoers

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -964,7 +964,7 @@ def get_vc_meta(username, vc_name):
                 "error":
                     "%s do not have permission to query meta from vc %s" %
                     (username, vc_name)
-            }, 401
+            }, 403
     except Exception as e:
         logger.exception("Exception in get_vc_meta VC %s for user %s", vc_name,
                          username)
@@ -983,6 +983,7 @@ def patch_vc_meta(username, vc_name, vc_meta):
                 return {"error": "empty vc_meta"}, 400
             with DataHandler() as data_handler:
                 meta = json.loads(data_handler.GetVC(vc_name)["metadata"])
+                origin = copy.deepcopy(meta)
                 if meta.get("admin") is None:
                     meta["admin"] = {}
 
@@ -1005,8 +1006,9 @@ def patch_vc_meta(username, vc_name, vc_meta):
                             job_max_time_second) != int:
                         return {
                             "error":
-                                "job_max_time_second should be int, got %s" %
-                                (job_max_time_second)
+                                "job_max_time_second should be int, got %s with type %s"
+                                %
+                                (job_max_time_second, type(job_max_time_second))
                         }, 400
                     else:
                         meta["admin"][
@@ -1018,8 +1020,8 @@ def patch_vc_meta(username, vc_name, vc_meta):
                             interactive_limit) != int:
                         return {
                             "error":
-                                "interactive_limit should be int, got %s" %
-                                (interactive_limit)
+                                "interactive_limit should be int, got %s with type %s"
+                                % (interactive_limit, type(interactive_limit))
                         }, 400
                     else:
                         meta["admin"]["interactive_limit"] = interactive_limit
@@ -1029,8 +1031,9 @@ def patch_vc_meta(username, vc_name, vc_meta):
                         "error": "unknown key(s) %s" % (str(vc_meta.keys()))
                     }, 400
                 else:
-                    logger.info("%s update vc meta for %s to %s", username,
-                                vc_name, json.dumps(meta))
+                    logger.info("%s update vc meta for %s from %s to %s",
+                                username, vc_name, json.dumps(origin),
+                                json.dumps(meta))
                     data_handler.UpdateVCMeta(vc_name, json.dumps(meta))
                     return {"error": None}, 200
         else:
@@ -1038,7 +1041,7 @@ def patch_vc_meta(username, vc_name, vc_meta):
                 "error":
                     "%s do not have permission to query meta from vc %s" %
                     (username, vc_name)
-            }, 401
+            }, 403
     except Exception as e:
         logger.exception("Exception in get_vc_meta VC %s for user %s", vc_name,
                          username)

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -944,6 +944,112 @@ def get_vc(username, vc_name):
     return ret
 
 
+def get_vc_meta(username, vc_name):
+    try:
+        if has_access(username, VC, vc_name, ADMIN):
+            result = {}
+            with DataHandler() as data_handler:
+                meta = json.loads(data_handler.GetVC(vc_name)["metadata"])
+                result["scheduling_policy"] = walk_json(meta,
+                                                        "admin",
+                                                        "scheduling_policy",
+                                                        default="RF")
+                result["job_max_time_second"] = walk_json(
+                    meta, "admin", "job_max_time_second")
+                result["interactive_limit"] = walk_json(meta, "admin",
+                                                        "interactive_limit")
+                return result, 200
+        else:
+            return {
+                "error":
+                    "%s do not have permission to query meta from vc %s" %
+                    (username, vc_name)
+            }, 401
+    except Exception as e:
+        logger.exception("Exception in get_vc_meta VC %s for user %s", vc_name,
+                         username)
+
+        return {
+            "error":
+                "failed to get meta from vc %s, exception %s" %
+                (vc_name, str(e))
+        }, 500
+
+
+def patch_vc_meta(username, vc_name, vc_meta):
+    try:
+        if has_access(username, VC, vc_name, ADMIN):
+            if vc_meta is None or len(vc_meta) == 0:
+                return {"error": "empty vc_meta"}, 400
+            with DataHandler() as data_handler:
+                meta = json.loads(data_handler.GetVC(vc_name)["metadata"])
+                if meta.get("admin") is None:
+                    meta["admin"] = {}
+
+                if "scheduling_policy" in vc_meta:
+                    scheduling_policy = vc_meta.pop("scheduling_policy")
+                    if scheduling_policy is not None and scheduling_policy not in {
+                            "RF", "FIFO"
+                    }:
+                        return {
+                            "error":
+                                "unknown scheduling_policy %s" %
+                                (scheduling_policy)
+                        }, 400
+                    else:
+                        meta["admin"]["scheduling_policy"] = scheduling_policy
+
+                if "job_max_time_second" in vc_meta:
+                    job_max_time_second = vc_meta.pop("job_max_time_second")
+                    if job_max_time_second is not None and type(
+                            job_max_time_second) != int:
+                        return {
+                            "error":
+                                "job_max_time_second should be int, got %s" %
+                                (job_max_time_second)
+                        }, 400
+                    else:
+                        meta["admin"][
+                            "job_max_time_second"] = job_max_time_second
+
+                if "interactive_limit" in vc_meta:
+                    interactive_limit = vc_meta.pop("interactive_limit")
+                    if interactive_limit is not None and type(
+                            interactive_limit) != int:
+                        return {
+                            "error":
+                                "interactive_limit should be int, got %s" %
+                                (interactive_limit)
+                        }, 400
+                    else:
+                        meta["admin"]["interactive_limit"] = interactive_limit
+
+                if len(vc_meta) > 0:
+                    return {
+                        "error": "unknown key(s) %s" % (str(vc_meta.keys()))
+                    }, 400
+                else:
+                    logger.info("%s update vc meta for %s to %s", username,
+                                vc_name, json.dumps(meta))
+                    data_handler.UpdateVCMeta(vc_name, json.dumps(meta))
+                    return {"error": None}, 200
+        else:
+            return {
+                "error":
+                    "%s do not have permission to query meta from vc %s" %
+                    (username, vc_name)
+            }, 401
+    except Exception as e:
+        logger.exception("Exception in get_vc_meta VC %s for user %s", vc_name,
+                         username)
+
+        return {
+            "error":
+                "failed to get meta from vc %s, exception %s" %
+                (vc_name, str(e))
+        }, 500
+
+
 def get_node_status_simplified(node_status):
     if node_status is None:
         return None

--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -448,6 +448,19 @@ class DataHandler(object):
             return False
 
     @record
+    def UpdateVCMeta(self, vc_name, metadata):
+        try:
+            sql = "UPDATE " + self.vctablename + " SET metadata = %s WHERE vcName = %s"
+            cursor = self.conn.cursor()
+            cursor.execute(sql, (metadata, vc_name))
+            self.conn.commit()
+            cursor.close()
+            return True
+        except Exception as e:
+            logger.exception('Exception: %s', str(e))
+            return False
+
+    @record
     def GetIdentityInfo(self, identityName):
         cursor = self.conn.cursor()
         query = """SELECT `identityName`,`uid`,`gid`,`groups`,`public_key`,`private_key`


### PR DESCRIPTION
Add two restful api:

* GET `VCMeta`
* POST `VCMeta`

When posting to change, can submit partial meta, and null value with a key will make it null, for example, post `{"job_max_time_second": null}` will turn off this in this vc.

Restful api also validate the meta:
* `job_max_time_second` should be null or int
* `interactive_limit` should be null or int
* `scheduling_policy` should be "RF" or "FIFO"

Ref #1147 #1157 #1177 

Fixed a bug in #1177 .

Also introduce `--dangerous` to integration test, for test case requiring change vc meta, will rollback to old meta, do not test these cases on production clusters.