### PR TITLE
User synchronizer: add timeout to requests

### DIFF
--- a/src/user-synchronizer/microsoft_graph.py
+++ b/src/user-synchronizer/microsoft_graph.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from os import environ
 import logging
 
 from oauthlib.oauth2 import BackendApplicationClient
@@ -27,7 +26,7 @@ def build_oauth(tenant_id, client_id, client_secret):
 
 def _get_object(oauth, url, params=None):
     try:
-        response = oauth.get(url, params=params)
+        response = oauth.get(url, params=params, timeout=(3.05, 27))
         response.raise_for_status()
         response_json = response.json()
 
@@ -42,7 +41,7 @@ def _get_object(oauth, url, params=None):
 
 def _iter_objects(oauth, url, params=None):
     while url is not None:
-        response = oauth.get(url, params=params)
+        response = oauth.get(url, params=params, timeout=(3.05, 27))
         response.raise_for_status()
         response_json = response.json()
         objects = response_json['value']
@@ -52,7 +51,7 @@ def _iter_objects(oauth, url, params=None):
         yield from objects
 
         url = response_json.get('@odata.nextLink')
-        params = None  # next urls contains params
+        params = None  # next urls contain params
 
 
 def iter_groups_by_mail(oauth, group_mail, fields):

--- a/src/user-synchronizer/restfulapi.py
+++ b/src/user-synchronizer/restfulapi.py
@@ -27,7 +27,7 @@ def generate_ssh_key_pair():
 
 def iter_acls(restfulapi_url):
     ''' Iterate group identities from RestfulAPI '''
-    response = get(restfulapi_url + '/GetAllACL')
+    response = get(restfulapi_url + '/GetAllACL', timeout=(3.05, 27))
     response.raise_for_status()
     response_json = response.json()
     result = response_json['result']
@@ -48,7 +48,7 @@ def update_identity(restfulapi_url, user_name, uid, gid, groups):
         'private_key': private,
         'public_key': public,
     }
-    response = get(restfulapi_url + '/AddUser', params=params)
+    response = get(restfulapi_url + '/AddUser', params=params, timeout=(3.05, 27))
     response.raise_for_status()
 
     logger.info('Updated {} to cluster'.format(user_name))


### PR DESCRIPTION
Along with #1231 

The timeout value is following [the example of requests](https://2.python-requests.org/en/master/user/advanced/#timeouts)