### PR TITLE
Add global team notifications

### DIFF
--- a/src/dashboard/src/Layout/Content.tsx
+++ b/src/dashboard/src/Layout/Content.tsx
@@ -12,6 +12,7 @@ import {
 } from '@material-ui/core';
 
 import LayoutContext from './Context';
+import NotificationBox from './NotificationBox';
 
 const useStyles = makeStyles(theme => createStyles({
   root: ({ drawerOpen }: { drawerOpen: boolean }) => ({
@@ -33,6 +34,7 @@ const Content: FunctionComponent = ({ children }) => {
   return (
     <Box flex={1} py={3} className={styles.root}>
       <Toolbar disableGutters/>
+      <NotificationBox marginTop={-3}/>
       {children}
     </Box>
   );

--- a/src/dashboard/src/Layout/NotificationBox.tsx
+++ b/src/dashboard/src/Layout/NotificationBox.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import {
+  FunctionComponent,
+  useContext,
+  useMemo,
+} from 'react';
+
+import { get } from 'lodash';
+
+import {
+  Box,
+  BoxProps,
+  Divider,
+  Paper,
+  Typography,
+  createStyles,
+  makeStyles,
+} from '@material-ui/core';
+
+import { Info } from '@material-ui/icons';
+
+import ConfigContext from '../contexts/Config';
+import TeamContext from '../contexts/Team';
+
+const usePaperStyle = makeStyles(theme => createStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    // marginBottom: theme.spacing(1),
+    padding: theme.spacing(1),
+  },
+}));
+
+const NotificationBox: FunctionComponent<BoxProps> = (props) => {
+  const { notifications } = useContext(ConfigContext);
+  const { currentTeamId } = useContext(TeamContext);
+
+  const notification = useMemo(() => {
+    return get(notifications, [currentTeamId]);
+  }, [notifications, currentTeamId]);
+
+  const paperStyle = usePaperStyle();
+
+  if (Boolean(notification) === false) return null;
+
+  return (
+    <Box {...props}>
+      <Paper elevation={0} classes={paperStyle}>
+        <Info fontSize="small" color="primary"/>
+        <Typography variant="body2" component={Box} flex={1} paddingLeft={1}>{notification}</Typography>
+      </Paper>
+      <Divider/>
+    </Box>
+  );
+};
+
+export default NotificationBox;

--- a/src/dashboard/src/contexts/Config.tsx
+++ b/src/dashboard/src/contexts/Config.tsx
@@ -4,6 +4,7 @@ interface Context {
   addGroup?: string;
   wiki?: string;
   support?: string;
+  notifications?: { [team: string]: string };
 }
 
 const Context = React.createContext<Context>({});


### PR DESCRIPTION
Add notification to dashboard yaml config:

```yaml
frontend:
  notifications:
    team_id: the quick brown fox jumps over the lazy dog.
```

And it will display in all pages if user is selecting this team:

![image](https://user-images.githubusercontent.com/2500247/85352680-1519d800-b539-11ea-92d1-f2fb2995df0a.png)



