### PR TITLE
Remove activeDeadlineSeconds from user-synchronizer

### DIFF
--- a/src/ClusterBootstrap/services/user-synchronizer/user-synchronizer-cronjob.yaml
+++ b/src/ClusterBootstrap/services/user-synchronizer/user-synchronizer-cronjob.yaml
@@ -12,7 +12,6 @@ spec:
       labels:
         app: user-synchronizer
     spec:
-      activeDeadlineSeconds: 3600
       template:
         metadata:
           name: user-synchronizer-pod


### PR DESCRIPTION
As the number of user grows, the user-synchronizer cannot finish within 1 hour. I think a better way is to make user-synchronizer a service instead of a cronjob. @Gerhut ?