### PR TITLE
global db config

### DIFF
--- a/src/ClusterBootstrap/services/restfulapi/config.yaml
+++ b/src/ClusterBootstrap/services/restfulapi/config.yaml
@@ -4,6 +4,27 @@ mysql :
   port : {{cnf["mysql_port"]}}
   username : {{cnf["mysql_username"]}}
   password : "{{cnf["mysql_password"]}}"
+global-mysql:
+  {% if cnf["global_mysql_node"]%}
+  hostname : {{cnf["global_mysql_node"]}}
+  {% else %}
+  hostname : {{cnf["mysql_node"]}}
+  {% endif %}
+  {% if cnf["global_mysql_port"] %}
+  port : {{cnf["global_mysql_port"]}}
+  {% else %}
+  port : {{cnf["mysql_port"]}}
+  {% endif %}
+  {% if cnf["global_mysql_username"] %}
+  username : {{cnf["global_mysql_username"]}}
+  {% else %}
+  username : {{cnf["mysql_username"]}}
+  {% endif %}
+  {% if cnf["global_mysql_password"] %}
+  password : "{{cnf["global_mysql_password"]}}"
+  {% else %}
+  password : "{{cnf["mysql_password"]}}"
+  {% endif %}
 kubelet-path : /usr/local/bin/kubectl
 storage-mount-path : {{cnf["storage-mount-path"]}}
 root-path : /DLWorkspace/src/

--- a/src/utils/JobRestAPIUtils.py
+++ b/src/utils/JobRestAPIUtils.py
@@ -351,9 +351,9 @@ def SubmitJob(jobParamsJsonStr):
             if not dataHandler.AddJob(tensorboardParams):
                 ret["error"] = "Cannot schedule tensorboard job."
 
-    with GlobalDBHandler(config["mysql"]["hostname"],
-                         config["mysql"]["username"],
-                         config["mysql"]["password"]) as global_handler:
+    with GlobalDBHandler(config["global-mysql"]["hostname"],
+                         config["global-mysql"]["username"],
+                         config["global-mysql"]["password"]) as global_handler:
         public_keys = global_handler.list_public_keys(jobParams["userName"])
         if len(public_keys) > 0:
             user_submitted = jobParams.get("ssh_public_keys", [])
@@ -1447,17 +1447,17 @@ def convert_date(obj, field):
 
 
 def list_public_keys(username):
-    with GlobalDBHandler(config["mysql"]["hostname"],
-                         config["mysql"]["username"],
-                         config["mysql"]["password"]) as handler:
+    with GlobalDBHandler(config["global-mysql"]["hostname"],
+                         config["global-mysql"]["username"],
+                         config["global-mysql"]["password"]) as handler:
         result = handler.list_public_keys(username)
         return [convert_date(obj, "add_time") for obj in result], 200
 
 
 def add_public_key(username, key_title, public_key):
-    with GlobalDBHandler(config["mysql"]["hostname"],
-                         config["mysql"]["username"],
-                         config["mysql"]["password"]) as handler:
+    with GlobalDBHandler(config["global-mysql"]["hostname"],
+                         config["global-mysql"]["username"],
+                         config["global-mysql"]["password"]) as handler:
         try:
             key_id = handler.add_public_key(username, key_title, public_key)
             return {"id": key_id}, 200
@@ -1468,9 +1468,9 @@ def add_public_key(username, key_title, public_key):
 
 
 def delete_public_key(username, key_id):
-    with GlobalDBHandler(config["mysql"]["hostname"],
-                         config["mysql"]["username"],
-                         config["mysql"]["password"]) as handler:
+    with GlobalDBHandler(config["global-mysql"]["hostname"],
+                         config["global-mysql"]["username"],
+                         config["global-mysql"]["password"]) as handler:
         try:
             existing_key = handler.get_public_key(key_id)
             if len(existing_key) == 0:


### PR DESCRIPTION
Add a `global-mysql` config to restfulapi config to support using different mysql instance for global and local db. Default this to local which will makes deployment easier.