### PR TITLE
support preemptable inference jobs

### DIFF
--- a/src/ClusterManager/job_launcher.py
+++ b/src/ClusterManager/job_launcher.py
@@ -1081,7 +1081,7 @@ class PythonLauncher(Launcher):
             conditionFields = {"jobId": job_object.job_id}
             dataHandler.UpdateJobTextFields(conditionFields, dataFields)
         except Exception as e:
-            logger.error("Submit job failed: %s, %s" % (job, str(e)), exc_info=True)
+            logger.exception("Submit job failed: %s" % job, exc_info=True)
             ret["error"] = str(e)
             retries = dataHandler.AddandGetJobRetries(job["jobId"])
             if retries >= 5:
@@ -1158,7 +1158,7 @@ class PythonLauncher(Launcher):
         name = job_object.job_id + "-1-deployment"
         deployment = self._get_deployment(name=name)
         replicas = deployment.spec.replicas
-        new_replicas = int(job_object.params["resourcegpu"] - job_object.params["mingpu"])
+        new_replicas = int(job_object.params["resourcegpu"]) - int(job_object.params["mingpu"])
         if replicas == new_replicas:
             return
 

--- a/src/ClusterManager/job_launcher.py
+++ b/src/ClusterManager/job_launcher.py
@@ -1081,7 +1081,7 @@ class PythonLauncher(Launcher):
             conditionFields = {"jobId": job_object.job_id}
             dataHandler.UpdateJobTextFields(conditionFields, dataFields)
         except Exception as e:
-            logger.error("Submit job failed: %s" % job, exc_info=True)
+            logger.error("Submit job failed: %s, %s" % (job, str(e)), exc_info=True)
             ret["error"] = str(e)
             retries = dataHandler.AddandGetJobRetries(job["jobId"])
             if retries >= 5:
@@ -1155,10 +1155,10 @@ class PythonLauncher(Launcher):
         if job_object.params["jobtrainingtype"] != "InferenceJob":
             return
 
-        name = job_object.job_id + "-deployment"
+        name = job_object.job_id + "-1-deployment"
         deployment = self._get_deployment(name=name)
         replicas = deployment.spec.replicas
-        new_replicas = int(job_object.params["resourcegpu"])
+        new_replicas = int(job_object.params["resourcegpu"] - job_object.params["mingpu"])
         if replicas == new_replicas:
             return
 

--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -14,7 +14,6 @@ sys.path.append(
 
 from mountpoint import make_mountpoint
 
-
 class JobTemplate(object):
     def __init__(self, template, secret_templates=None):
         self.template = template
@@ -105,7 +104,6 @@ class JobTemplate(object):
         # Must be after job.get_plugins
         # TODO: Make mountpoints independent of job.get_plugins
         params["mountpoints"] = [mp.to_dict() for mp in job.mountpoints]
-
         return params, None
 
     def generate_secrets(self, job):

--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -226,8 +226,10 @@ class InferenceJobTemplate(JobTemplate):
 
         deployment_params = copy.deepcopy(params)
 
-        deployment_params["deployment_replicas"] = params["resourcegpu"]
+        deployment_params["deployment_replicas"] = params["mingpu"]
         deployment_params["LaunchCMD"] = params["cmd"]
+        deployment_params["preemptionAllowed"] = False
+        deployment_params["preemptable"] = "0"
 
         deployment_yaml = self.deployment_template.render(job=deployment_params)
         deployment_obj = yaml.full_load(deployment_yaml)
@@ -238,6 +240,21 @@ class InferenceJobTemplate(JobTemplate):
                 "value": params["cmd"]
             })
         k8s_pods.append(deployment_obj)
+
+        preemptable_deployment_params = copy.deepcopy(params)
+        preemptable_deployment_params["deployment_replicas"] = params["resourcegpu"] - params["mingpu"]
+        preemptable_deployment_params["LaunchCMD"] = params["cmd"]
+        preemptable_deployment_params["preemptable"] = "1"
+
+        preemptable_deployment_yaml = self.deployment_template.render(job=preemptable_deployment_params)
+        preemptable_deployment_obj = yaml.full_load(preemptable_deployment_yaml)
+        # because user's cmd can be multiple lines, should add after yaml load
+        preemptable_deployment_obj["spec"]["template"]["spec"]["containers"][0][
+            "env"].append({
+                "name": "DLTS_LAUNCH_CMD",
+                "value": params["cmd"]
+            })
+        k8s_pods.append(preemptable_deployment_obj)
 
         return k8s_pods, None
 

--- a/src/ClusterManager/pod_template.py
+++ b/src/ClusterManager/pod_template.py
@@ -224,12 +224,14 @@ class InferenceJobTemplate(JobTemplate):
         })
         k8s_pods.append(pod_obj)
 
+        # Since cluster status is caculated based on pod label, we seperate inference workers to 2 deployments:
+        # non-preemptable deployment, and preemptable deployment, with different label and replicas. 
         deployment_params = copy.deepcopy(params)
 
         deployment_params["deployment_replicas"] = params["mingpu"]
         deployment_params["LaunchCMD"] = params["cmd"]
         deployment_params["preemptionAllowed"] = False
-        deployment_params["preemptable"] = "0"
+        deployment_params["deploymentIndex"] = "0"
 
         deployment_yaml = self.deployment_template.render(job=deployment_params)
         deployment_obj = yaml.full_load(deployment_yaml)
@@ -244,7 +246,7 @@ class InferenceJobTemplate(JobTemplate):
         preemptable_deployment_params = copy.deepcopy(params)
         preemptable_deployment_params["deployment_replicas"] = params["resourcegpu"] - params["mingpu"]
         preemptable_deployment_params["LaunchCMD"] = params["cmd"]
-        preemptable_deployment_params["preemptable"] = "1"
+        preemptable_deployment_params["deploymentIndex"] = "1"
 
         preemptable_deployment_yaml = self.deployment_template.render(job=preemptable_deployment_params)
         preemptable_deployment_obj = yaml.full_load(preemptable_deployment_yaml)

--- a/src/ClusterManager/test/utils.py
+++ b/src/ClusterManager/test/utils.py
@@ -363,7 +363,10 @@ def gen_default_job_description(
         args["jobtrainingtype"] = "InferenceJob"
         args["hostNetwork"] = False
         args["isPrivileged"] = False
-        args["resourcegpu"] = 1 # num of worker
+        args["resourcegpu"] = 0
+        args["mingpu"] = 1
+        args["maxgpu"] = 4
+        args["preemptionAllowed"] = True
     else:
         logger.error("unknown job_type %s, wrong test case", job_type)
         raise RuntimeError("unknown job_type %s" % (job_type))

--- a/src/ClusterManager/test_job_manager.py
+++ b/src/ClusterManager/test_job_manager.py
@@ -15,6 +15,8 @@ from cluster_resource import ClusterResource
 from job_manager import discount_cluster_resource, \
     get_cluster_schedulable as get_cluster_schedulable_from_reserved, \
     mark_schedulable_non_preemptable_jobs, \
+    mark_schedulable_inference_jobs_non_preemptable_part, \
+    mark_schedulable_inference_jobs_preemptable_part, \
     is_version_satisified
 
 
@@ -39,117 +41,7 @@ def get_cluster_schedulable_from_unschedulable(cluster_status):
 
 
 class TestJobManager(unittest.TestCase):
-    def test_mark_schedulable_non_preemptable_gpu_jobs(self):
-        # job1 is running on an unschedulable node
-        job1_info = {
-            "job": {
-                "vcName": "platform",
-                "jobId": "job1",
-            },
-            "jobId":
-                "job1",
-            "job_resource":
-                ClusterResource(
-                    params={
-                        "cpu": {
-                            "Standard_ND24rs": 1
-                        },
-                        "memory": {
-                            "Standard_ND24rs": 0
-                        },
-                        "gpu": {
-                            "Standard_ND24rs": 3
-                        },
-                        "gpu_memory": {
-                            "Standard_ND24rs": 0
-                        },
-                    }),
-            "preemptionAllowed":
-                False,
-            "sort_key":
-                "0_0_999899_2020-03-31 08:07:46",
-            "allowed":
-                False,
-            "status":
-                "running",
-            "reason":
-                None,
-        }
-
-        # job2 is running on a good node
-        job2_info = {
-            "job": {
-                "vcName": "platform",
-                "jobId": "job2",
-            },
-            "jobId":
-                "job2",
-            "job_resource":
-                ClusterResource(
-                    params={
-                        "cpu": {
-                            "Standard_ND24rs": 1
-                        },
-                        "memory": {
-                            "Standard_ND24rs": 0
-                        },
-                        "gpu": {
-                            "Standard_ND24rs": 4
-                        },
-                        "gpu_memory": {
-                            "Standard_ND24rs": 0
-                        },
-                    }),
-            "preemptionAllowed":
-                False,
-            "sort_key":
-                "0_0_999899_2020-03-31 08:08:49",
-            "allowed":
-                False,
-            "status":
-                "running",
-            "reason":
-                None,
-        }
-
-        # job3 is submitted just now
-        job3_info = {
-            "job": {
-                "vcName": "platform",
-                "jobId": "job3",
-            },
-            "jobId":
-                "job3",
-            "job_resource":
-                ClusterResource(
-                    params={
-                        "cpu": {
-                            "Standard_ND24rs": 1
-                        },
-                        "memory": {
-                            "Standard_ND24rs": 0
-                        },
-                        "gpu": {
-                            "Standard_ND24rs": 4
-                        },
-                        "gpu_memory": {
-                            "Standard_ND24rs": 0
-                        },
-                    }),
-            "preemptionAllowed":
-                False,
-            "sort_key":
-                "0_2_999899_2020-03-31 09:00:10",
-            "allowed":
-                False,
-            "status":
-                "queued",
-            "reason":
-                None,
-        }
-
-        jobs_info = [job1_info, job2_info, job3_info]
-
+    def setUp(self):
         cluster_status = {
             "gpu_capacity": {
                 "Standard_ND24rs": 12
@@ -180,49 +72,108 @@ class TestJobManager(unittest.TestCase):
             },
         }
 
-        cluster_capacity = ClusterResource(
+        self.cluster_capacity = ClusterResource(
             params={
                 "cpu": cluster_status["cpu_capacity"],
                 "memory": cluster_status["memory_capacity"],
                 "gpu": cluster_status["gpu_capacity"],
             })
-        cluster_reserved = ClusterResource(
+
+        self.cluster_reserved = ClusterResource(
             params={
                 "cpu": cluster_status["cpu_reserved"],
                 "memory": cluster_status["memory_reserved"],
                 "gpu": cluster_status["gpu_reserved"],
             })
-        cluster_unschedulable = ClusterResource(
+
+        self.cluster_unschedulable = ClusterResource(
             params={
                 "cpu": cluster_status["cpu_unschedulable"],
                 "memory": cluster_status["memory_unschedulable"],
                 "gpu": cluster_status["gpu_unschedulable"],
             })
 
-        vc_capacity = ClusterResource(
+        self.vc_capacity = ClusterResource(
             params={
                 "cpu": cluster_status["cpu_capacity"],
                 "memory": cluster_status["memory_capacity"],
                 "gpu": cluster_status["gpu_capacity"],
             })
-        vc_unschedulable = ClusterResource(
+
+        self.vc_unschedulable = ClusterResource(
             params={
                 "cpu": cluster_status["cpu_reserved"],
                 "memory": cluster_status["memory_reserved"],
                 "gpu": cluster_status["gpu_reserved"],
             })
-        vc_schedulable = discount_cluster_resource(vc_capacity -
-                                                   vc_unschedulable)
-        vc_schedulables = {"platform": vc_schedulable}
+        vc_schedulable = discount_cluster_resource(self.vc_capacity -
+                                                self.vc_unschedulable)
+        self.vc_schedulables = {"platform": vc_schedulable}
+
+    def gen_job_info(self, jobId, job_resource, job_training_type="RegularJob", job_preemptable_resource=None):
+        return {
+            "job": {
+                "vcName": "platform",
+                "jobId": jobId,
+            },
+            "preemptionAllowed": False,
+            "jobId": jobId,
+            "jobtrainingtype": job_training_type,
+            "job_resource": job_resource,
+            "job_preemptable_resource": job_preemptable_resource,
+            "sort_key": "",
+            "allowed": False,
+            "allowed_resource": None,
+            "status": "queued",
+            "reason": None
+        }
+
+    def gen_job_resource(self, gpu, cpu=1, memory=0, gpu_memory=0):
+        return ClusterResource(
+                    params={
+                        "cpu": {
+                            "Standard_ND24rs": cpu
+                        },
+                        "memory": {
+                            "Standard_ND24rs": memory
+                        },
+                        "gpu": {
+                            "Standard_ND24rs": gpu
+                        },
+                        "gpu_memory": {
+                            "Standard_ND24rs": gpu_memory
+                        },
+                    })
+
+    def test_mark_schedulable_non_preemptable_gpu_jobs(self):
+        # job1 is running on an unschedulable node
+        job1_resource = self.gen_job_resource(3)
+        job1_info = self.gen_job_info("job1", job1_resource)
+        job1_info["sort_key"] = "0_0_999899_2020-03-31 08:07:46"
+        job1_info["status"] = "running"
+
+        # job2 is running on a good node
+        job2_resource = self.gen_job_resource(4)
+        job2_info = self.gen_job_info("job2", job2_resource)
+        job2_info["sort_key"] = "0_0_999899_2020-03-31 08:08:49"
+        job2_info["status"] = "running"
+
+        # job3 is submitted just now
+        job3_resource = self.gen_job_resource(4)
+        job3_info = self.gen_job_info("job3", job3_resource)
+        job3_info["sort_key"] = "0_2_999899_2020-03-31 09:00:10"
+        job3_info["status"] = "queued"
+
+        jobs_info = [job1_info, job2_info, job3_info]
 
         # job3 will not but should be scheduled if using
         # cluster_schedulable = cluster_capacity - cluster_unschedulable
-        c_schedulable = discount_cluster_resource(cluster_capacity -
-                                                  cluster_unschedulable)
+        c_schedulable = discount_cluster_resource(self.cluster_capacity -
+                                                  self.cluster_unschedulable)
 
         jobs_info_list = copy.deepcopy(jobs_info)
         mark_schedulable_non_preemptable_jobs(jobs_info_list, c_schedulable,
-                                              copy.deepcopy(vc_schedulables),
+                                              copy.deepcopy(self.vc_schedulables),
                                               {})
 
         self.assertTrue(jobs_info_list[0]["allowed"])
@@ -231,17 +182,69 @@ class TestJobManager(unittest.TestCase):
 
         # job3 will and should be scheduled if using
         # cluster_schedulable = cluster_capacity - cluster_reserved
-        c_schedulable = discount_cluster_resource(cluster_capacity -
-                                                  cluster_reserved)
+        c_schedulable = discount_cluster_resource(self.cluster_capacity -
+                                                  self.cluster_reserved)
 
         jobs_info_list = copy.deepcopy(jobs_info)
         mark_schedulable_non_preemptable_jobs(jobs_info_list, c_schedulable,
-                                              copy.deepcopy(vc_schedulables),
+                                              copy.deepcopy(self.vc_schedulables),
                                               {})
 
         self.assertTrue(jobs_info_list[0]["allowed"])
         self.assertTrue(jobs_info_list[1]["allowed"])
         self.assertTrue(jobs_info_list[2]["allowed"])
+
+    def test_mark_inference_jobs(self):
+        # vc gpu: 12, cluster gpu: 8
+        # job1: mingpu:1, maxgpu:1. use 1 vc gpu
+        job1_resource = self.gen_job_resource(1)
+        job1_info = self.gen_job_info("job1", job1_resource, "InferenceJob")
+
+        # job2: mingpu:4, maxgpu: 6. use 4 vc gpu, and 2 cluster gpu
+        job2_resource = self.gen_job_resource(4)
+        job2_preemptable_resource = self.gen_job_resource(2)
+        job2_info = self.gen_job_info("job2", job2_resource, "InferenceJob", job2_preemptable_resource)
+
+        # job3: mingpu:4, maxgpu:6. cannot schedule since cluster gpu cannot satisfy mingpu
+        job3_resource = self.gen_job_resource(4)
+        job3_preemptable_resource = self.gen_job_resource(2)
+        job3_info = self.gen_job_info("job3", job3_resource, "InferenceJob", job3_preemptable_resource)
+
+        # job4: mingpu:0, maxgpu:4. use 4 cluster gpu
+        job4_resource = self.gen_job_resource(0)
+        job4_preemptable_resource = self.gen_job_resource(4)
+        job4_info = self.gen_job_info("job4", job4_resource, "InferenceJob", job4_preemptable_resource)
+
+        jobs_info = [job1_info, job2_info, job3_info, job4_info]
+
+        c_schedulable = discount_cluster_resource(self.cluster_capacity -
+                                                  self.cluster_unschedulable)
+
+        self.assertEqual(list(c_schedulable.gpu.to_dict().values())[0], 8.0)
+        self.assertEqual(list(self.vc_schedulables["platform"].gpu.to_dict().values())[0], 12.0)
+
+        mark_schedulable_inference_jobs_non_preemptable_part(jobs_info, c_schedulable,
+                                                             self.vc_schedulables)
+        self.assertTrue(job1_info["allowed"])
+        self.assertEqual(job1_info["allowed_resource"], job1_resource)
+        self.assertTrue(job2_info["allowed"])
+        self.assertEqual(job2_info["allowed_resource"], job2_resource)
+        self.assertFalse(job3_info["allowed"])
+        self.assertTrue(job4_info["allowed"])
+        self.assertEqual(list(c_schedulable.gpu.to_dict().values())[0], 3.0)
+        self.assertEqual(list(self.vc_schedulables["platform"].gpu.to_dict().values())[0], 7.0)
+
+        mark_schedulable_inference_jobs_preemptable_part(jobs_info, c_schedulable)
+
+        self.assertTrue(job1_info["allowed"])
+        self.assertEqual(job1_info["allowed_resource"], job1_resource)
+        self.assertTrue(job2_info["allowed"])
+        self.assertEqual(job2_info["allowed_resource"], job2_resource + job2_preemptable_resource)
+        self.assertFalse(job3_info["allowed"])
+        self.assertTrue(job4_info["allowed"])
+        job4_allowed_resource = self.gen_job_resource(1, 0.25)
+        self.assertTrue(job4_info["allowed_resource"], job4_allowed_resource)
+        self.assertEqual(list(c_schedulable.gpu.to_dict().values())[0], 0)
 
     def test_version_satisified(self):
         self.assertTrue(is_version_satisified("1.15.1", "1.15"))

--- a/src/Jobs_Templete/deployment.yaml.template
+++ b/src/Jobs_Templete/deployment.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ job["jobId"] }}-{{ job["preemptable"] }}-deployment
+  name: {{ job["jobId"] }}-{{ job["deploymentIndex"] }}-deployment
   labels:
     run: {{ job["jobId"] }}
     jobId: {{ job["jobId"] }}

--- a/src/Jobs_Templete/deployment.yaml.template
+++ b/src/Jobs_Templete/deployment.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ job["jobId"] }}-deployment
+  name: {{ job["jobId"] }}-{{ job["preemptable"] }}-deployment
   labels:
     run: {{ job["jobId"] }}
     jobId: {{ job["jobId"] }}
@@ -20,6 +20,7 @@ spec:
         userName: {{ job["user"] }}
         vcName: {{ job["vcName"] }}
         type: job
+        preemptionAllowed: "{{ job["preemptionAllowed"] }}"
       {% if "gpuType" in job %}
         {% if job["gpuType"]|length > 0 %}
         gpuType: {{ job["gpuType"] }}

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -314,15 +314,17 @@ class ScaleJob(Resource):
         self.get_parser = reqparse.RequestParser()
         self.get_parser.add_argument("jobId", required=True)
         self.get_parser.add_argument("userName", required=True)
-        self.get_parser.add_argument("resourcegpu", required=True)
+        self.get_parser.add_argument("mingpu", required=True)
+        self.get_parser.add_argument("maxgpu", required=True)
 
     def get(self):
         args = self.get_parser.parse_args()
         job_id = args["jobId"]
         username = args["userName"]
-        resourcegpu = int(args["resourcegpu"])
+        mingpu = int(args["mingpu"])
+        maxgpu = int(args["maxgpu"])
         msg, status_code = JobRestAPIUtils.scale_inference_job(
-            username, job_id, resourcegpu)
+            username, job_id, mingpu, maxgpu)
         if status_code != 200:
             return msg, status_code
 

--- a/src/RestAPI/dlwsrestapi.py
+++ b/src/RestAPI/dlwsrestapi.py
@@ -311,14 +311,14 @@ class ApproveJob(Resource):
 @api.resource("/ScaleJob")
 class ScaleJob(Resource):
     def __init__(self):
-        self.get_parser = reqparse.RequestParser()
-        self.get_parser.add_argument("jobId", required=True)
-        self.get_parser.add_argument("userName", required=True)
-        self.get_parser.add_argument("mingpu", required=True)
-        self.get_parser.add_argument("maxgpu", required=True)
+        self.post_parser = reqparse.RequestParser()
+        self.post_parser.add_argument("jobId", required=True)
+        self.post_parser.add_argument("userName", required=True)
+        self.post_parser.add_argument("mingpu", required=True)
+        self.post_parser.add_argument("maxgpu", required=True)
 
-    def get(self):
-        args = self.get_parser.parse_args()
+    def post(self):
+        args = self.post_parser.parse_args()
         job_id = args["jobId"]
         username = args["userName"]
         mingpu = int(args["mingpu"])

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -540,7 +540,7 @@ def scale_inference_job(username, job_id, mingpu, maxgpu):
     dataHandler = DataHandler()
     try:
         job = dataHandler.GetJobTextFields(job_id,
-                                           ["userName", "vcName", "jobParams"])
+                                           ["userName", "vcName", "jobStatus", "jobParams"])
 
         if job is None:
             msg = "Job %s cannot be found in database" % job_id
@@ -559,6 +559,12 @@ def scale_inference_job(username, job_id, mingpu, maxgpu):
         if job_type != "InferenceJob":
             msg = "Only inference job could be scaled, current job %s is %s" % (
                 job_id, job_type)
+            logger.error(msg)
+            return msg, 403
+
+        if (job["jobStatus"] != 'queued' and job_params["mingpu"] != mingpu):
+            msg = "Inference job %s has been scheduled, only maxgpu can be changed. \
+                Please pause the job first, change mingpu, then resume the job" % (job_id)
             logger.error(msg)
             return msg, 403
 

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -562,9 +562,9 @@ def scale_inference_job(username, job_id, mingpu, maxgpu):
             logger.error(msg)
             return msg, 403
 
-        if (job["jobStatus"] != 'queued' and job_params["mingpu"] != mingpu):
-            msg = "Inference job %s has been scheduled, only maxgpu can be changed. \
-                Please pause the job first, change mingpu, then resume the job" % (job_id)
+        if ((job["jobStatus"] == 'scheduling' or job["jobStatus"] == 'running') and job_params["mingpu"] != mingpu):
+            msg = "Inference job %s has been scheduled, only maxgpu can be changed. " % (job_id) + \
+                  "Please pause the job first, change mingpu, then resume the job."
             logger.error(msg)
             return msg, 403
 

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -169,10 +169,14 @@ def populate_job_resource(params):
             if job_params.gpu_type:
                 params["gpuType"] = job_params.gpu_type
             params["resourcegpu"] = job_params.gpu_limit
+            if params.get("jobtrainingtype") == "InferenceJob":
+                params["mingpu"] = job_params.min_gpu
+                params["maxgpu"] = job_params.max_gpu
             params["cpurequest"] = job_params.cpu_request
             params["cpulimit"] = job_params.cpu_limit
             params["memoryrequest"] = job_params.memory_request
             params["memorylimit"] = job_params.memory_limit
+
         else:
             logger.warning("job_params %s is invalid. Not populating.",
                            job_params)
@@ -210,6 +214,9 @@ def SubmitJob(jobParamsJsonStr):
         jobParams["preemptionAllowed"] = False
     else:
         jobParams["preemptionAllowed"] = ToBool(jobParams["preemptionAllowed"])
+
+    if jobParams.get("jobtrainingtype") == "InferenceJob":
+        jobParams["preemptionAllowed"] = True
 
     uniqId = str(uuid.uuid4())
     if "jobId" not in jobParams or jobParams["jobId"] == "":
@@ -529,7 +536,7 @@ def approve_job(username, job_id):
     return op_job(username, job_id, ApproveOp())
 
 
-def scale_inference_job(username, job_id, resourcegpu):
+def scale_inference_job(username, job_id, mingpu, maxgpu):
     dataHandler = DataHandler()
     try:
         job = dataHandler.GetJobTextFields(job_id,
@@ -555,7 +562,8 @@ def scale_inference_job(username, job_id, resourcegpu):
             logger.error(msg)
             return msg, 403
 
-        job_params["resourcegpu"] = resourcegpu
+        job_params["mingpu"] = mingpu
+        job_params["maxgpu"] = maxgpu
         dataHandler.UpdateJobTextFields(
             {"jobId": job_id},
             {"jobParams": base64encode(json.dumps(job_params))})

--- a/src/utils/cluster_resource.py
+++ b/src/utils/cluster_resource.py
@@ -45,6 +45,16 @@ class ClusterResource(object):
     def to_dict(self):
         return dictionarize(copy.deepcopy(self.__dict__))
 
+    def has_empty_gpu_or_cpu(self):
+        for r_type in self.__dict__:
+            if r_type == "gpu" or r_type == "cpu":
+                param = self.__dict__[r_type]
+                for k, v in param.res.items():
+                    if v == 0:
+                        return True
+
+        return False
+
     @property
     def floor(self):
         params = {

--- a/src/utils/test_cluster_resource.py
+++ b/src/utils/test_cluster_resource.py
@@ -423,3 +423,34 @@ class TestClusterResource(TestCase):
                 },
             })
         self.assertEqual(expected, v)
+
+    def test_has_empty_gpu_or_cpu(self):
+        v = ClusterResource(
+            params={
+                "cpu": {
+                    "r1": "1.5",
+                },
+                "memory": {
+                    "r1": "100.2",
+                },
+                "gpu": {
+                    "r1": "0",
+                }
+            })
+        self.assertTrue(v.has_empty_gpu_or_cpu())
+        v = ClusterResource(
+            params={
+                "cpu": {
+                    "r1": "1.5",
+                },
+                "memory": {
+                    "r1": "100.2",
+                },
+                "gpu": {
+                    "r1": "1.0",
+                },
+                "gpu_memory": {
+                    "r1": "0"
+                }
+            })
+        self.assertFalse(v.has_empty_gpu_or_cpu())


### PR DESCRIPTION
1. RestAPI: 
    - SubmitJob(): parse "mingpu", "maxgpu" in jobParams, and also be compatible with "resourcegpu", "gpulimit".
    - ScaleJob(): change "resourcegpu" to "mingpu" and "maxgpu". No compatibility issue.
2. JobManager:
   - Add "job_preemptable_resource", "allowed_resource" in job_info. If inference job is scheduling/running, subtract “mingpu” related resource, and keep the job for preempt gpu allocation later.
   - Scheduling logic:
   1) Mark non-preempt training job: job status is "queued".
   2) Mark inference job non-preempt part: job status is "queued". Allocate if all "mingpu" related resource could be satisfied.
   3) Mark preempt training job: job status is "queued/scheduling/running".
   4) Mark inference job preempt part: job status is "queued/scheduling/running". Allocate partial resource if not all "maxgpu" related resource could be satisfied. Suppose CPU/Memory is more than GPU, so allocate GPU first, CPU and memory is in proportion with allocated GPU.

Refinement:
1. fair-sharing: In 4), share remaining GPU among different inference jobs in proportion or on average.
2. Assumption does not apply for CPU cluster, CPU inference job