### PR TITLE
Dashboard: allow submit null timeout

### DIFF
--- a/src/dashboard/server/api/services/cluster.js
+++ b/src/dashboard/server/api/services/cluster.js
@@ -219,7 +219,7 @@ class Cluster extends Service {
 
   /**
    * @param {string} jobId
-   * @param {number} timeout
+   * @param {number|null} timeout
    * @return {Promise}
    */
   async setJobTimeout (jobId, timeout) {

--- a/src/dashboard/server/api/validator/timeout.schema.json
+++ b/src/dashboard/server/api/validator/timeout.schema.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "timeout": {
-      "type": "number"
+      "type": ["number", "null"]
     }
   },
   "required": ["timeout"]


### PR DESCRIPTION
Luckily the RestfulAPI side support null timeout, (nullable=True by default) ref: <https://flask-restful.readthedocs.io/en/latest/api.html#reqparse.Argument> and <https://github.com/microsoft/DLWorkspace/blob/v1.7/src/RestAPI/dlwsrestapi.py#L1100>

Frontend: delete the timeout field and press enter will set timeout to null, which disables the job kill timeout.