### PR TITLE
Add a new api which can get gpu_pernode and gputype

### DIFF
--- a/src/dashboard/config/local.yaml
+++ b/src/dashboard/config/local.yaml
@@ -1,0 +1,15 @@
+sign: 6a005e53ffcc4a85231795ba677b010daf4a99172b2da5a699e1207f0c87f5751e0f1d547b6c3e204cfc4d9122c45a7a14895d47b3a440ae8cc1596af74580b4
+masterToken: 6a005e53ffcc4a85231795ba677b010daf4a99172b2da5a699e1207f0c87f5751e0f1d547b6c3e204cfc4d9122c45a7a14895d47b3a440ae8cc1596af74580b4
+AddGroupLink: https://dlts.azurewebsites.net/v2/htmlfiles/Overview/VirtualClusters.html
+WikiLink: https://aka.ms/dltsuserwiki_v2
+ 
+restfulapi: http://ether
+ 
+activeDirectory:
+  tenant: 72f988bf-86f1-41af-91ab-2d7cd011db47
+  clientId: 48d30ab1-0ecd-4e51-a67e-0b9da6cf6be1
+  clientSecret: Bz-6mff@Llqw-GQMz5H?JJkVbdyy0Pj5
+ 
+clusters:
+  az-eus-p40-dlts2itp:   
+    restfulapi: http://az-eus-p40-dlts2itp-infra01.eastus.cloudapp.azure.com:5000

--- a/src/dashboard/server/api/controllers/team/metadata.js
+++ b/src/dashboard/server/api/controllers/team/metadata.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {Object} State
+ * @property {import('../../services/cluster')} cluster
+ */
+
+/** @type {import('koa').Middleware<State>} */
+module.exports = async context => {
+  const { cluster } = context.state
+  const { teamId } = context.params
+  const quota = await cluster.getQuota()
+  if (!quota.hasOwnProperty(teamId)) {
+    context.body = 'teamId not found!'
+  } else {
+    const metadataObject = quota[teamId]['resourceMetadata']['gpu']
+    const gpus = Object.create(null)
+    for (const sku of Object.keys(metadataObject)) {
+      gpus['type'] = metadataObject[sku]['gpu_type']
+      gpus['per_node'] = metadataObject[sku]['per_node']
+    }
+    context.body = gpus
+  }
+}

--- a/src/dashboard/server/api/router.js
+++ b/src/dashboard/server/api/router.js
@@ -25,6 +25,9 @@ router.get('/teams/:teamId/clusters/:clusterId',
 router.get('/clusters/:clusterId',
   require('./middlewares/user')(),
   require('./controllers/cluster'))
+router.get('/teams/:teamId/clusters/:clusterId/metadata',
+  require('./middlewares/user')(),
+  require('./controllers/team/metadata'))
 
 router.get('/teams/:teamId/jobs',
   require('./middlewares/user')(),

--- a/src/dashboard/server/api/services/cluster.js
+++ b/src/dashboard/server/api/services/cluster.js
@@ -434,6 +434,19 @@ class Cluster extends Service {
       throw error
     }
   }
+
+  /**
+   * @return {Promise<object>}
+   */
+  async getQuota () {
+    const { user } = this.context.state
+    const params = new URLSearchParams({ userName: user.email })
+    const response = await this.fetch('/ResourceQuota?' + params)
+    this.context.assert(response.ok, response.status)
+    const data = await response.json()
+    this.context.log.debug({ data }, 'Got cluster quota')
+    return data
+  }
 }
 
 module.exports = Cluster


### PR DESCRIPTION
We want to have an Aether REST API, given team/cluster/userName, it could return #gpusPerNode and gpuType.

As the #gpusPerNode and gpuType would be quite different in different team/clusters, for example the resourceGpu in Azure-WestUS2-V100-16GB-LowPriority is 4; Azure-NorthCentralUS-V100 is 8. For our users, resourceGpu is the No.1 most frequently wrong parameter. When users switch team/cluster, lots of them don’t know they need to change resourceGpu as well.

for example：https://dltshub.redmond.corp.microsoft.com//api/teams/{$0}/clusters/{$1}/metadata?email={$2}
the result is : {type: {$0}, per_node: {$1}}