### PR TITLE
Dashboard: add preemptableJobByDefault cluster config.

### DIFF
--- a/src/dashboard/config/test.yaml
+++ b/src/dashboard/config/test.yaml
@@ -15,6 +15,7 @@ clusters:
     grafana: http://grafana.universe
   Targaryen:
     restfulapi: http://targaryen
+    preemptableJobByDefault: true
 
 frontend:
   key: value

--- a/src/dashboard/server/api/controllers/cluster/jobs.post.js
+++ b/src/dashboard/server/api/controllers/cluster/jobs.post.js
@@ -16,5 +16,9 @@ module.exports = async context => {
   job['familyToken'] = uuid()
   job['isParent'] = 1
 
+  if (job['preemptionAllowed'] == null && cluster.config['preemptableJobByDefault'] != null) {
+    job['preemptionAllowed'] = cluster.config['preemptableJobByDefault'] ? 'True' : 'False'
+  }
+
   context.body = await cluster.addJob(job)
 }

--- a/src/dashboard/server/api/controllers/cluster/jobs.post.js
+++ b/src/dashboard/server/api/controllers/cluster/jobs.post.js
@@ -16,8 +16,8 @@ module.exports = async context => {
   job['familyToken'] = uuid()
   job['isParent'] = 1
 
-  if (job['preemptionAllowed'] == null && cluster.config['preemptableJobByDefault'] != null) {
-    job['preemptionAllowed'] = cluster.config['preemptableJobByDefault'] ? 'True' : 'False'
+  if (job['preemptionAllowed'] == null && cluster.config['preemptableJobByDefault']) {
+    job['preemptionAllowed'] = 'True'
   }
 
   context.body = await cluster.addJob(job)

--- a/src/dashboard/server/api/validator/config.schema.json
+++ b/src/dashboard/server/api/validator/config.schema.json
@@ -73,6 +73,11 @@
               "items": {
                 "type": "string"
               }
+            },
+            "preemptableJobByDefault": {
+              "title": "Set job as preemptable by default",
+              "description": "Set to true to make the frontend mark the job as preemptable by default, and set `preemptionAllowed` field of submitted job to true if unset.",
+              "type": "boolean"
             }
           }
         }

--- a/src/dashboard/server/test/controllers/cluster/jobs.post.js
+++ b/src/dashboard/server/test/controllers/cluster/jobs.post.js
@@ -54,4 +54,16 @@ describe('POST /clusters/:clusterid/jobs', function () {
       { vcName: 'test', userName: 'foo' }, { params: userParams })
     response.status.should.equal(200)
   })
+
+  it('should set preemtible if preemptableJobByDefault configured in cluster', async function () {
+    nock('http://targaryen')
+      .post('/PostJob', _.matches({ userName: 'dlts@example.com', preemptionAllowed: 'True' }))
+      .reply(200, {
+        message: 'job adding succeeded'
+      })
+
+    const response = await axiosist(api).post('/clusters/Targaryen/jobs',
+      { vcName: 'test', userName: 'foo' }, { params: userParams })
+    response.status.should.equal(200)
+  })
 })

--- a/src/dashboard/src/pages/Submission/Training.tsx
+++ b/src/dashboard/src/pages/Submission/Training.tsx
@@ -714,18 +714,19 @@ const Training: React.FunctionComponent = () => {
       history.push(`/job/${currentTeamId}/${selectedCluster}/${jobId.current}`)
     }
   }, [postJobData, ssh, ipython, tensorboard, interactivePorts, history, selectedCluster, postEndpoints, currentTeamId])
-  const fetchGrafanaUrl = '/api/clusters'
-  const request = useFetch(fetchGrafanaUrl)
-  const fetchGrafana = async () => {
-    const { grafana } = await request.get(`/${selectedCluster}`)
+  const request = useFetch('/api/clusters')
+  const fetchConfig = async () => {
+    if (typeof selectedCluster !== 'string') return
+    const { grafana, preemptableJobByDefault = false } = await request.get(`/${selectedCluster}`)
     setGrafanaUrl(grafana)
+    setPreemptible(preemptableJobByDefault)
   }
   const handleCloseGPUGramentation = () => {
     setShowGPUFragmentation(false)
   }
 
   React.useEffect(() => {
-    fetchGrafana()
+    fetchConfig()
     if (postEndpointsData) {
       setOpen(true)
       setTimeout(() => {


### PR DESCRIPTION
- Should be Boolean
- Backend: fill unset `preemptionAllowed` with set `preemptableJobByDefault`
- Frontend: in submittion page, automatically fill preemptible field with set `preemptableJobByDefault` when cluster changed