### PR TITLE
inject /proc to /host-proc

### DIFF
--- a/src/ClusterManager/framework.py
+++ b/src/ClusterManager/framework.py
@@ -312,6 +312,10 @@ def gen_containers(job, role):
             "name": "dshm",
             "mountPath": "/dev/shm"
         },
+        {
+            "name": "host-proc",
+            "mountPath": "/host-proc"
+        },
     ]
 
     if job.dns_policy is None:
@@ -488,6 +492,12 @@ def gen_task_role(job, role):
             "name": "dshm",
             "emptyDir": {
                 "medium": "Memory"
+            }
+        },
+        {
+            "name": "host-proc",
+            "hostPath": {
+                "path": "/proc"
             }
         },
     ]

--- a/src/Jobs_Templete/deployment.yaml.template
+++ b/src/Jobs_Templete/deployment.yaml.template
@@ -79,6 +79,8 @@ spec:
           readOnly: true
         - name: ssh-volume
           mountPath: /home/{{ job["user"] }}/.ssh
+        - mountPath: /host-proc
+          name: host-proc
         {% if not job["dnsPolicy"] %}
         - mountPath: /etc/resolv.conf
           name: resolv
@@ -165,6 +167,9 @@ spec:
         hostPath:
           path: /etc/resolv.conf
       {% endif %}
+      - hostPath:
+          path: /proc
+        name: host-proc
       - name: dshm
         emptyDir:
           medium: Memory

--- a/src/Jobs_Templete/pod.yaml.template
+++ b/src/Jobs_Templete/pod.yaml.template
@@ -182,6 +182,8 @@ spec:
       readOnly: true
     - name: ssh-volume
       mountPath: /home/{{ job["user"] }}/.ssh
+    - mountPath: /host-proc
+      name: host-proc
     {% if not job["dnsPolicy"] %}
     - mountPath: /etc/resolv.conf
       name: resolv
@@ -296,6 +298,9 @@ spec:
   - name: dshm
     emptyDir:
       medium: Memory
+  - hostPath:
+      path: /proc
+    name: host-proc
   {% if not job["dnsPolicy"] %}
   - name: resolv
     hostPath:


### PR DESCRIPTION
so user could run `sync; echo 3 | sudo tee /host-proc/sys/vm/drop_caches` to free cache on nodes. Some teams is complaining that node cache memory usage slows training process down.