### PR TITLE
Ignore invalid infiniband metric

### DIFF
--- a/src/docker-images/job-exporter/src/infiniband.py
+++ b/src/docker-images/job-exporter/src/infiniband.py
@@ -105,8 +105,7 @@ def get_infinibands():
                                             "port_xmit_data")))
             except Exception as e:
                 logger.debug("Failed to parse rcv/xmit metric data. %s", e)
-                receive_bytes = None
-                transmit_bytes = None
+                continue
 
             infiniband = Infiniband(device, port, link_layer, rate, state,
                                     phys_state, receive_bytes, transmit_bytes)


### PR DESCRIPTION
None value infiniband will cause [RuntimeError](https://github.com/microsoft/DLWorkspace/blob/53a5b5eb6afdb8737fa248ade187fa26e4200736/src/docker-images/job-exporter/src/collector.py#L234). All subsequent metrics fail to publish.