### PR TITLE
add a global db to support public keys management

### DIFF
--- a/src/ClusterManager/test/utils.py
+++ b/src/ClusterManager/test/utils.py
@@ -458,6 +458,38 @@ def update_vc_meta(rest_url, vc_name, username, vc_meta):
     return resp.json()
 
 
+def add_public_key(rest_url, username, key_title, public_key):
+    args = urllib.parse.urlencode({
+        "username": username,
+        "key_title": key_title,
+    })
+    url = urllib.parse.urljoin(rest_url, "/PublicKey") + "?" + args
+    resp = requests.post(url, json={"public_key": public_key})
+    resp.raise_for_status()
+    return resp.json()
+
+
+def delete_public_key(rest_url, username, key_id):
+    args = urllib.parse.urlencode({
+        "username": username,
+        "key_id": key_id,
+    })
+    url = urllib.parse.urljoin(rest_url, "/PublicKey") + "?" + args
+    resp = requests.delete(url)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_public_key(rest_url, username):
+    args = urllib.parse.urlencode({
+        "username": username,
+    })
+    url = urllib.parse.urljoin(rest_url, "/PublicKey") + "?" + args
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json()
+
+
 def scale_job(rest_url, email, job_id, resourcegpu):
     args = urllib.parse.urlencode({
         "userName": email,

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -691,6 +691,43 @@ class VCMeta(Resource):
         return resp, code
 
 
+@api.resource("/PublicKey")
+class VCMeta(Resource):
+    def __init__(self):
+        self.get_parser = reqparse.RequestParser()
+        self.get_parser.add_argument("username", required=True)
+
+        self.post_parser = reqparse.RequestParser()
+        self.post_parser.add_argument("username", required=True)
+        self.post_parser.add_argument("key_title", required=True)
+
+        self.delete_parser = reqparse.RequestParser()
+        self.delete_parser.add_argument("username", required=True)
+        self.delete_parser.add_argument("key_id", required=True)
+
+    def get(self):
+        args = self.get_parser.parse_args()
+        username = args["userName"]
+        return JobRestAPIUtils.list_public_keys(username)
+
+    def post(self):
+        args = self.post_parser.parse_args()
+        username = args["userName"]
+        key_title = args["key_title"]
+
+        val = request.get_json()
+        public_key = val.get("public_key")
+        if public_key is None or len(public_key) == 0:
+            return {"error": "no public key provided"}, 400
+        return JobRestAPIUtils.add_public_key(username, key_title, public_key)
+
+    def delete(self):
+        args = self.delete_parser.parse_args()
+        username = args["userName"]
+        key_id = args["key_id"]
+        return JobRestAPIUtils.delete_public_key(username, key_id)
+
+
 @api.resource("/AddVC")
 class AddVC(Resource):
     def __init__(self):

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -692,7 +692,7 @@ class VCMeta(Resource):
 
 
 @api.resource("/PublicKey")
-class VCMeta(Resource):
+class PublicKey(Resource):
     def __init__(self):
         self.get_parser = reqparse.RequestParser()
         self.get_parser.add_argument("username", required=True)
@@ -707,12 +707,12 @@ class VCMeta(Resource):
 
     def get(self):
         args = self.get_parser.parse_args()
-        username = args["userName"]
+        username = args["username"]
         return JobRestAPIUtils.list_public_keys(username)
 
     def post(self):
         args = self.post_parser.parse_args()
-        username = args["userName"]
+        username = args["username"]
         key_title = args["key_title"]
 
         val = request.get_json()
@@ -723,7 +723,7 @@ class VCMeta(Resource):
 
     def delete(self):
         args = self.delete_parser.parse_args()
-        username = args["userName"]
+        username = args["username"]
         key_id = args["key_id"]
         return JobRestAPIUtils.delete_public_key(username, key_id)
 

--- a/src/utils/DataHandler.py
+++ b/src/utils/DataHandler.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__file__)
 
 if "datasource" in config and config["datasource"] == "MySQL":
     from MySQLDataHandler import DataHandler
+    from MySQLDataHandler import GlobalDBHandler
 else:
     logger.error("configured database not supported")
 

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -20,7 +20,7 @@ from threading import Lock
 import requests
 
 from config import config
-from DataHandler import DataHandler, DataManager
+from DataHandler import DataHandler, DataManager, GlobalDBHandler
 from authorization import ResourceType, Permission, AuthorizationManager, IdentityManager, ACLManager
 import authorization
 from job_op import KillOp, PauseOp, ResumeOp, ApproveOp
@@ -328,6 +328,13 @@ def SubmitJob(jobParamsJsonStr):
         if "error" not in ret:
             if not dataHandler.AddJob(tensorboardParams):
                 ret["error"] = "Cannot schedule tensorboard job."
+
+    with GlobalDBHandler() as global_handler:
+        public_keys = global_handler.list_public_keys(jobParams["userName"])
+        if len(public_keys) > 0:
+            user_submitted = jobParams.get("ssh_public_keys", [])
+            user_submitted.extend([obj["public_key"] for obj in public_keys])
+            jobParams["ssh_public_keys"] = user_submitted
 
     if "error" not in ret:
         if dataHandler.AddJob(jobParams):
@@ -1196,6 +1203,43 @@ def get_vc_v2(username, vc_name):
                          username)
 
     return vc_status
+
+
+def list_public_keys(username):
+    with GlobalDBHandler() as handler:
+        return handler.list_public_keys(), 200
+
+
+def add_public_key(username, key_title, public_key):
+    with GlobalDBHandler() as handler:
+        try:
+            handler.add_public_key(username, key_title, public_key)
+            return {"error": None}, 200
+        except Exception as e:
+            logger.exception("failed to add_public_key %s %s", username,
+                             key_title)
+            return {"error": "failed to add public key %s" % (str(e))}, 500
+
+
+def delete_public_key(username, key_id):
+    with GlobalDBHandler() as handler:
+        try:
+            existing_key = handler.get_public_key(key_id)
+            if len(existing_key) == 0:
+                return {"error": "key not exist"}, 404
+            elif len(existing_key) > 1:
+                return {"error": "impossible, multiple keys with same id"}, 500
+
+            if existing_key[0]["username"] != username:
+                return {"error": "you are not the owner of this key"}, 403
+
+            handler.delete_public_key(key_id)
+
+            return {"error": None}, 200
+        except Exception as e:
+            logger.exception("failed to delete_public_key %s %s", username,
+                             key_id)
+            return {"error": "failed to delete public key %s" % (str(e))}, 500
 
 
 def DeleteVC(userName, vcName):


### PR DESCRIPTION
Leverage #860 to support passing public keys to job containers.

This PR expose a `/PublicKey` api in restfulapi. With `GET`, `POST` and `DELETE` method supported. It should be easy to get what parameters needed to provide to these methods.

@Gerhut please add a front end page to allow user use this, this will allow user user provided key to access all jobs from all clusters.

The SQL for create this global db is:
```sql
CREATE DATABASE IF NOT EXISTS `DLTS_GLOBAL` DEFAULT CHARACTER SET 'utf8';

CREATE TABLE IF NOT EXISTS `public_keys`
(
    `id`         INT          NOT NULL AUTO_INCREMENT,
    `username`   VARCHAR(255) NOT NULL,
    `key_title`  VARCHAR(255) NOT NULL COMMENT 'help user recognize key',
    `add_time`   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    `public_key` TEXT         NOT NULL,
    PRIMARY KEY (`id`),
    INDEX user_title (`username`, `key_title`)
);
```