### PR TITLE
add a init program

### DIFF
--- a/src/docker-images/init-container/Dockerfile
+++ b/src/docker-images/init-container/Dockerfile
@@ -21,6 +21,10 @@ WORKDIR /gpu_topo_build
 COPY gpu_topo.cpp /gpu_topo_build
 RUN g++ -o gpu_topo gpu_topo.cpp
 
+FROM golang:1.12.6-alpine as go-builder
+COPY runtime /runtime
+RUN go build -o /runtime/init /runtime/init.go
+
 FROM python:3.8.0-alpine3.10
 
 WORKDIR /dlts-init
@@ -30,6 +34,7 @@ RUN pip3 install -r /dlts-init/requirements.txt
 
 COPY --from=builder /ssh_build/root /dlts-init/ssh_build
 COPY --from=builder /gpu_topo_build/gpu_topo /dlts-init/gpu_topo
+COPY --from=go-builder /runtime/init /dlts-init/init
 
 COPY install.sh init.sh /dlts-init/
 COPY ssh_config /dlts-init/ssh_config

--- a/src/docker-images/init-container/init.sh
+++ b/src/docker-images/init-container/init.sh
@@ -9,4 +9,5 @@ cp -r /dlts-init/ssh_config $DLTS_RUNTIME_DIR
 cp /dlts-init/gpu_topo $DLTS_RUNTIME_DIR
 cp -r /dlts-init/install.sh $DLTS_RUNTIME_DIR
 cp -r /dlts-init/runtime $DLTS_RUNTIME_DIR
+cp /dlts-init/init $DLTS_RUNTIME_DIR
 python3 /dlts-init/runtime/sync.py

--- a/src/docker-images/init-container/install.sh
+++ b/src/docker-images/init-container/install.sh
@@ -16,3 +16,5 @@ ssh-keygen -t rsa -f /usr/etc/ssh_host_rsa_key -N "" > /dev/null
 ssh-keygen -t ecdsa -f /usr/etc/ssh_host_ecdsa_key -N "" > /dev/null
 
 cp $cwd/gpu_topo /usr/bin
+mkdir -p /usr/local/bin
+cp $cwd/init /usr/local/bin

--- a/src/docker-images/init-container/runtime/init.go
+++ b/src/docker-images/init-container/runtime/init.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Fprintf(os.Stderr, "[init] Usage: %s cmd to run\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	stopCh := make(chan bool, 1)
+	go waitOrphans(stopCh)
+
+	err := run(os.Args[1:]...)
+
+	stopCh <- true
+
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			now := time.Now()
+			fmt.Fprintf(os.Stderr, "[init] %v exit code: %d\n", now.UTC(), status.ExitStatus())
+			os.Exit(status.ExitStatus())
+		} else {
+			now := time.Now()
+			fmt.Fprintf(os.Stderr, "[init] %v unknown exiterr %v\n", now.UTC(), exiterr)
+			os.Exit(2)
+		}
+	} else if err == nil {
+		now := time.Now()
+		fmt.Fprintf(os.Stderr, "[init] %v success\n", now.UTC())
+		os.Exit(0)
+	} else {
+		fmt.Fprintf(os.Stderr, "[init] failed to run %v with error %v\n", os.Args[1:], err)
+		os.Exit(2)
+	}
+}
+
+func waitOrphans(stopCh chan bool) {
+	for {
+		var status syscall.WaitStatus
+
+		pid, _ := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+
+		if pid <= 0 {
+			// no orphan
+			time.Sleep(1 * time.Second)
+		} else {
+			// reap orphan
+			continue
+		}
+
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+	}
+}
+
+func run(command ...string) error {
+	sigs := make(chan os.Signal, 1)
+	defer close(sigs)
+	signal.Notify(sigs)
+	defer signal.Reset()
+
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	go func() {
+		for sig := range sigs {
+			if sig != syscall.SIGCHLD {
+				fmt.Fprintf(os.Stderr, "[init] received signal %d\n", sig)
+				syscall.Kill(-cmd.Process.Pid, sig.(syscall.Signal))
+			}
+		}
+	}()
+
+	return cmd.Run()
+}

--- a/src/init-scripts/bootstrap.sh
+++ b/src/init-scripts/bootstrap.sh
@@ -39,15 +39,9 @@ set +e
 # Execute user's command for the job
 if [ "$DLTS_ROLE_NAME" = "worker" ];
 then
-    runuser -l ${DLTS_USER_NAME} -c "sleep infinity"
+    exec /usr/local/bin/init runuser -l ${DLTS_USER_NAME} -c "sleep infinity"
 else
     printenv DLTS_LAUNCH_CMD > /dlts-runtime/status/job_command.sh
     chmod +x /dlts-runtime/status/job_command.sh
-    runuser -s /bin/bash -l ${DLTS_USER_NAME} -c /dlts-runtime/status/job_command.sh
-    # Save exit code
-    EXIT_CODE=$?
-    echo  `date` ": ${EXIT_CODE}"
+    exec /usr/local/bin/init runuser -s /bin/bash -l ${DLTS_USER_NAME} -c /dlts-runtime/status/job_command.sh
 fi
-
-# exit
-exit ${EXIT_CODE}


### PR DESCRIPTION
Some benefit of init program:

* reap zombie processes
* capture signal and print out for debug
* capture exit signal and broadcast to user's process, allow graceful exit, also improve exit speed

compiled init program has 2.2MB, and takes 5s to terminate the pod instead of 30s.

Before this, integration test takes 3m56s:
```
real    3m56.608s
user    0m11.417s
sys     0m2.814s
```

After this, takes 2m35s:
```
real    2m35.153s
user    0m10.407s
sys     0m2.847s
```