### PR TITLE
Consider ctime when expiring paths

### DIFF
--- a/src/StorageManager/path_node.py
+++ b/src/StorageManager/path_node.py
@@ -51,10 +51,11 @@ class PathNode(object):
         self.subtree_ctime = datetime.fromtimestamp(stat.st_ctime)
         if self.isdir:
             self.time = self.mtime
-            self.subtree_time = self.subtree_mtime
+            self.subtree_time = max(self.subtree_mtime, self.subtree_ctime)
         else:
             self.time = max(self.atime, self.mtime)
             self.subtree_time = max(self.subtree_atime, self.subtree_mtime)
+            self.subtree_time = max(self.subtree_time, self.subtree_ctime)
         self.uid = stat.st_uid
         self.gid = stat.st_gid
 

--- a/src/StorageManager/rule.py
+++ b/src/StorageManager/rule.py
@@ -100,25 +100,35 @@ class Rule(object):
         path = self.config["path"]
         alias = self.config["alias"]
 
-        header = "atime,mtime,time,size_in_bytes,readable_size,owner,path\n"
+        header = "subtree_atime,subtree_mtime,subtree_ctime,subtree_time,subtree_size_in_bytes,subtree_readable_size,owner,path\n"
 
         preview_len = min(preview_len, len(nodes))
         preview = header
         for node in nodes[0:preview_len]:
-            preview += "%s,%s,%s,%s,%s,%s,%s\n" % (
-                node.subtree_atime, node.subtree_mtime, node.subtree_time,
-                node.subtree_size, bytes2human_readable(node.subtree_size),
-                node.owner, node.path.replace(path, alias, 1))
+            preview += "%s,%s,%s,%s,%s,%s,%s,%s\n" % (
+                node.subtree_atime,
+                node.subtree_mtime,
+                node.subtree_ctime,
+                node.subtree_time,
+                node.subtree_size,
+                bytes2human_readable(node.subtree_size),
+                node.owner,
+                node.path.replace(path, alias, 1))
         if preview_len < len(nodes):
             preview += "...\n"
 
         data = header
         max_len = min(MAX_NODES_IN_REPORT, len(nodes))
         for node in nodes[0:max_len]:
-            cur_node = "%s,%s,%s,%s,%s,%s,%s\n" % (
-                node.subtree_atime, node.subtree_mtime, node.subtree_time,
-                node.subtree_size, bytes2human_readable(node.subtree_size),
-                node.owner, node.path.replace(path, alias, 1))
+            cur_node = "%s,%s,%s,%s,%s,%s,%s,%s\n" % (
+                node.subtree_atime,
+                node.subtree_mtime,
+                node.subtree_ctime,
+                node.subtree_time,
+                node.subtree_size,
+                bytes2human_readable(node.subtree_size),
+                node.owner,
+                node.path.replace(path, alias, 1))
             data += cur_node
 
         report = {

--- a/src/StorageManager/test_path_node.py
+++ b/src/StorageManager/test_path_node.py
@@ -8,7 +8,7 @@ NODE_PATH = "/dummy"
 NODE_SIZE = 2147483648
 NODE_ATIME = 1574203167
 NODE_MTIME = 1574201167
-NODE_CTIME = 1574203167
+NODE_CTIME = 1574201127
 NODE_UID = 635550533
 NODE_GID = 600000513
 USER_NAME = "dummy"
@@ -37,8 +37,8 @@ class TestPathNode(TestCase):
         self.assertEqual(datetime(2019, 11, 19, 22, 39, 27), node.subtree_atime)
         self.assertEqual(datetime(2019, 11, 19, 22, 6, 7), node.mtime)
         self.assertEqual(datetime(2019, 11, 19, 22, 6, 7), node.subtree_mtime)
-        self.assertEqual(datetime(2019, 11, 19, 22, 39, 27), node.ctime)
-        self.assertEqual(datetime(2019, 11, 19, 22, 39, 27), node.subtree_ctime)
+        self.assertEqual(datetime(2019, 11, 19, 22, 5, 27), node.ctime)
+        self.assertEqual(datetime(2019, 11, 19, 22, 5, 27), node.subtree_ctime)
         self.assertEqual(datetime(2019, 11, 19, 22, 6, 7), node.time)
         self.assertEqual(datetime(2019, 11, 19, 22, 6, 7), node.subtree_time)
         self.assertEqual(NODE_UID, node.uid)
@@ -58,5 +58,5 @@ class TestPathNode(TestCase):
         self.assertEqual(USER_NAME, node.owner)
 
         expected = "2019/11/19 22:39:27,2019/11/19 22:06:07," \
-                   "2019/11/19 22:39:27,2019/11/19 22:39:27,2G,dummy,/dummy"
+                   "2019/11/19 22:05:27,2019/11/19 22:39:27,2G,dummy,/dummy"
         self.assertEqual(expected, str(node))

--- a/src/StorageManager/test_path_tree.py
+++ b/src/StorageManager/test_path_tree.py
@@ -45,6 +45,7 @@ def stat_side_effect(value):
         node.st_ino = 3
         node.st_size = EMPTY_DIR_SIZE
         node.st_mtime -= 3 * DAY
+        node.st_ctime -= 3 * DAY
         node.st_uid = 1002
     elif value == FILE2_1:
         node.st_ino = 4
@@ -52,12 +53,14 @@ def stat_side_effect(value):
         node.st_size = FILE2_1_LEN
         node.st_atime -= 2 * DAY
         node.st_mtime -= 14 * DAY
+        node.st_ctime -= 14 * DAY
         node.st_uid = 1002
     elif value == FILE2_2:
         node.st_ino = 5
         node.st_size = FILE2_2_LEN
         node.st_atime -= 7 * DAY
         node.st_mtime -= 5 * DAY
+        node.st_ctime -= 5 * DAY
         node.st_uid = 1002
     elif value == FILE2_3:
         node.st_ino = 4
@@ -65,12 +68,14 @@ def stat_side_effect(value):
         node.st_size = FILE2_3_LEN
         node.st_atime -= 2 * DAY
         node.st_mtime -= 14 * DAY
+        node.st_ctime -= 14 * DAY
         node.st_uid = 1000
     elif value == FILE1:
         node.st_ino = 6
         node.st_size = FILE1_LEN
         node.st_atime -= 3 * DAY
         node.st_mtime -= 3 * DAY
+        node.st_ctime -= 3 * DAY
         node.st_uid = 1001
 
     return node


### PR DESCRIPTION
Unzipped folder preserves atime and mtime for its files. This is incorrectly identified as expired when users download and unzip archived datasets.