### PR TITLE
Add a new api which can get gpu_pernode and gputype

### DIFF
--- a/src/dashboard/server/api/controllers/team/metadata.js
+++ b/src/dashboard/server/api/controllers/team/metadata.js
@@ -1,0 +1,32 @@
+/**
+ * @typedef {Object} State
+ * @property {import('../../services/cluster')} cluster
+ */
+
+const tryParseJSON = (json, empty) => {
+  try {
+    return JSON.parse(json)
+  } catch (e) {
+    return empty
+  }
+}
+
+/** @type {import('koa').Middleware<State>} */
+module.exports = async context => {
+    const { cluster } = context.state
+    const { teamId } = context.params
+    const quota = await cluster.getQuota()
+    if(!quota.hasOwnProperty(teamId))
+      context.body = "teamId not found!"
+    else{
+      const metadataObject = quota[teamId]['resourceMetadata']['gpu']
+      const gpus = Object.create(null)
+      for (const sku of Object.keys(metadataObject)) {
+        gpus['type'] = metadataObject[sku]['gpu_type']
+        gpus['per_node'] = metadataObject[sku]['per_node']
+      }
+      context.body = gpus
+    }
+
+  }
+  

--- a/src/dashboard/server/api/controllers/team/metadata.js
+++ b/src/dashboard/server/api/controllers/team/metadata.js
@@ -13,20 +13,19 @@ const tryParseJSON = (json, empty) => {
 
 /** @type {import('koa').Middleware<State>} */
 module.exports = async context => {
-    const { cluster } = context.state
-    const { teamId } = context.params
-    const quota = await cluster.getQuota()
-    if(!quota.hasOwnProperty(teamId))
-      context.body = "teamId not found!"
-    else{
-      const metadataObject = quota[teamId]['resourceMetadata']['gpu']
-      const gpus = Object.create(null)
-      for (const sku of Object.keys(metadataObject)) {
-        gpus['type'] = metadataObject[sku]['gpu_type']
-        gpus['per_node'] = metadataObject[sku]['per_node']
-      }
-      context.body = gpus
+  const { cluster } = context.state
+  const { teamId } = context.params
+  const quota = await cluster.getQuota()
+  if (!quota.hasOwnProperty(teamId)) {
+    context.body = 'teamId not found!'
+  } 
+  else {
+    const metadataObject = quota[teamId]['resourceMetadata']['gpu']
+    const gpus = Object.create(null)
+    for (const sku of Object.keys(metadataObject)) {
+      gpus['type'] = metadataObject[sku]['gpu_type']
+      gpus['per_node'] = metadataObject[sku]['per_node']
     }
-
+    context.body = gpus
   }
-  
+}

--- a/src/dashboard/server/api/controllers/team/metadata.js
+++ b/src/dashboard/server/api/controllers/team/metadata.js
@@ -3,14 +3,6 @@
  * @property {import('../../services/cluster')} cluster
  */
 
-const tryParseJSON = (json, empty) => {
-  try {
-    return JSON.parse(json)
-  } catch (e) {
-    return empty
-  }
-}
-
 /** @type {import('koa').Middleware<State>} */
 module.exports = async context => {
   const { cluster } = context.state
@@ -18,8 +10,7 @@ module.exports = async context => {
   const quota = await cluster.getQuota()
   if (!quota.hasOwnProperty(teamId)) {
     context.body = 'teamId not found!'
-  } 
-  else {
+  } else {
     const metadataObject = quota[teamId]['resourceMetadata']['gpu']
     const gpus = Object.create(null)
     for (const sku of Object.keys(metadataObject)) {

--- a/src/dashboard/server/api/router.js
+++ b/src/dashboard/server/api/router.js
@@ -25,6 +25,9 @@ router.get('/teams/:teamId/clusters/:clusterId',
 router.get('/clusters/:clusterId',
   require('./middlewares/user')(),
   require('./controllers/cluster'))
+router.get('/teams/:teamId/clusters/:clusterId/metadata',
+  require('./middlewares/user')(),
+  require('./controllers/team/metadata'))
 
 router.get('/teams/:teamId/jobs',
   require('./middlewares/user')(),

--- a/src/dashboard/server/api/services/cluster.js
+++ b/src/dashboard/server/api/services/cluster.js
@@ -435,7 +435,7 @@ class Cluster extends Service {
     }
   }
 
-    /**
+  /**
    * @return {Promise<object>}
    */
   async getQuota () {
@@ -447,7 +447,6 @@ class Cluster extends Service {
     this.context.log.debug({ data }, 'Got cluster quota')
     return data
   }
-
 }
 
 module.exports = Cluster

--- a/src/dashboard/server/api/services/cluster.js
+++ b/src/dashboard/server/api/services/cluster.js
@@ -434,6 +434,20 @@ class Cluster extends Service {
       throw error
     }
   }
+
+    /**
+   * @return {Promise<object>}
+   */
+  async getQuota () {
+    const { user } = this.context.state
+    const params = new URLSearchParams({ userName: user.email })
+    const response = await this.fetch('/ResourceQuota?' + params)
+    this.context.assert(response.ok, response.status)
+    const data = await response.json()
+    this.context.log.debug({ data }, 'Got cluster quota')
+    return data
+  }
+
 }
 
 module.exports = Cluster


### PR DESCRIPTION
We want to have an Aether REST API, given team/cluster/userName, it could return #gpusPerNode and gpuType.

As the #gpusPerNode and gpuType would be quite different in different team/clusters, for example the resourceGpu in Azure-WestUS2-V100-16GB-LowPriority is 4; Azure-NorthCentralUS-V100 is 8.  For our users, resourceGpu is the No.1 most frequently wrong parameter. When users switch team/cluster, lots of them don’t know they need to change resourceGpu as well.

for example：https://dltshub.redmond.corp.microsoft.com//api/teams/{$0}/clusters/{$1}/metadata?email={$2}
the result is :  {type: {$0}, per_node: {$1}}