### PR TITLE
VC resource quota proportional update

### DIFF
--- a/src/ClusterBootstrap/ctl.py
+++ b/src/ClusterBootstrap/ctl.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import copy
 import os
 import re
 import sys
@@ -12,8 +13,6 @@ import datetime
 import argparse
 import textwrap
 import random
-import requests
-import urllib.parse
 
 from mysql import connector
 cwd = os.path.dirname(__file__)
@@ -458,7 +457,6 @@ def show_resource_quota(config, args):
             content.update({sku: value})
 
         print(tabulate(content, headers="keys"))
-
     else:
         for r_type in ["gpu", "gpu_memory", "cpu", "memory"]:
             vc_list = list(spec.keys())
@@ -486,6 +484,34 @@ def show_resource_quota(config, args):
             print("%s:\n" % title)
             print(tabulate(content, headers="keys"))
             print("\n")
+
+
+def update_resource_quota(config, args):
+    admin = get_email(get_admin_name(config, args), config)
+
+    rest_url = config.get("dashboard_rest_url")
+    assert rest_url is not None
+
+    rest_util = RestUtil(rest_url)
+    # remote_spec = rest_util.get_resource_quota(admin)
+
+    local_parser = argparse.ArgumentParser()
+    local_parser.add_argument("--vc_name", required=True)
+    local_parser.add_argument("--sku", required=True)
+    local_parser.add_argument("--quota", required=True)
+
+    local_args, _ = local_parser.parse_known_args(args.nargs[1:])
+    vc_name = local_args.vc_name
+    sku = local_args.sku
+    quota = local_args.quota
+    print(vc_name, sku, quota)
+
+
+
+    # payload = {}
+    # resp = rest_util.update_resource_quota(admin)
+    # if resp.get("error") is not None:
+    #     print("!!!Failed to update resource quota with %s!!!" % payload)
 
 
 def run_command(args, command):
@@ -543,6 +569,10 @@ def run_command(args, command):
         nargs = args.nargs
         if nargs[0] == "show":
             show_resource_quota(config, args)
+        elif nargs[0] == "update":
+            update_resource_quota(config, args)
+        else:
+            print("Unrecognized command. Support option(s): show, update")
     else:
         print("invalid command, please read the doc")
 

--- a/src/ClusterBootstrap/ctl.py
+++ b/src/ClusterBootstrap/ctl.py
@@ -428,7 +428,7 @@ def show_resource_quota(config, args):
                 val = walk_json(
                     spec, vc_name, "resourceQuota", "gpu", sku) or 0
                 value.append(val)
-            content.update({"%s (%s)" % (sku, gpu_type): value})
+            content.update({"%s(%s)" % (sku, gpu_type): value})
 
         # Add delimiter for GPU and CPU sku
         content.update({"|": ["|" for _ in vc_list]})
@@ -438,9 +438,16 @@ def show_resource_quota(config, args):
         for vc_name, vc in spec.items():
             all_sku = all_sku.union(set(walk_json(
                 vc, "resourceMetadata", "cpu", default={}).keys()))
+
+        def sku_exists(sku):
+            for k, v in content.items():
+                if k.startswith(sku):
+                    return True
+            return False
+
         all_sku = sorted(list(all_sku))
         for sku in all_sku:
-            if sku in content:
+            if sku_exists(sku):
                 continue
 
             value = []

--- a/src/ClusterBootstrap/ctl.py
+++ b/src/ClusterBootstrap/ctl.py
@@ -416,19 +416,19 @@ def show_resource_quota(config, args):
         content = {"vc": vc_list}
 
         # GPU first
-        all_sku = set()
+        all_sku = {}  # sku -> gpu_type
         for vc_name, vc in spec.items():
-            all_sku = all_sku.union(set(walk_json(
-                vc, "resourceMetadata", "gpu", default={}).keys()))
+            gpu_meta = walk_json(vc, "resourceMetadata", "gpu", default={})
+            for sku, sku_info in gpu_meta.items():
+                all_sku[sku] = sku_info.get("gpu_type")
 
-        all_sku = sorted(list(all_sku))
-        for sku in all_sku:
+        for sku, gpu_type in all_sku.items():
             value = []
             for vc_name in vc_list:
                 val = walk_json(
                     spec, vc_name, "resourceQuota", "gpu", sku) or 0
                 value.append(val)
-            content.update({sku: value})
+            content.update({"%s (%s)" % (sku, gpu_type): value})
 
         # Add delimiter for GPU and CPU sku
         content.update({"|": ["|" for _ in vc_list]})

--- a/src/ClusterBootstrap/install_prerequisites.sh
+++ b/src/ClusterBootstrap/install_prerequisites.sh
@@ -42,7 +42,7 @@ sudo pip install setuptools pyyaml jinja2 requests tzlocal pycurl
 
 sudo apt-get --no-install-recommends install -y python3-pip
 sudo pip3 install --upgrade pip
-sudo pip3 install setuptools pyyaml jinja2 requests tzlocal pycurl
+sudo pip3 install setuptools pyyaml jinja2 requests tzlocal pycurl, tabulate
 
 sudo echo "dockerd > /dev/null 2>&1 &" | cat >> /etc/bash.bashrc
 sudo usermod -aG docker $USER

--- a/src/ClusterBootstrap/utils.py
+++ b/src/ClusterBootstrap/utils.py
@@ -19,6 +19,8 @@ import shutil
 import glob
 import random
 import string
+import requests
+import urllib.parse
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, Template
@@ -848,3 +850,33 @@ def multiprocess_exec(func, args_list, process_num):
     pool = Pool(process_num)
     pool.map(func, args_list)
     pool.close()
+
+
+def walk_json(obj, *fields, default=None):
+    """ for example a=[{"a": {"b": 2}}]
+    walk_json(a, 0, "a", "b") will get 2
+    walk_json(a, 0, "not_exist") will get None
+    """
+    try:
+        for f in fields:
+            obj = obj[f]
+        return obj
+    except:
+        return default
+
+
+class RestUtil(object):
+    def __init__(self, rest_url):
+        self.rest_url = rest_url
+
+    def get_resource_quota(self, username):
+        args = urllib.parse.urlencode({"userName": username})
+        url = urllib.parse.urljoin(self.rest_url, "/ResourceQuota") + "?" + args
+        resp = requests.get(url)
+        return resp.json()
+
+    def update_resource_quota(self, username, payload):
+        args = urllib.parse.urlencode({"userName": username})
+        url = urllib.parse.urljoin(self.rest_url, "/ResourceQuota") + "?" + args
+        resp = requests.post(url, json=payload)
+        return resp.json()

--- a/src/ClusterManager/test/test_admin_ops.py
+++ b/src/ClusterManager/test/test_admin_ops.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import logging
+
+import utils
+
+logger = logging.getLogger(__file__)
+
+
+@utils.case(dangerous=True)
+def test_vc_quota_change(args):
+    job_spec = utils.gen_default_job_description("regular", args.email,
+                                                 args.uid, args.vc)
+
+    with utils.vc_setting(args.rest, args.vc, args.email,
+                          {"job_max_time_second": 5}):
+        with utils.run_job(args.rest, job_spec) as job:
+            state = job.block_until_state_not_in(
+                {"unapproved", "queued", "scheduling"})
+            assert state == "running"
+
+            state = job.block_until_state_not_in({"running"}, timeout=30)
+            assert state == "killed"
+            expected = "running exceed pre-defined 5s"
+
+            details = utils.get_job_detail(args.rest, args.email, job.jid)
+            message = details.get("errorMsg")
+            assert message == expected, "unexpected message " + message

--- a/src/ClusterManager/test/test_admin_ops.py
+++ b/src/ClusterManager/test/test_admin_ops.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__file__)
 @utils.case(dangerous=True)
 def test_vc_quota_change(args):
     sku = "Standard_ND24rs"
-    origin_spec = utils.get_resource_quota(args.rest, args.username)
+    origin_spec = utils.get_resource_quota(args.rest, args.email)
     gpu_count = int(utils.walk_json(origin_spec, args.vc, "resourceQuota",
                                     "gpu", sku))
     assert gpu_count is not None
@@ -19,7 +19,7 @@ def test_vc_quota_change(args):
     target_gpu_count = gpu_count + 1
     quota_spec = {args.vc: {"resourceQuota": {"gpu": {sku: target_gpu_count}}}}
     with utils.ResourceQuota(args.rest, args.email, quota_spec):
-        spec = utils.get_resource_quota(args.rest, args.username)
+        spec = utils.get_resource_quota(args.rest, args.email)
         r_quota = utils.walk_json(spec, args.vc, "resourceQuota")
         assert r_quota is not None
 
@@ -31,12 +31,16 @@ def test_vc_quota_change(args):
         r_metadata = utils.walk_json(spec, args.vc, "resourceMetadata")
         assert r_metadata is not None
 
-        gpu_per_node = int(utils.walk_json(r_metadata, "gpu", sku))
+        gpu_per_node = \
+            int(utils.walk_json(r_metadata, "gpu", sku, "per_node") or 0)
         gpu_memory_per_node = \
-            utils.to_byte(utils.walk_json(r_metadata, "gpu_memory", sku))
-        cpu_per_node = int(utils.walk_json(r_metadata, "cpu", sku))
+            utils.to_byte(
+                utils.walk_json(r_metadata, "gpu_memory", sku, "per_node") or 0)
+        cpu_per_node = \
+            int(utils.walk_json(r_metadata, "cpu", sku, "per_node") or 0)
         memory_per_node = \
-            utils.to_byte(utils.walk_json(r_metadata, "memory", sku))
+            utils.to_byte(
+                utils.walk_json(r_metadata, "memory", sku, "per_node") or 0)
 
         nodes = target_gpu_count / gpu_per_node
         assert gpu == target_gpu_count

--- a/src/ClusterManager/test/utils.py
+++ b/src/ClusterManager/test/utils.py
@@ -468,6 +468,22 @@ def update_vc_meta(rest_url, vc_name, username, vc_meta):
     return resp.json()
 
 
+def get_resource_quota(rest_url, username):
+    args = urllib.parse.urlencode({"userName": username})
+    url = urllib.parse.urljoin(rest_url, "/ResourceQuota") + "?" + args
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def update_resource_quota(rest_url, username, payload):
+    args = urllib.parse.urlencode({"userName": username})
+    url = urllib.parse.urljoin(rest_url, "/ResourceQuota") + "?" + args
+    resp = requests.post(url, json=payload)
+    resp.raise_for_status()
+    return resp.json()
+
+
 def add_public_key(rest_url, username, key_title, public_key):
     args = urllib.parse.urlencode({
         "username": username,
@@ -599,6 +615,36 @@ class vc_setting(object):
         self.username = username
         self.vc_spec = vc_spec
         self.origin_vc_spec = None
+
+    def __enter__(self):
+        self.origin_vc_spec = get_vc_meta(self.rest_url, self.vc_name,
+                                          self.username)
+        spec = copy.deepcopy(self.origin_vc_spec)
+        spec.update(self.vc_spec)
+        update_vc_meta(self.rest_url, self.vc_name, self.username, spec)
+        logger.info("update vc meta from %s to %s",
+                    json.dumps(self.origin_vc_spec), json.dumps(spec))
+        return self
+
+    def __exit__(self, type, value, traceback):
+        try:
+            if self.origin_vc_spec is None:
+                return
+            update_vc_meta(self.rest_url, self.vc_name, self.username,
+                           self.origin_vc_spec)
+            logger.info("rollback vc meta to %s",
+                        json.dumps(self.origin_vc_spec))
+        except Exception:
+            logger.exception("failed to rollback vc meta %s",
+                             json.dumps(self.origin_vc_spec))
+
+
+class ResourceQuota(object):
+    def __init__(self, rest_url, username, quota_spec):
+        self.rest_url = rest_url
+        self.username = username
+        self.quota_spec = quota_spec
+        self.origin_quota_spec = None
 
     def __enter__(self):
         self.origin_vc_spec = get_vc_meta(self.rest_url, self.vc_name,

--- a/src/ClusterManager/test/utils.py
+++ b/src/ClusterManager/test/utils.py
@@ -119,6 +119,37 @@ def snake_case(s):
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
 
+def to_byte(data):
+    data = str(data).lower()
+    number = float(re.findall(r"[-+]?[0-9]*[.]?[0-9]+", data)[0])
+    if "ki" in data:
+        return number * 2**10
+    elif "mi" in data:
+        return number * 2**20
+    elif "gi" in data:
+        return number * 2**30
+    elif "ti" in data:
+        return number * 2**40
+    elif "pi" in data:
+        return number * 2**50
+    elif "ei" in data:
+        return number * 2**60
+    elif "k" in data:
+        return number * 10**3
+    elif "m" in data:
+        return number * 10**6
+    elif "g" in data:
+        return number * 10**9
+    elif "t" in data:
+        return number * 10**12
+    elif "p" in data:
+        return number * 10**15
+    elif "e" in data:
+        return number * 10**18
+    else:
+        return number
+
+
 def get_alias(email):
     if not isinstance(email, str):
         return None
@@ -647,26 +678,26 @@ class ResourceQuota(object):
         self.origin_quota_spec = None
 
     def __enter__(self):
-        self.origin_vc_spec = get_vc_meta(self.rest_url, self.vc_name,
-                                          self.username)
-        spec = copy.deepcopy(self.origin_vc_spec)
-        spec.update(self.vc_spec)
-        update_vc_meta(self.rest_url, self.vc_name, self.username, spec)
-        logger.info("update vc meta from %s to %s",
-                    json.dumps(self.origin_vc_spec), json.dumps(spec))
+        self.origin_quota_spec = get_resource_quota(self.rest_url,
+                                                    self.username)
+        spec = copy.deepcopy(self.origin_quota_spec)
+        spec.update(self.quota_spec)
+        update_resource_quota(self.rest_url, self.username, spec)
+        logger.info("update resource quota from %s to %s",
+                    json.dumps(self.origin_quota_spec), json.dumps(spec))
         return self
 
     def __exit__(self, type, value, traceback):
         try:
-            if self.origin_vc_spec is None:
+            if self.origin_quota_spec is None:
                 return
-            update_vc_meta(self.rest_url, self.vc_name, self.username,
-                           self.origin_vc_spec)
-            logger.info("rollback vc meta to %s",
-                        json.dumps(self.origin_vc_spec))
+            update_resource_quota(self.rest_url, self.username,
+                                  self.origin_quota_spec)
+            logger.info("rollback resource quota to %s",
+                        json.dumps(self.origin_quota_spec))
         except Exception:
-            logger.exception("failed to rollback vc meta %s",
-                             json.dumps(self.origin_vc_spec))
+            logger.exception("failed to rollback resource quota %s",
+                             json.dumps(self.origin_quota_spec))
 
 
 def block_until_state(rest_url, jid, not_in, states, timeout=300):

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -697,6 +697,30 @@ class VCMeta(Resource):
         return resp, code
 
 
+@api.resource("/ResourceQuota")
+class ResourceQuota(Resource):
+    def __init__(self):
+        self.get_parser = reqparse.RequestParser()
+        self.get_parser.add_argument("userName", required=True)
+
+        self.post_parser = reqparse.RequestParser()
+        self.post_parser.add_argument("userName", required=True)
+
+    def get(self):
+        args = self.get_parser.parse_args()
+        username = args["userName"]
+        resp, code = JobRestAPIUtils.get_resource_quota(username)
+        return resp, code
+
+    def post(self):
+        args = self.post_parser.parse_args()
+        username = args["userName"]
+        resource_quota = request.get_json(silent=True)
+        resp, code = JobRestAPIUtils.patch_resource_quota(username,
+                                                             resource_quota)
+        return resp, code
+
+
 @api.resource("/PublicKey")
 class PublicKey(Resource):
     def __init__(self):

--- a/src/dev-utils/h
+++ b/src/dev-utils/h
@@ -151,7 +151,7 @@ def get_vc_user_quota(config_dir):
 
         conn.commit()
     except Exception:
-        logger.exception("Failed to get user quota for VC %s", vc)
+        logger.exception("Failed to get VC user quota")
     finally:
         if cursor is not None:
             cursor.close()

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -1218,9 +1218,9 @@ def patch_resource_quota(username, payload):
                         count = int(count)
                         nodes = count / gpu_per_node
                         r_quota["gpu"][sku] = int(nodes * gpu_per_node)
-                        r_quota["gpu_memory"][sku] = nodes * gpu_memory_per_node
-                        r_quota["cpu"][sku] = nodes * cpu_per_node
-                        r_quota["memory"][sku] = nodes * memory_per_node
+                        r_quota["gpu_memory"][sku] = int(nodes * gpu_memory_per_node)
+                        r_quota["cpu"][sku] = int(nodes * cpu_per_node)
+                        r_quota["memory"][sku] = int(nodes * memory_per_node)
 
                         # Keep consistent for legacy quota
                         quota[gpu_type] = count

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -32,7 +32,7 @@ sys.path.append(
 from common import walk_json
 from job_params_util import make_job_params
 import JobLogUtils
-from resource_stat import Gpu
+from resource_stat import Gpu, to_byte
 
 DEFAULT_JOB_PRIORITY = 100
 USER_JOB_PRIORITY_RANGE = (100, 200)
@@ -56,6 +56,26 @@ USER = Permission.User
 DEFAULT_EXPIRATION = 24 * 30 * 60
 vc_cache = TTLCache(maxsize=10240, ttl=DEFAULT_EXPIRATION)
 vc_cache_lock = Lock()
+
+
+def is_cluster_admin(username):
+    return AuthorizationManager.HasAccess(
+        username, ResourceType.Cluster, "", Permission.Admin)
+
+
+def is_vc_admin(username, vc_name):
+    return AuthorizationManager.HasAccess(
+        username, ResourceType.VC, vc_name, Permission.Admin)
+
+
+def is_vc_collaborator(username, vc_name):
+    return AuthorizationManager.HasAccess(
+        username, ResourceType.VC, vc_name, Permission.Collaborator)
+
+
+def is_vc_user(username, vc_name):
+    return AuthorizationManager.HasAccess(
+        username, ResourceType.VC, vc_name, Permission.User)
 
 
 def get_job_total_gpu(job_params):
@@ -121,9 +141,9 @@ def populate_job_resource(params):
     try:
         # Populate sku with one from vc info in DB
         vc_name = params["vcName"]
-        vc_lists = getClusterVCs()
+        vc_list = get_vc_list()
         vc_info = None
-        for vc in vc_lists:
+        for vc in vc_list:
             if vc["vcName"] == vc_name:
                 vc_info = vc
                 break
@@ -904,28 +924,28 @@ def AddVC(userName, vcName, quota, metadata):
     return ret
 
 
-def getClusterVCs():
-    vcList = None
+def get_vc_list():
+    vc_list = None
     try:
         with vc_cache_lock:
-            vcList = copy.deepcopy(list(vc_cache.values()))
+            vc_list = copy.deepcopy(list(vc_cache.values()))
     except Exception:
         pass
 
-    if not vcList:
-        vcList = DataManager.ListVCs()
+    if not vc_list:
+        vc_list = DataManager.ListVCs()
         with vc_cache_lock:
-            for vc in vcList:
+            for vc in vc_list:
                 vc_cache[vc["vcName"]] = vc
 
-    return vcList
+    return vc_list
 
 
 def ListVCs(userName):
     ret = []
-    vcList = getClusterVCs()
+    vc_list = get_vc_list()
 
-    for vc in vcList:
+    for vc in vc_list:
         if AuthorizationManager.HasAccess(userName, ResourceType.VC,
                                           vc["vcName"], Permission.User):
             vc['admin'] = AuthorizationManager.HasAccess(
@@ -942,7 +962,7 @@ def get_vc(username, vc_name):
             cluster_status, _ = data_handler.GetClusterStatus()
 
         vc_statuses = cluster_status.get("vc_statuses", {})
-        vc_list = getClusterVCs()
+        vc_list = get_vc_list()
 
         for vc in vc_list:
             if vc["vcName"] == vc_name and \
@@ -1060,17 +1080,187 @@ def patch_vc_meta(username, vc_name, vc_meta):
         else:
             return {
                 "error":
-                    "%s do not have permission to query meta from vc %s" %
+                    "%s do not have permission to update meta for vc %s" %
                     (username, vc_name)
             }, 403
     except Exception as e:
-        logger.exception("Exception in get_vc_meta VC %s for user %s", vc_name,
-                         username)
+        logger.exception("Exception in patch_vc_meta VC %s for user %s",
+                         vc_name, username)
 
         return {
             "error":
-                "failed to get meta from vc %s, exception %s" %
+                "failed to update meta from vc %s, exception %s" %
                 (vc_name, str(e))
+        }, 500
+
+
+def get_resource_quota(username):
+    """Get resource quota for all VCs.
+
+    Args:
+        username: Name of the user querying VC resource quota.
+
+    Returns:
+        Resource quota and metadata for all VCs if user is cluster admin,
+        error otherwise.
+    """
+    try:
+        if is_cluster_admin(username):
+            vc_list = get_vc_list()
+            result = {}
+            for vc in vc_list:
+                vc_name = vc["vcName"]
+                result[vc_name] = {}
+                result[vc_name] = {
+                    "resourceQuota": vc["resourceQuota"],
+                    "resourceMetadata": vc["resourceMetadata"],
+                }
+            return result, 200
+        else:
+            return {
+                "error":
+                    "%s does not have permission to query resource quota for VCs" %
+                    username
+            }, 403
+    except Exception as e:
+        logger.exception("Exception in get_vc_resource_quota for user %s",
+                         username)
+        return {
+            "error":
+                "failed to get vc resource quota, exception %s" % str(e)
+        }, 500
+
+
+def patch_resource_quota(username, payload):
+    """Update VC resource quota with payload.
+
+    Args:
+        username: Name of the user updating VC resource quota.
+        payload: Resource quota payload to update.
+
+    Returns:
+        200 if successful, error otherwise.
+    """
+    try:
+        if is_cluster_admin(username):
+            if payload is None or len(payload) == 0:
+                return {"error": "empty payload"}, 400
+
+            vc_list = get_vc_list()
+            with DataHandler() as data_handler:
+                for vc in vc_list:
+                    vc_name = vc["vcName"]
+                    if vc_name not in payload:
+                        continue
+
+                    vc_payload = payload[vc_name]
+                    r_meta = vc["resourceMetadata"]
+                    req_quota = walk_json(vc_payload, "resourceQuota")
+                    if req_quota is None or len(req_quota) == 0:
+                        return {
+                            "error": "empty resourceQuota for vc %s" % vc_name
+                        }, 400
+
+                    r_quota = {
+                        "gpu": {},
+                        "gpu_memory": {},
+                        "cpu": {},
+                        "memory": {},
+                    }
+                    quota = {}
+
+                    req_gpu_quota = walk_json(req_quota, "gpu", default={})
+                    for sku, count in req_gpu_quota.items():
+                        gpu_meta = walk_json(r_meta, "gpu", default={})
+                        if sku not in gpu_meta:
+                            return {
+                                "error":
+                                    "unrecognized sku %s for vc %s" %
+                                    (sku, vc_name)
+                            }, 400
+
+                        gpu_type = walk_json(
+                            r_meta, "gpu", sku, "gpu_type")
+                        gpu_per_node = int(walk_json(
+                            r_meta, "gpu", sku, "per_node") or 0)
+                        gpu_memory_per_node = to_byte(walk_json(
+                            r_meta, "gpu_memory", sku, "per_node") or 0)
+                        cpu_per_node = int(walk_json(
+                            r_meta, "cpu", sku, "per_node") or 0)
+                        memory_per_node = to_byte(walk_json(
+                            r_meta, "memory", sku, "per_node") or 0)
+
+                        # Resource quota proportional to GPU
+                        count = int(count)
+                        nodes = count / gpu_per_node
+                        r_quota["gpu"][sku] = int(nodes * gpu_per_node)
+                        r_quota["gpu_memory"][sku] = nodes * gpu_memory_per_node
+                        r_quota["cpu"][sku] = nodes * cpu_per_node
+                        r_quota["memory"][sku] = nodes * memory_per_node
+
+                        # Keep consistent for legacy quota
+                        quota[gpu_type] = count
+
+                    req_cpu_quota = walk_json(req_quota, "cpu", default={})
+                    for sku, count in req_cpu_quota.items():
+                        # Already populated GPU sku
+                        if sku in r_quota["cpu"]:
+                            continue
+
+                        cpu_meta = walk_json(r_meta, "cpu", default={})
+                        if sku not in cpu_meta:
+                            return {
+                                "error":
+                                    "unrecognized sku %s for vc %s" %
+                                    (sku, vc_name)
+                            }, 400
+
+                        count = int(count)
+                        cpu_per_node = int(walk_json(
+                            r_meta, "cpu", sku, "per_node") or 0)
+                        memory_per_node = to_byte(walk_json(
+                            r_meta, "memory", sku, "per_node") or 0)
+
+                        # Resource quota proportional to CPU
+                        nodes = count / cpu_per_node
+                        r_quota["cpu"][sku] = nodes * cpu_per_node
+                        r_quota["memory"][sku] = nodes * memory_per_node
+
+                        # Keep consistent for legacy quota
+                        quota["None"] = count
+
+                    success = data_handler.update_vc_resource_quota(
+                        vc_name, json.dumps(r_quota), json.dumps(quota))
+                    if success:
+                        logger.info("updated payload %s for vc %s",
+                                    json.dumps(vc_payload), vc_name)
+                    else:
+                        logger.error("DB error processing payload %s for vc %s",
+                                     json.dumps(vc_payload), vc_name)
+                        return {
+                            "error":
+                                "DB error processing payload %s for vc %s" %
+                                (json.dumps(vc_payload), vc_name)
+                        }, 500
+
+            # Invalidate local vc_cache
+            with vc_cache_lock:
+                [vc_cache.pop(vc["vcName"], None) for vc in vc_list]
+
+            return {"error": None}, 200
+        else:
+            return {
+                "error":
+                    "%s does not have permission to update vc with payload %s" %
+                    (username, json.dumps(payload))
+            }, 403
+    except Exception as e:
+        logger.exception("Exception in patch_vc_resource_quota %s for user %s",
+                         json.dumps(payload), username)
+        return {
+            "error":
+                "failed to patch vc resource quota (may succeeded partially), "
+                "exception %s" % str(e)
         }, 500
 
 
@@ -1196,7 +1386,7 @@ def get_vc_v2(username, vc_name):
             cluster_status, _ = data_handler.GetClusterStatus()
 
         vc_statuses = cluster_status.get("vc_statuses", {})
-        vc_list = getClusterVCs()
+        vc_list = get_vc_list()
 
         for vc in vc_list:
             if vc["vcName"] == vc_name and \
@@ -1204,10 +1394,6 @@ def get_vc_v2(username, vc_name):
                 vc_status = vc_statuses.get(vc_name, {})
                 vc_status["vc_name"] = vc_name
                 vc_status["node_status"] = cluster_status.get("node_status")
-
-                gpu_idle = get_gpu_idle(vc_name)
-                if gpu_idle is not None:
-                    vc_status["gpu_idle"] = gpu_idle
                 break
 
         vc_status = get_vc_simplified(vc_status)

--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -340,12 +340,12 @@ class DataHandler(object):
     def update_vc_resource_quota(self, vc_name, resource_quota, quota=None):
         # TODO: remove dependency on quota field
         try:
-            sql = "UPDATE " + self.vctablename + " SET resource_quota = %s"
+            sql = "UPDATE " + self.vctablename + " SET resourceQuota = %s"
             if quota is not None:
                 sql += ", quota = %s"
             sql += " WHERE vcName = %s"
             cursor = self.conn.cursor()
-            cursor.execute(sql, (quota, resource_quota, vc_name))
+            cursor.execute(sql, (resource_quota, quota, vc_name))
             self.conn.commit()
             return True
         except Exception:

--- a/src/utils/MySQLDataHandler.py
+++ b/src/utils/MySQLDataHandler.py
@@ -337,6 +337,23 @@ class DataHandler(object):
             return False
 
     @record
+    def update_vc_resource_quota(self, vc_name, resource_quota, quota=None):
+        # TODO: remove dependency on quota field
+        try:
+            sql = "UPDATE " + self.vctablename + " SET resource_quota = %s"
+            if quota is not None:
+                sql += ", quota = %s"
+            sql += " WHERE vcName = %s"
+            cursor = self.conn.cursor()
+            cursor.execute(sql, (quota, resource_quota, vc_name))
+            self.conn.commit()
+            return True
+        except Exception:
+            logger.exception("failed to update vc %s resource quota with %s, %s",
+                             vc_name, quota, resource_quota)
+            return False
+
+    @record
     def GetIdentityInfo(self, identityName):
         cursor = self.conn.cursor()
         query = """SELECT `identityName`,`uid`,`gid`,`groups`,`public_key`,`private_key`


### PR DESCRIPTION
It has been a pain for us to manually update the `resourceQuota` in `vc` table when there is quota shifting from a vc to another. This PR
1. exposes a rest api `/ResourceQuota` for admin to update `resourceQuota` in `vc`. Resources for GPU sku will be set proportionally to requested GPU quota, while resources for CPU sku wikk be set proportionally to requested CPU quota. The restful API server will invalidate the local cache afterwards, saving us the extra step to restart it. @Gerhut need your help to add a dashboard page for cluster admin to manage VC quota.
2. add a command in `ctl.py` to query/update resource quota for vc:
```
$ ./ctl.py quota show  # brief view on GPU (and CPU)
vc          Standard_ND24rs(P40)  |
--------  ----------------------  ---
platform                      12  |
vc1                            0  |

$ ./ctl.py -x quota show  # detail view (GPU, GPU memory, CPU, memory)
gpu:

vc          Standard_ND24rs
--------  -----------------
platform                 12
vc1                       0


gpu_memory (Gi):

vc          Standard_ND24rs
--------  -----------------
platform                288
vc1                       0


cpu:

vc          Standard_ND24rs
--------  -----------------
platform                 72
vc1                       0


memory (Gi):

vc          Standard_ND24rs
--------  -----------------
platform               1344
vc1                       0

$ ./ctl.py quota update --vc_name platform --sku Standard_ND24s --quota 13
```