### PR TITLE
Add OUT_OF_POOL_UNTRACKED state

### DIFF
--- a/src/ClusterBootstrap/ctl.py
+++ b/src/ClusterBootstrap/ctl.py
@@ -329,8 +329,8 @@ def cordon(config, args):
             admin_name = yaml.safe_load(f)["admin_name"]
     else:
         admin_name = args.admin
-        assert admin_name is not None and admin_name, "specify admin_name by"\
-        "--admin or in ~/.dlts-admin.yaml"
+        assert admin_name is not None and admin_name, "specify admin_name by " \
+            "--admin or in ~/.dlts-admin.yaml"
     now = datetime.datetime.now(pytz.timezone("UTC"))
     timestr = now.strftime("%Y/%m/%d %H:%M:%S %Z")
     node = args.nargs[0]
@@ -341,18 +341,23 @@ def cordon(config, args):
     run_kubectl(config, args, [k8s_cmd])
     run_kubectl(config, args, ["cordon {}".format(node)])
 
+    if args.repair_cycle:
+        k8s_cmd = "annotate node {} --overwrite REPAIR_CYCLE=True".format(node)
+        run_kubectl(config, args, [k8s_cmd])
+
 
 def uncordon(config, args):
     node = args.nargs[0]
     query_cmd = "get nodes {} -o=jsonpath=\'{{.metadata.annotations.cordon-note}}\'".format(node)
     output = run_kubectl(config, args, [query_cmd], need_output=True)
     if output and not args.force:
-        print("node annotated, if you are sure that you want to uncordon it, "\
-            "please specify --force or use `{} kubectl cordon <node>` to"\
-            " cordon".format(__file__))
+        print("node annotated, if you are sure that you want to uncordon it, " \
+              "please specify --force or use `{} kubectl cordon <node>` to " \
+              "cordon".format(__file__))
     else:
         run_kubectl(config, args, ["uncordon {}".format(node)])
         run_kubectl(config, args, ["annotate node {} cordon-note-".format(node)])
+        run_kubectl(config, args, ["annotate node {} REPAIR_CYCLE-".format(node)])
 
 
 def run_command(args, command):
@@ -440,6 +445,9 @@ if __name__ == '__main__':
                         action="store_true")
     parser.add_argument("--admin",
                         help="Name of admin that execute this script")
+    parser.add_argument("-rc", "--repair_cycle",
+                        help="Whether to put a node into repair cycle with cordon command",
+                        action="store_true")
     parser.add_argument("command",
                         help="See above for the list of valid command")
     parser.add_argument('nargs', nargs=argparse.REMAINDER,

--- a/src/ClusterBootstrap/ctl.py
+++ b/src/ClusterBootstrap/ctl.py
@@ -354,6 +354,7 @@ def uncordon(config, args):
         run_kubectl(config, args, ["uncordon {}".format(node)])
         run_kubectl(config, args, ["annotate node {} cordon-note-".format(node)])
         run_kubectl(config, args, ["annotate node {} REPAIR_CYCLE-".format(node)])
+        run_kubectl(config, args, ["label node {} REPAIR_STATE-".format(node)])
 
 
 def start_repair(config, args):

--- a/src/ClusterBootstrap/ctl.py
+++ b/src/ClusterBootstrap/ctl.py
@@ -353,8 +353,11 @@ def uncordon(config, args):
     else:
         run_kubectl(config, args, ["uncordon {}".format(node)])
         run_kubectl(config, args, ["annotate node {} cordon-note-".format(node)])
-        run_kubectl(config, args, ["annotate node {} REPAIR_CYCLE-".format(node)])
-        run_kubectl(config, args, ["label node {} REPAIR_STATE-".format(node)])
+        run_kubectl(
+            config, args, ["annotate node {} REPAIR_CYCLE-".format(node)])
+        run_kubectl(
+            config, args,
+            ["label node {} --overwrite REPAIR_STATE=IN_SERVICE".format(node)])
 
 
 def start_repair(config, args):

--- a/src/RepairManager/src/constant.py
+++ b/src/RepairManager/src/constant.py
@@ -9,3 +9,8 @@ REPAIR_STATE_LAST_UPDATE_TIME = "REPAIR_STATE_LAST_UPDATE_TIME"
 
 # Annotation key for unhealthy rules
 REPAIR_UNHEALTHY_RULES = "REPAIR_UNHEALTHY_RULES"
+
+# Annotation key for whether the node is in repair cycle.
+# An unschedulable node that is not in repair cycle can be manually repaired
+# by administrator without repair cycle interruption.
+REPAIR_CYCLE = "REPAIR_CYCLE"

--- a/src/RepairManager/src/repairmanager.py
+++ b/src/RepairManager/src/repairmanager.py
@@ -175,10 +175,16 @@ class RepairManager(object):
         the node is validated (corrected if necessary), False otherwise.
         """
         if node.state != State.IN_SERVICE and node.unschedulable is False:
-            if self.from_any_to_out_of_pool(node):
-                return True
+            if node.repair_cycle is True:
+                if self.from_any_to_out_of_pool(node):
+                    return True
+                else:
+                    return False
             else:
-                return False
+                if self.from_any_to_out_of_pool_untracked(node):
+                    return True
+                else:
+                    return False
         return True
 
     def update(self, node):
@@ -378,7 +384,7 @@ class RepairManager(object):
         annotations = {
             REPAIR_STATE_LAST_UPDATE_TIME:
                 str(datetime.datetime.timestamp(datetime.datetime.utcnow())),
-            REPAIR_CYCLE: "False",
+            REPAIR_CYCLE: None,
         }
         if self.patch(node, unschedulable=True, labels=labels,
                       annotations=annotations):
@@ -395,7 +401,7 @@ class RepairManager(object):
         annotations = {
             REPAIR_STATE_LAST_UPDATE_TIME:
                 str(datetime.datetime.timestamp(datetime.datetime.utcnow())),
-            REPAIR_CYCLE: "False",
+            REPAIR_CYCLE: None,
         }
         if self.patch(node, unschedulable=False, labels=labels,
                       annotations=annotations):
@@ -486,7 +492,7 @@ class RepairManager(object):
             REPAIR_STATE_LAST_UPDATE_TIME:
                 str(datetime.datetime.timestamp(datetime.datetime.utcnow())),
             REPAIR_UNHEALTHY_RULES: None,
-            REPAIR_CYCLE: "False",
+            REPAIR_CYCLE: None,
         }
         if self.patch(node, unschedulable=False, labels=labels,
                       annotations=annotations):

--- a/src/RepairManager/src/rule.py
+++ b/src/RepairManager/src/rule.py
@@ -199,7 +199,8 @@ class UnschedulableRule(Rule):
 
     def check_health_impl(self, node, stat):
         # Unhealthy if node is IN_SERVICE but marked as unschedulable
-        if node.state == State.IN_SERVICE and node.unschedulable is True:
+        if node.state == State.IN_SERVICE and node.unschedulable is True and \
+                node.repair_cycle is True:
             return False
         else:
             return True

--- a/src/RepairManager/test/test_repairmanager.py
+++ b/src/RepairManager/test/test_repairmanager.py
@@ -81,7 +81,8 @@ class TestRepairManager(unittest.TestCase):
                          4,
                          4,
                          State.IN_SERVICE,
-                         [])
+                         [],
+                         repair_cycle=False)
 
     def test_validate(self):
         self.repairmanager.dry_run = False
@@ -134,30 +135,35 @@ class TestRepairManager(unittest.TestCase):
         self.rules[0].health = True
         self.repairmanager.update(self.node)
         self.assertEqual(State.IN_SERVICE, self.node.state)
-        self.assertEqual(False, self.node.unschedulable)
+        self.assertFalse(self.node.unschedulable)
+        self.assertFalse(self.node.repair_cycle)
         self.assertEqual([], self.node.unhealthy_rules)
 
         self.rules[0].health = False
         self.repairmanager.update(self.node)
         self.assertEqual(State.OUT_OF_POOL, self.node.state)
-        self.assertEqual(True, self.node.unschedulable)
+        self.assertTrue(self.node.unschedulable)
+        self.assertTrue(self.node.repair_cycle)
         self.assertEqual(self.rules, self.node.unhealthy_rules)
 
         # OUT_OF_POOL -> READY_FOR_REPAIR
         self.rules[0].prepared = False
         self.repairmanager.update(self.node)
         self.assertEqual(State.OUT_OF_POOL, self.node.state)
-        self.assertEqual(True, self.node.unschedulable)
+        self.assertTrue(self.node.unschedulable)
+        self.assertTrue(self.node.repair_cycle)
 
         self.rules[0].prepared = True
         self.repairmanager.update(self.node)
         self.assertEqual(State.READY_FOR_REPAIR, self.node.state)
-        self.assertEqual(True, self.node.unschedulable)
+        self.assertTrue(self.node.unschedulable)
+        self.assertTrue(self.node.repair_cycle)
 
         # READY_FOR_REPAIR -> IN_REPAIR
         self.repairmanager.update(self.node)
         self.assertEqual(State.READY_FOR_REPAIR, self.node.state)
-        self.assertEqual(True, self.node.unschedulable)
+        self.assertTrue(self.node.unschedulable)
+        self.assertTrue(self.node.repair_cycle)
 
         # Agent becomes alive
         self.server.start()
@@ -165,12 +171,14 @@ class TestRepairManager(unittest.TestCase):
 
         self.repairmanager.update(self.node)
         self.assertEqual(State.IN_REPAIR, self.node.state)
-        self.assertEqual(True, self.node.unschedulable)
+        self.assertTrue(self.node.unschedulable)
+        self.assertTrue(self.node.repair_cycle)
 
         # IN_REPAIR -> IN_REPAIR
         self.repairmanager.update(self.node)
         self.assertEqual(State.IN_REPAIR, self.node.state)
-        self.assertEqual(True, self.node.unschedulable)
+        self.assertTrue(self.node.unschedulable)
+        self.assertTrue(self.node.repair_cycle)
 
         # Agent start to consume repair signal
         self.agent.repair_handler.start()
@@ -187,6 +195,7 @@ class TestRepairManager(unittest.TestCase):
 
         # IN_REPAIR -> AFTER_REPAIR
         self.assertTrue(wait_for_repair())
+        self.assertTrue(self.node.repair_cycle)
 
         node = copy.deepcopy(self.node)
 
@@ -198,7 +207,8 @@ class TestRepairManager(unittest.TestCase):
         self.rules[0].health = False
         self.repairmanager.update(node)
         self.assertEqual(State.AFTER_REPAIR, node.state)
-        self.assertEqual(True, node.unschedulable)
+        self.assertTrue(node.unschedulable)
+        self.assertTrue(node.repair_cycle)
         self.assertEqual(self.rules, node.unhealthy_rules)
 
         # AFTER_REPAIR -> OUT_OF_POOL
@@ -206,15 +216,55 @@ class TestRepairManager(unittest.TestCase):
         self.repairmanager.grace_period = -1  # Make sure it's after grace period
         self.repairmanager.update(node)
         self.assertEqual(State.OUT_OF_POOL, node.state)
-        self.assertEqual(True, node.unschedulable)
+        self.assertTrue(node.unschedulable)
+        self.assertTrue(node.repair_cycle)
         self.assertEqual(self.rules, node.unhealthy_rules)
 
         # AFTER_REPAIR -> IN_SERVICE
         self.rules[0].health = True
         self.repairmanager.update(self.node)
         self.assertEqual(State.IN_SERVICE, self.node.state)
-        self.assertEqual(False, self.node.unschedulable)
+        self.assertFalse(self.node.unschedulable)
+        self.assertFalse(self.node.repair_cycle)
         self.assertEqual([], self.node.unhealthy_rules)
+
+    def test_repair_cycle_update_with_out_of_pool_untracked(self):
+        # IN_SERVICE -> OUT_OF_POOL_UNTRACKED
+        # OUT_OF_POOL -> OUT_OF_POOL_UNTRACKED
+        # READY_FOR_REPAIR -> OUT_OF_POOL_UNTRACKED
+        # IN_REPAIR -> OUT_OF_POOL_UNTRACKED
+        # AFTER_REPAIR -> OUT_OF_POOL_UNTRACKED
+        states = [State.IN_SERVICE, State.OUT_OF_POOL, State.READY_FOR_REPAIR,
+                  State.IN_REPAIR, State.AFTER_REPAIR]
+        for state in states:
+            self.node.state = state
+            self.node.unschedulable = True
+            self.node.repair_cycle = False
+            self.repairmanager.update(self.node)
+            self.assertEqual(State.OUT_OF_POOL_UNTRACKED, self.node.state)
+            self.assertTrue(self.node.unschedulable)
+            self.assertFalse(self.node.repair_cycle)
+
+        # OUT_OF_POOL_UNTRACKED -> IN_SERVICE
+        self.node.state = State.OUT_OF_POOL_UNTRACKED
+        self.node.unschedulable = False
+        self.node.repair_cycle = False
+        self.repairmanager.update(self.node)
+        self.assertEqual(State.IN_SERVICE, self.node.state)
+        self.assertFalse(self.node.unschedulable)
+        self.assertFalse(self.node.repair_cycle)
+
+        # OUT_OF_POOL_UNTRACKED -> OUT_OF_POOL
+        self.node.state = State.OUT_OF_POOL_UNTRACKED
+        self.node.unschedulable = True
+        self.node.repair_cycle = True
+        self.node.unhealthy_rules = []
+        self.repairmanager.update(self.node)
+        self.assertEqual(State.OUT_OF_POOL, self.node.state)
+        self.assertTrue(self.node.unschedulable)
+        self.assertTrue(self.node.repair_cycle)
+        self.assertEqual(1, len(self.node.unhealthy_rules))
+        self.assertEqual("UnschedulableRule", self.node.unhealthy_rules[0].name)
 
     def test_check_health(self):
         # Node is healthy

--- a/src/RepairManager/test/test_rule.py
+++ b/src/RepairManager/test/test_rule.py
@@ -106,8 +106,15 @@ class TestUnschedulableRule(TestRule):
         self.rule = UnschedulableRule()
 
     def test_check_health(self):
-        # Node is marked as unschedulable
+        # Node is marked as unschedulable but not in repair cycle.
+        # Wait for admin to do manual repair
         self.node.unschedulable = True
+        self.node.repair_cycle = False
+        self.assertTrue(self.rule.check_health(self.node))
+        self.assertTrue(self.rule.check_health(self.node, stat="current"))
+
+        # Node is marked as unschedulable and in repair cycle.
+        self.node.repair_cycle = True
         self.assertFalse(self.rule.check_health(self.node))
         self.assertFalse(self.rule.check_health(self.node, stat="current"))
 


### PR DESCRIPTION
TODO 5 in #1182 

Allows a node to be taken out of repair cycle for further investigation by admin:
```
./ctl.py cordon <node_name> # Cordon a node
./ctl.py start-repair <node_name> # Post a repair cycle signal for repairmanager to pick up
./ctl.py cancel-repair <node_name> # Remove the repair cycle signal so that repairmanager will put the node into OUT_OF_POOL_UNTRACKED in the next round.
./ctl.py uncordon <node_name> # Uncordon node and remove repair cycle signal if any
```

![image](https://user-images.githubusercontent.com/5781796/85348032-24ecda00-b4af-11ea-871f-f524653e0c25.png)
