### PR TITLE
Dashboard: add SSH tab back to admins' view

### DIFF
--- a/src/dashboard/src/pages/Job/Tabs/Ssh/index.tsx
+++ b/src/dashboard/src/pages/Job/Tabs/Ssh/index.tsx
@@ -88,7 +88,7 @@ const useEndpoints = () => {
 
 const Ssh: FunctionComponent = () => {
   const { enqueueSnackbar } = useSnackbar()
-  const { cluster, job } = useContext(Context)
+  const { cluster, job, owned } = useContext(Context)
 
   const [endpoints, enableSSH] = useEndpoints()
 
@@ -189,8 +189,8 @@ const Ssh: FunctionComponent = () => {
       })}
     </List>
     <Box paddingX={2} paddingBottom={2}>
-      <Authentication onAddKeyToCommand={handleAddKeyToCommand}/>
-      { cluster.supportAllowedIp === true && <Network/> }
+      { owned && <Authentication onAddKeyToCommand={handleAddKeyToCommand}/> }
+      { owned && cluster.supportAllowedIp === true && <Network/> }
     </Box>
   </>
 }

--- a/src/dashboard/src/pages/Job/Tabs/index.tsx
+++ b/src/dashboard/src/pages/Job/Tabs/index.tsx
@@ -36,11 +36,9 @@ const getComponentName = (Component: ComponentType) => {
 const JobTabs: FunctionComponent = () => {
   const { job, admin, owned } = useContext(Context)
   const active = isStatusActive(job)
-  const components = useMemo(() => owned
+  const components = useMemo(() => owned || admin
     ? [Brief, Ssh, Metrics, Console, Apps]
-    : admin
-      ? [Brief, Metrics, Console, Apps]
-      : [Brief, Metrics, Console]
+    : [Brief, Metrics, Console]
   , [owned, admin])
   const [index, setIndex] = useHashTab(
     ...components.map(


### PR DESCRIPTION
Also, hide the authentication & network panels for non-owner.