### PR TITLE
 Dashboard: fix default cluster from navigation.

### DIFF
--- a/src/dashboard/src/pages/Submission/DataJob.tsx
+++ b/src/dashboard/src/pages/Submission/DataJob.tsx
@@ -18,7 +18,7 @@ import { DirectoryPathTextField } from './components/GPUCard'
 import ClustersContext from '../../contexts/Clusters'
 import UserContext from '../../contexts/User'
 import TeamContext from '../../contexts/Team'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import Slide from '@material-ui/core/Slide'
 import { green } from '@material-ui/core/colors'
 import useFetch from 'use-http'
@@ -42,6 +42,7 @@ const Transition = React.forwardRef<unknown, TransitionProps & { children?: Reac
 })
 
 const DataJob: React.FC = (props: any) => {
+  const location = useLocation()
   const styles = useStyles()
   const [azureDataStorage, setAzureDataStorage] = useState('')
   const [nfsDataStorage, setNFSDataStorage] = useState('')
@@ -51,7 +52,13 @@ const DataJob: React.FC = (props: any) => {
   const { email } = React.useContext(UserContext)
   const { currentTeamId } = React.useContext(TeamContext)
   const { clusters } = React.useContext(ClustersContext)
-  const [selectedCluster, saveSelectedCluster] = React.useState(() => clusters[0].id)
+  const [selectedCluster, saveSelectedCluster] = React.useState(() => {
+    const clusterId = location.state.cluster
+    if (clusters.some(({ id }) => id === clusterId)) {
+      return clusterId
+    }
+    return clusters[0].id
+  })
   const [workStorage, setWorkStorage] = useState('')
   const [dataStorage, setDataStorage] = useState('')
 

--- a/src/dashboard/src/pages/Submission/Training.tsx
+++ b/src/dashboard/src/pages/Submission/Training.tsx
@@ -27,7 +27,7 @@ import {
 } from '@material-ui/core'
 import Tooltip from '@material-ui/core/Tooltip'
 import { Info, Delete, Add } from '@material-ui/icons'
-import { withRouter } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import IconButton from '@material-ui/core/IconButton'
 import useFetch from 'use-http'
 import { join } from 'path'
@@ -56,7 +56,9 @@ const sanitizePath = (path: string) => {
   path = join('.', path)
   return path
 }
-const Training: React.ComponentClass = withRouter(({ history, location }) => {
+const Training: React.FunctionComponent = () => {
+  const history = useHistory()
+  const location = useLocation()
   const { clusters } = React.useContext(ClustersContext)
   const [selectedCluster, saveSelectedCluster] = React.useState(() => {
     const clusterId = location.state.cluster
@@ -1338,6 +1340,6 @@ const Training: React.ComponentClass = withRouter(({ history, location }) => {
       />
     </Container>
   )
-})
+}
 
 export default Training

--- a/src/dashboard/src/pages/Submission/Training.tsx
+++ b/src/dashboard/src/pages/Submission/Training.tsx
@@ -56,9 +56,15 @@ const sanitizePath = (path: string) => {
   path = join('.', path)
   return path
 }
-const Training: React.ComponentClass = withRouter(({ history }) => {
+const Training: React.ComponentClass = withRouter(({ history, location }) => {
   const { clusters } = React.useContext(ClustersContext)
-  const [selectedCluster, saveSelectedCluster] = React.useState(() => clusters[0].id)
+  const [selectedCluster, saveSelectedCluster] = React.useState(() => {
+    const clusterId = location.state.cluster
+    if (clusters.some(({ id }) => id === clusterId)) {
+      return clusterId
+    }
+    return clusters[0].id
+  })
   const { email } = React.useContext(UserContext)
   const { currentTeamId } = React.useContext(TeamContext)
   // const team = 'platform';


### PR DESCRIPTION
If user navigate to job submission by clicking the submit job button in resource card in home page, the default cluster should be set to the cluster the button belongs to.